### PR TITLE
trustee: support proxy

### DIFF
--- a/Dockerfile.as-grpc
+++ b/Dockerfile.as-grpc
@@ -7,6 +7,14 @@
 ARG BASE_IMAGE=alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest
 
 FROM ${BASE_IMAGE} AS builder
+
+ARG ALL_PROXY
+ARG NO_PROXY
+ENV ALL_PROXY=$ALL_PROXY
+ENV NO_PROXY=$NO_PROXY
+
+ARG CARGO_JOBS
+
 ARG ARCH=x86_64
 
 WORKDIR /tmp
@@ -18,10 +26,21 @@ WORKDIR /usr/src/attestation-service
 COPY . .
 RUN sed -i 's/version = 4/version = 3/g' Cargo.lock
 
+RUN if [ -n "$CARGO_JOBS" ]; then \
+      [ ! -d /root/.cargo ] && mkdir /root/.cargo; \
+      echo -e "[build]\njobs = $CARGO_JOBS" >> /root/.cargo/config.toml; \
+    fi
+
 # Build and Install gRPC attestation-service
 RUN cargo install --path attestation-service --bin grpc-as --features grpc-bin,all-verifier --locked
 
 FROM ${BASE_IMAGE}
+
+ARG ALL_PROXY
+ARG NO_PROXY
+ENV ALL_PROXY=$ALL_PROXY
+ENV NO_PROXY=$NO_PROXY
+
 ARG ARCH=x86_64
 
 WORKDIR /tmp

--- a/Dockerfile.as-restful
+++ b/Dockerfile.as-restful
@@ -7,6 +7,14 @@
 ARG BASE_IMAGE=alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest
 
 FROM ${BASE_IMAGE} AS builder
+
+ARG ALL_PROXY
+ARG NO_PROXY
+ENV ALL_PROXY=$ALL_PROXY
+ENV NO_PROXY=$NO_PROXY
+
+ARG CARGO_JOBS
+
 ARG ARCH=x86_64
 
 WORKDIR /tmp
@@ -18,10 +26,21 @@ WORKDIR /usr/src/attestation-service
 COPY . .
 RUN sed -i 's/version = 4/version = 3/g' Cargo.lock
 
+RUN if [ -n "$CARGO_JOBS" ]; then \
+      [ ! -d /root/.cargo ] && mkdir /root/.cargo; \
+      echo -e "[build]\njobs = $CARGO_JOBS" >> /root/.cargo/config.toml; \
+    fi
+
 # Build and Install RESTful attestation-service
 RUN cargo install --path attestation-service --bin restful-as --features restful-bin,all-verifier --locked
 
 FROM ${BASE_IMAGE}
+
+ARG ALL_PROXY
+ARG NO_PROXY
+ENV ALL_PROXY=$ALL_PROXY
+ENV NO_PROXY=$NO_PROXY
+
 ARG ARCH=x86_64
 
 RUN yum install -y yum-utils

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,4 +1,6 @@
-FROM docker.io/library/node:latest as builder
+ARG NODE_IMAGE=docker.io/library/node
+
+FROM ${NODE_IMAGE}:latest as builder
 
 WORKDIR /app
 

--- a/Dockerfile.kbs
+++ b/Dockerfile.kbs
@@ -3,6 +3,14 @@
 ARG BASE_IMAGE=alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest
 
 FROM ${BASE_IMAGE} AS builder
+
+ARG ALL_PROXY
+ARG NO_PROXY
+ENV ALL_PROXY=$ALL_PROXY
+ENV NO_PROXY=$NO_PROXY
+
+ARG CARGO_JOBS
+
 ARG ARCH=x86_64
 ARG HTTPS_CRYPTO=rustls
 ARG ALIYUN=true
@@ -14,6 +22,11 @@ COPY . .
 RUN yum install -y cargo curl clang perl protobuf-devel git libgudev-devel openssl-devel
 
 RUN sed -i 's/version = 4/version = 3/g' Cargo.lock
+
+RUN if [ -n "$CARGO_JOBS" ]; then \
+      [ ! -d /root/.cargo ] && mkdir /root/.cargo; \
+      echo -e "[build]\njobs = $CARGO_JOBS" >> /root/.cargo/config.toml; \
+    fi
 
 # Build and Install KBS
 RUN cd kbs && make AS_FEATURE=coco-as-grpc ALIYUN=${ALIYUN} TPM_PCA_PLUGIN=${TPM_PCA_PLUGIN} && \

--- a/Dockerfile.rvps
+++ b/Dockerfile.rvps
@@ -8,6 +8,13 @@ ARG BASE_IMAGE=alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux
 
 FROM ${BASE_IMAGE} AS builder
 
+ARG ALL_PROXY
+ARG NO_PROXY
+ENV ALL_PROXY=$ALL_PROXY
+ENV NO_PROXY=$NO_PROXY
+
+ARG CARGO_JOBS
+
 WORKDIR /usr/src/rvps
 
 COPY . .
@@ -16,7 +23,12 @@ RUN yum install -y cargo curl clang perl protobuf-devel git openssl-devel
 
 RUN sed -i 's/version = 4/version = 3/g' Cargo.lock
 
-RUN cargo install --bin rvps --path rvps  --locked
+RUN if [ -n "$CARGO_JOBS" ]; then \
+      [ ! -d /root/.cargo ] && mkdir /root/.cargo; \
+      echo -e "[build]\njobs = $CARGO_JOBS" >> /root/.cargo/config.toml; \
+    fi
+
+RUN cargo install --bin rvps --path rvps --locked
 
 FROM ${BASE_IMAGE}
 

--- a/Dockerfile.trustee-client
+++ b/Dockerfile.trustee-client
@@ -6,6 +6,13 @@
 
 FROM alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest as builder
 
+ARG ALL_PROXY
+ARG NO_PROXY
+ENV ALL_PROXY=$ALL_PROXY
+ENV NO_PROXY=$NO_PROXY
+
+ARG CARGO_JOBS
+
 RUN yum install -y perl wget curl clang openssh-clients openssl-devel protobuf-devel git
 
 WORKDIR /usr/src/trustee
@@ -26,6 +33,11 @@ RUN printf '\
     [source.aliyun]\n\
     registry = "sparse+https://mirrors.aliyun.com/crates.io-index/"\n\
     ' > ~/.cargo/config
+
+RUN if [ -n "$CARGO_JOBS" ]; then \
+      [ ! -d /root/.cargo ] && mkdir /root/.cargo; \
+      echo -e "[build]\njobs = $CARGO_JOBS" >> /root/.cargo/config.toml; \
+    fi
 
 RUN cargo build -p kbs-client --locked --release --no-default-features --features sample_only
 

--- a/Dockerfile.trustee-gateway
+++ b/Dockerfile.trustee-gateway
@@ -4,6 +4,11 @@ ARG BASE_IMAGE=registry.openanolis.cn/openanolis/anolisos:23.3
 
 FROM ${BASE_IMAGE} AS builder
 
+ARG ALL_PROXY
+ARG NO_PROXY
+ENV ALL_PROXY=$ALL_PROXY
+ENV NO_PROXY=$NO_PROXY
+
 WORKDIR /usr/src/trustee
 
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   kbs:
     build:
       context: .
+      network: host
       dockerfile: Dockerfile.kbs
     image: trustee-kbs:latest
     command: [
@@ -23,6 +24,7 @@ services:
   as:
     build:
       context: .
+      network: host
       dockerfile: Dockerfile.as-grpc
     image: trustee-as:latest
     ports:
@@ -47,6 +49,7 @@ services:
   as-restful:
     build:
       context: .
+      network: host
       dockerfile: Dockerfile.as-restful
     image: trustee-as-restful:latest
     ports:
@@ -71,6 +74,7 @@ services:
   rvps:
     build:
       context: .
+      network: host
       dockerfile: Dockerfile.rvps
     image: trustee-rvps:latest
     restart: always # keep the server running
@@ -88,6 +92,7 @@ services:
   gateway:
     build:
       context: .
+      network: host
       dockerfile: Dockerfile.trustee-gateway
     image: trustee-gateway:latest
     restart: always
@@ -109,6 +114,7 @@ services:
   frontend:
     build:
       context: .
+      network: host
       dockerfile: Dockerfile.frontend
     image: trustee-frontend:latest
     ports:


### PR DESCRIPTION
In order to build trustee in limited network, all Dockerfile uses configurable ALL_PROXY and NO_PROXY environment variables to set the network proxy.

Due to the particularity of docker container, the local proxy, such as socks5://localhost:6666, has to be specially handled. To simplify it, enable host network for docker/docker compose build.

At last, introduce configurable CARGO_JOBS environment to avoid the build failure "Too many open files" on a busy build system.