### PR TITLE
feat(rekor-v2): unify provenance metadata schema and add OCI-based RVPS verification path

### DIFF
--- a/attestation-service/src/bin/attestation-challenge-client/cli.rs
+++ b/attestation-service/src/bin/attestation-challenge-client/cli.rs
@@ -161,6 +161,22 @@ pub struct SetReferenceValueArgs {
     #[arg(long = "rekor-url", default_value = DEFAULT_REKOR_URL)]
     pub rekor_url: String,
 
+    /// Rekor API major version (auto/1/2)
+    #[arg(long = "rekor-api-version", default_value = "auto", value_enum)]
+    pub rekor_api_version: RekorApiVersion,
+
+    /// Provenance source protocol (e.g. oci). If provided, provenance is pulled from source URI.
+    #[arg(long = "provenance-source-protocol")]
+    pub provenance_source_protocol: Option<String>,
+
+    /// Provenance source URI (e.g. oci://registry/repo:tag)
+    #[arg(long = "provenance-source-uri")]
+    pub provenance_source_uri: Option<String>,
+
+    /// Provenance source artifact type (bundle/provenance)
+    #[arg(long = "provenance-source-artifact", default_value = "bundle")]
+    pub provenance_source_artifact: String,
+
     /// Path to the provenance payload JSON (required for sample)
     #[arg(long = "payload")]
     pub payload: Option<PathBuf>,
@@ -172,4 +188,14 @@ pub enum ProvenanceType {
     Slsa,
     #[value(name = "sample")]
     Sample,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RekorApiVersion {
+    #[value(name = "auto")]
+    Auto,
+    #[value(name = "1")]
+    V1,
+    #[value(name = "2")]
+    V2,
 }

--- a/attestation-service/src/bin/attestation-challenge-client/commands/set_reference_value.rs
+++ b/attestation-service/src/bin/attestation-challenge-client/commands/set_reference_value.rs
@@ -1,4 +1,4 @@
-use crate::cli::{ProvenanceType, SetReferenceValueArgs};
+use crate::cli::{ProvenanceType, RekorApiVersion, SetReferenceValueArgs};
 use crate::config::{build_default_config, resolve_work_dir};
 use crate::rekor::RekorClient;
 use crate::rvps_message::{build_rvps_message, build_rvps_message_with_payload_string};
@@ -41,22 +41,80 @@ async fn handle_slsa(args: SetReferenceValueArgs) -> Result<()> {
         .await
         .context("initialize attestation service")?;
 
-    let payload = json!({
-        "artifact_type": artifact_type,
-        "slsa_provenance": slsa_provenance,
-        "artifacts_download_url": Vec::<String>::new(),
-    });
+    let source_protocol = args.provenance_source_protocol.as_deref();
+    let source_uri = args.provenance_source_uri.as_deref();
 
-    let message = build_rvps_message("slsa", &payload)?;
+    if source_protocol.is_some()
+        || source_uri.is_some()
+        || args.rekor_api_version == RekorApiVersion::V2
+    {
+        let protocol = source_protocol
+            .ok_or_else(|| anyhow!("--provenance-source-protocol is required when provenance source mode is used or rekor-api-version=2"))?;
+        let uri = source_uri
+            .ok_or_else(|| anyhow!("--provenance-source-uri is required when provenance source mode is used or rekor-api-version=2"))?;
 
-    attestation_service
-        .register_reference_value(&message)
-        .await
-        .context("register reference values to RVPS")?;
+        let payload = json!({
+            "rv_list": [
+                {
+                    "id": &artifact_name,
+                    "version": "cli",
+                    "type": &artifact_type,
+                    "provenance_info": {
+                        "type": "slsa-intoto-statements",
+                        "rekor_url": args.rekor_url,
+                        "rekor_api_version": rekor_api_version_to_u8(args.rekor_api_version),
+                    },
+                    "provenance_source": {
+                        "protocol": protocol,
+                        "uri": uri,
+                        "artifact": args.provenance_source_artifact,
+                    },
+                    "operation_type": "refresh"
+                }
+            ]
+        });
 
-    println!("Reference values registered, artifact: `{artifact_name}`");
+        attestation_service
+            .set_reference_value_list(&payload.to_string())
+            .await
+            .context("set reference value list to RVPS")?;
+        println!("Reference values registered via provenance source, artifact: `{artifact_name}`");
+    } else {
+        let rekor_client = RekorClient::new(&args.rekor_url)?;
+        let slsa_provenance = rekor_client
+            .fetch_slsa_provenance(&artifact_name)
+            .await
+            .context("fetch SLSA provenance from Rekor")?;
+
+        if slsa_provenance.is_empty() {
+            bail!("No SLSA provenance found on Rekor for artifact `{artifact_name}`");
+        }
+
+        let payload = json!({
+            "artifact_type": artifact_type,
+            "slsa_provenance": slsa_provenance,
+            "artifacts_download_url": Vec::<String>::new(),
+        });
+
+        let message = build_rvps_message("slsa", &payload)?;
+
+        attestation_service
+            .register_reference_value(&message)
+            .await
+            .context("register reference values to RVPS")?;
+
+        println!("Reference values registered, artifact: `{artifact_name}`");
+    }
 
     Ok(())
+}
+
+fn rekor_api_version_to_u8(v: RekorApiVersion) -> Option<u8> {
+    match v {
+        RekorApiVersion::Auto => None,
+        RekorApiVersion::V1 => Some(1),
+        RekorApiVersion::V2 => Some(2),
+    }
 }
 
 async fn handle_sample(args: SetReferenceValueArgs) -> Result<()> {

--- a/docs/challenge_ra.md
+++ b/docs/challenge_ra.md
@@ -46,6 +46,9 @@ attestation-challenge-client set-reference-value-list --rv-list <rv-list.json>
 ### SLSA 模式 (rekor透明日志)
 
 #### 方式一（经典模式）
+
+这种方式只支持rekor v1
+
 ```bash
 attestation-challenge-client set-reference-value \
   --provenance-type slsa \
@@ -57,6 +60,8 @@ attestation-challenge-client set-reference-value \
 - `--rekor-url` 可选，默认 `https://rekor.sigstore.dev`。
 
 #### 方式二（批量模式）
+
+这种方式能够支持rekor v2
 
 ```bash
 attestation-challenge-client set-reference-value-list --rv-list /path/to/rv-list.json

--- a/docs/rekor.md
+++ b/docs/rekor.md
@@ -101,9 +101,15 @@ cat << EOF > rvps-set-list.json
       "type": "model",
       "provenance_info": {
         "type": "slsa-intoto-statements",
-        "rekor_url": "https://rekor.sigstore.dev"
+        "rekor_url": "https://log2025-1.rekor.sigstore.dev",
+        "rekor_api_version": 2
       },
-      "operation_type": "add"
+      "provenance_source": {
+        "protocol": "oci",
+        "uri": "oci://127.0.0.1:5000/trustee/provenance:v1",
+        "artifact": "bundle"
+      },
+      "operation_type": "refresh"
     }
   ]
 }
@@ -114,6 +120,13 @@ curl -k -X POST http://<gateway-host>:<port>/api/rvps/set_reference_value_list \
   -d @rvps-set-list.json
 ```
 
+说明：
+
+- `provenance_source.protocol`：当前支持 `oci`
+- `provenance_source.uri`：OCI 地址，格式 `oci://<registry>/<repo>:<tag>` 或 `oci://<registry>/<repo>@sha256:<digest>`
+- `provenance_source.artifact`：`bundle` 或 `provenance`，默认建议 `bundle`
+- 当请求中未提供 `provenance_source` 字段时，仍走现有 Rekor v1 索引查询兼容路径
+
 ### 4.2 发布侧：生成并上传 Rekor
 
 ```bash
@@ -123,23 +136,180 @@ cd trustee/tools/slsa
   --artifact /path/to/artifact \
   --artifact-id app-binary \
   --artifact-version 1.0.0 \
-  --sign-key /path/to/cosign.key
+  --sign-key /path/to/cosign.key \
+  --rekor-url https://log2025-1.rekor.sigstore.dev \
+  --rekor-api-version 2 \
+  --provenance-store-protocol oci \
+  --provenance-store-uri oci://<registry>/<repo>:<tag> \
+  --provenance-store-artifact bundle
 ```
 
-该脚本会生成 statement + DSSE 并调用 `rekor-cli upload --type intoto` 上传到 Rekor。
+该脚本会生成 statement + DSSE，并在 `bundle` 模式输出统一的 provenance metadata 结构：
+
+- `sourceBundle`：来源 bundle（与 Sigstore bundle 结构对齐）；
+- `dsseEnvelope`：便于直接消费的 DSSE；
+- `rekorEntryV2`：可选（v2 上传成功时带上）。
+
+同时支持：
+
+- 上传到 Rekor v1（`rekor-cli upload --type intoto`）；
+- 上传到 Rekor v2（`/api/v2/log/entries`，`dsseRequestV002`）；
+- 把 provenance 元数据上传到指定存储地址（首期支持 OCI）。
+
+> 说明：CI 发布到 GitHub Release 的 `*.provenance-metadata.json` 与 `slsa-generator` 的 `provenance.trustee-bundle.json` 已统一为同一 schema（`sourceBundle + dsseEnvelope + rekorEntryV2`）。
+
+### 4.3 审计侧：使用脚本验证参考值与 Rekor v2 一致性
+
+当审计者已拿到 `provenance_source.protocol` 和 `provenance_source.uri` 时，可直接使用脚本：
+
+`tools/slsa/audit_reference_value_v2.py`
+
+示例：
+
+```bash
+cd trustee/tools/slsa
+./audit_reference_value_v2.py \
+  --reference-id demo-artifact-v2 \
+  --reference-version 1.0.0 \
+  --reference-value 3c8b9c3566c89593595c9604b7855abbb07cbb1e4d5e586a06b9407e88b637e3 \
+  --provenance-source-protocol oci \
+  --provenance-source-uri oci://127.0.0.1:5000/trustee/provenance:demo-artifact-v2 \
+  --provenance-source-artifact bundle \
+  --verbose-http
+```
+
+脚本会在终端输出完整审计过程，并给出 PASS/FAIL 结果，覆盖：
+
+1. 参考值与 statement 中 `subject(name=id).digest.sha256` 一致；
+2. DSSE payload 摘要与 Rekor v2 `canonicalizedBody.spec.dsseV002` 一致；
+3. 校验 proof checkpoint 与 latest checkpoint 的签名（基于 Sigstore trusted root）；
+4. 通过 `logIndex + tile` 验证 entry 确实存在于透明日志；
+5. 通过 inclusion proof 验证 entry 包含于已签名树根；
+6. append-only 严格校验：
+   - 首次运行：建立 checkpoint 基线；
+   - 后续运行：对“上次 checkpoint”和“本次 checkpoint”执行树根重构比对，确认无回滚/分叉。
+
+说明：
+
+- 默认 checkpoint 状态文件：`~/.cache/trustee-rekor-audit/<origin>.json`
+- 可通过 `--state-file` 指定自定义状态文件路径；
+- 可通过 `--trusted-root-url` 指定 trusted root JSON（默认使用 Sigstore root-signing 仓库）；
+- `--verbose-http` 会打印访问 Rekor v2/OCI 的具体 URL，便于审计留痕；
+- 当前 provenance source 协议实现为 `oci`。
 
 ---
 
-## 5. 源码与文档链接清单
+## 5. 审计者验证指南（v1 / v2）
 
-### 5.1 透明日志访问核心代码
+### 5.1 审计目标（两代通用）
+
+审计者通常需要确认三件事：
+
+1. 某项参考值（或其 provenance/attestation）在透明日志里确实存在对应 entry；
+2. 该 entry 确实被包含在日志某个已签名树根（checkpoint）中（包含性证明）；
+3. 日志从上次观测到当前保持 append-only（无回滚/分叉，一致性证明）。
+
+### 5.2 Rekor v1：基于 `rekor-cli` 的审计
+
+Rekor v1 可以直接使用 `rekor-cli` 完成端到端审计。
+
+```bash
+# 0) 目标日志
+REKOR_URL="https://rekor.sigstore.dev"
+
+# 1) 先按 hash 搜索候选 entry（示例：制品 sha256）
+ARTIFACT_SHA256="<artifact-sha256-hex>"
+rekor-cli search --rekor_server "${REKOR_URL}" --sha "${ARTIFACT_SHA256}"
+
+# 2) 按 UUID 或 log index 拉取 entry，确认“确实存在”
+UUID="<uuid-from-search>"
+rekor-cli get --rekor_server "${REKOR_URL}" --uuid "${UUID}"
+
+# 3) 验证包含性 + 条目内容（示例：intoto 类型）
+# 需要提供与条目对应的 artifact / signature / public-key（或等价材料）
+rekor-cli verify \
+  --rekor_server "${REKOR_URL}" \
+  --uuid "${UUID}" \
+  --type intoto \
+  --artifact /path/to/artifact \
+  --signature /path/to/signature \
+  --public-key /path/to/public.key
+
+# 4) append-only（一致性）检查
+# 记录上次和本次树大小，获取一致性证明材料
+OLD_SIZE="<old-tree-size>"
+NEW_SIZE="<new-tree-size>"
+rekor-cli logproof \
+  --rekor_server "${REKOR_URL}" \
+  --first-size "${OLD_SIZE}" \
+  --last-size "${NEW_SIZE}"
+```
+
+说明：
+
+- v1 的优势是：检索、包含性验证、一致性证明都能由 `rekor-cli` 统一覆盖；
+- 实际生产中可结合周期性采集 `loginfo`/`logproof` 做持续审计。
+
+### 5.3 Rekor v2：基于 entry + checkpoint + tiles 的审计
+
+Rekor v2 的模型与 v1 不同：**写接口是 `/api/v2/log/entries`，读侧基于 checkpoint + tile API**。  
+因此通常不再依赖 `rekor-cli search/get` 这种“索引检索式”审计流程，而是按下述三步完成。
+
+#### 5.3.1 目标1：entry 存在性（存在于日志索引位置）
+
+输入材料（建议随制品/metadata 一起持久化）：
+
+- `logIndex`
+- `canonicalizedBody`
+- `inclusionProof`（至少包含 `treeSize`、`rootHash`、`hashes`）
+
+最小验证思路：
+
+1. 由 `canonicalizedBody` 计算 leaf hash（RFC6962 叶子哈希：`SHA256(0x00 || canonicalizedBody_bytes)`）；
+2. 按 `logIndex` 定位 level-0 tile（`/tile/0/...`）中的对应位置；
+3. 对比 tile 里的 leaf hash 与本地计算值一致，即可确认“该条目确实在日志里占有该索引位置”。
+
+#### 5.3.2 目标2：包含性证明（entry 包含在某个已签名树根）
+
+验证步骤：
+
+1. 使用 `inclusionProof.hashes` + `logIndex` + leaf hash，按 RFC6962 规则回放路径，得到计算根；
+2. 与 `inclusionProof.rootHash` 比较，应一致；
+3. 使用 `inclusionProof.checkpoint.envelope`（已签名 checkpoint）验证签名与 `treeSize/rootHash` 对应关系。
+
+> 第 3 步建议使用 Sigstore 官方信任根（TUF 分发）中的 Rekor 公钥做签名校验。
+
+#### 5.3.3 目标3：append-only（一致性证明）
+
+v2 一致性验证是“**旧 checkpoint -> 新 checkpoint**”的 consistency proof 校验。流程为：
+
+1. 保存上次可信 checkpoint（`size_old`, `root_old`）；
+2. 获取当前 checkpoint（`size_new`, `root_new`）；
+3. 通过 tile API 拉取所需 Merkle 节点，构造并验证 consistency proof；
+4. 校验通过则说明日志从 old 到 new 仅追加、无回滚/分叉。
+
+实践建议：
+
+- 该流程建议使用专用审计器（如 `rekor-monitor`/`omniwitness` 或基于 `sigstore-go` 的校验代码）自动化执行；
+- v2 更推荐“持续监控 + 本地保存 checkpoint 状态”，而不是临时手工查单条。
+
+#### 5.3.4 与 Trustee 的对应关系
+
+- Trustee 在 v2 路径中会保存/消费 `rekorEntryV2` 与 DSSE 内容并做摘要一致性校验；
+- 对外部独立审计者，建议复用同一份 bundle/metadata 做“存在性 + 包含性 + 一致性”三层验证，形成可复验审计链路。
+
+---
+
+## 6. 源码与文档链接清单
+
+### 6.1 透明日志访问核心代码
 
 - [RVPS Rekor 客户端实现](../rvps/src/rekor.rs)
 - [RVPS 批量设置参考值主逻辑（含 Rekor 查询）](../rvps/src/lib.rs)
 - [RVPS `rv_list` 数据结构与解析](../rvps/src/rv_list/mod.rs)
 - [SLSA digest 提取逻辑](../rvps/src/rv_list/slsa_parse.rs)
 
-### 5.2 对外接口与使用文档
+### 6.2 对外接口与使用文档
 
 - [Gateway API 文档（`set_reference_value_list`）](../trustee-gateway/trustee_gateway_api.md)
 - [SLSA 生成与上链工具说明](../tools/slsa/README.md)

--- a/rvps/src/lib.rs
+++ b/rvps/src/lib.rs
@@ -7,6 +7,7 @@ pub mod client;
 pub mod config;
 pub mod extractors;
 pub mod pre_processor;
+mod provenance_source;
 pub mod reference_value;
 mod rekor;
 mod rv_list;
@@ -22,11 +23,15 @@ use extractors::Extractors;
 use pre_processor::{PreProcessor, PreProcessorAPI};
 
 use anyhow::{bail, Context, Result};
+use base64::Engine;
 use chrono::{Months, Timelike, Utc};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::Digest;
 use std::collections::{HashMap, HashSet};
 
+use provenance_source::{OciProvenanceFetcher, ProvenanceFetcher, ProvenanceSource};
 use rv_list::{extract_slsa_digests, parse_reference_value_list, ReferenceValueOperation};
 
 /// Default version of Message
@@ -179,12 +184,37 @@ impl Rvps {
                 None => format!("measurement.{}.{}", item.rv_type, item.id),
             };
 
-            let lookup = format!("{}{}", item.id, item.version);
-            let rekor_client = rekor::RekorClient::new(&item.provenance_info.rekor_url)?;
-            let slsa_docs = rekor_client
-                .fetch_slsa_provenance_for_lookup(&lookup)
-                .await
-                .with_context(|| format!("fetch SLSA provenance for {}", item.id))?;
+            let slsa_docs = if let Some(source) = &item.provenance_source {
+                let protocol = source.protocol.to_ascii_lowercase();
+                let material = match protocol.as_str() {
+                    "oci" => {
+                        let fetcher = OciProvenanceFetcher::new();
+                        let src = ProvenanceSource {
+                            protocol: source.protocol.clone(),
+                            uri: source.uri.clone(),
+                            artifact: source.artifact.clone(),
+                        };
+                        fetcher
+                            .fetch(&src)
+                            .await
+                            .with_context(|| format!("fetch provenance from OCI `{}`", src.uri))?
+                    }
+                    other => bail!("unsupported provenance_source.protocol `{other}`"),
+                };
+                parse_slsa_documents_from_material(&material.raw_bytes).with_context(|| {
+                    format!(
+                        "parse fetched provenance material for `{}` (media type: {:?})",
+                        item.id, material.media_type
+                    )
+                })?
+            } else {
+                let lookup = format!("{}{}", item.id, item.version);
+                let rekor_client = rekor::RekorClient::new(&item.provenance_info.rekor_url)?;
+                rekor_client
+                    .fetch_slsa_provenance_for_lookup(&lookup)
+                    .await
+                    .with_context(|| format!("fetch SLSA provenance for {}", item.id))?
+            };
 
             let mut digest_set = HashSet::new();
             for doc in &slsa_docs {
@@ -278,5 +308,222 @@ impl Rvps {
                 Ok(false)
             }
         }
+    }
+}
+
+fn parse_slsa_documents_from_material(raw_bytes: &[u8]) -> Result<Vec<String>> {
+    let text = std::str::from_utf8(raw_bytes).context("provenance material is not UTF-8 text")?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        bail!("provenance material is empty");
+    }
+
+    if let Ok(json) = serde_json::from_str::<Value>(trimmed) {
+        return parse_slsa_documents_from_json(&json);
+    }
+
+    // in-toto bundle is JSONL; parse line by line as DSSE envelopes.
+    let mut docs = Vec::new();
+    for line in trimmed.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(line).context("parse JSONL line as JSON")?;
+        if let Some(statement) = dsse_payload_statement(&value)? {
+            docs.push(statement);
+        }
+    }
+
+    if docs.is_empty() {
+        bail!("no SLSA statement found in provenance material");
+    }
+
+    Ok(unique_docs(docs))
+}
+
+fn parse_slsa_documents_from_json(value: &Value) -> Result<Vec<String>> {
+    verify_rekor_v2_consistency(value)?;
+
+    // Direct in-toto statement JSON.
+    if is_statement_json(value) {
+        return Ok(vec![value.to_string()]);
+    }
+
+    // DSSE envelope object.
+    if let Some(statement) = dsse_payload_statement(value)? {
+        return Ok(vec![statement]);
+    }
+
+    // Sigstore bundle: prefer dsseEnvelope payload when available.
+    let mut docs = Vec::new();
+    if let Some(dsse) = value.get("dsseEnvelope") {
+        if let Some(statement) = dsse_payload_statement(dsse)? {
+            docs.push(statement);
+        }
+    }
+    if let Some(dsse) = value.pointer("/content/dsseEnvelope") {
+        if let Some(statement) = dsse_payload_statement(dsse)? {
+            docs.push(statement);
+        }
+    }
+    if let Some(dsse) = value.pointer("/sourceBundle/dsseEnvelope") {
+        if let Some(statement) = dsse_payload_statement(dsse)? {
+            docs.push(statement);
+        }
+    }
+    if let Some(dsse) = value.pointer("/sourceBundle/content/dsseEnvelope") {
+        if let Some(statement) = dsse_payload_statement(dsse)? {
+            docs.push(statement);
+        }
+    }
+
+    // Array of envelopes/statements.
+    if let Some(arr) = value.as_array() {
+        for item in arr {
+            if is_statement_json(item) {
+                docs.push(item.to_string());
+                continue;
+            }
+            if let Some(statement) = dsse_payload_statement(item)? {
+                docs.push(statement);
+            }
+        }
+    }
+
+    if docs.is_empty() {
+        bail!("unsupported provenance material JSON format");
+    }
+    Ok(unique_docs(docs))
+}
+
+fn dsse_payload_statement(value: &Value) -> Result<Option<String>> {
+    let payload = value.get("payload").and_then(|v| v.as_str());
+    let payload_type = value.get("payloadType").and_then(|v| v.as_str());
+    let signatures = value.get("signatures").and_then(|v| v.as_array());
+    if payload.is_none() || payload_type.is_none() || signatures.is_none() {
+        return Ok(None);
+    }
+
+    let payload_type = payload_type.unwrap_or_default().to_ascii_lowercase();
+    if !payload_type.starts_with("application/vnd.in-toto") {
+        return Ok(None);
+    }
+
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(payload.unwrap_or_default())
+        .context("decode DSSE payload")?;
+    let statement = String::from_utf8(decoded).context("DSSE payload is not UTF-8")?;
+    let statement_json: Value =
+        serde_json::from_str(&statement).context("parse DSSE payload as JSON")?;
+    if !is_statement_json(&statement_json) {
+        bail!("DSSE payload is not an in-toto statement");
+    }
+
+    Ok(Some(statement))
+}
+
+fn verify_rekor_v2_consistency(value: &Value) -> Result<()> {
+    let dsse = value
+        .get("dsseEnvelope")
+        .or_else(|| value.pointer("/content/dsseEnvelope"))
+        .or_else(|| value.pointer("/sourceBundle/dsseEnvelope"))
+        .or_else(|| value.pointer("/sourceBundle/content/dsseEnvelope"));
+    let tlog_entry = value
+        .get("rekorEntryV2")
+        .or_else(|| value.pointer("/verificationMaterial/tlogEntries/0"))
+        .or_else(|| value.pointer("/sourceBundle/verificationMaterial/tlogEntries/0"));
+
+    let (Some(dsse), Some(tlog_entry)) = (dsse, tlog_entry) else {
+        return Ok(());
+    };
+
+    let payload_b64 = dsse
+        .get("payload")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("dsseEnvelope.payload missing for Rekor v2 verification"))?;
+    let payload_bytes = base64::engine::general_purpose::STANDARD
+        .decode(payload_b64)
+        .context("decode dsseEnvelope.payload for Rekor v2 verification")?;
+    let payload_sha256 = sha2::Sha256::digest(payload_bytes);
+    let payload_sha256_b64 = base64::engine::general_purpose::STANDARD.encode(payload_sha256);
+
+    let canonicalized_body_b64 = tlog_entry
+        .get("canonicalizedBody")
+        .or_else(|| tlog_entry.get("canonicalized_body"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Rekor v2 tlog entry missing canonicalizedBody"))?;
+    let canonicalized_body = base64::engine::general_purpose::STANDARD
+        .decode(canonicalized_body_b64)
+        .context("decode Rekor v2 canonicalizedBody")?;
+    let canonicalized_json: Value = serde_json::from_slice(&canonicalized_body)
+        .context("parse Rekor v2 canonicalizedBody JSON")?;
+
+    let kind = canonicalized_json
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if kind != "dsse" {
+        bail!("Rekor v2 canonicalizedBody kind `{kind}` is not dsse");
+    }
+
+    let rekor_payload_digest = canonicalized_json
+        .pointer("/spec/dsseV002/data/digest")
+        .or_else(|| canonicalized_json.pointer("/spec/dsseV002/payloadHash/digest"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Rekor v2 canonicalizedBody missing dsse payload digest"))?;
+
+    if rekor_payload_digest != payload_sha256_b64 {
+        bail!(
+            "Rekor v2 digest mismatch: rekor=`{}`, payload_sha256_b64=`{}`",
+            rekor_payload_digest,
+            payload_sha256_b64
+        );
+    }
+
+    Ok(())
+}
+
+fn is_statement_json(value: &Value) -> bool {
+    value
+        .get("predicateType")
+        .and_then(|v| v.as_str())
+        .is_some()
+        && value.get("_type").and_then(|v| v.as_str()).is_some()
+}
+
+fn unique_docs(docs: Vec<String>) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for doc in docs {
+        if seen.insert(doc.clone()) {
+            out.push(doc);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_direct_statement() {
+        let statement = r#"{"_type":"https://in-toto.io/Statement/v1","predicateType":"https://slsa.dev/provenance/v1","subject":[],"predicate":{}}"#;
+        let docs = parse_slsa_documents_from_material(statement.as_bytes()).unwrap();
+        assert_eq!(docs.len(), 1);
+    }
+
+    #[test]
+    fn parse_dsse_envelope() {
+        let statement = r#"{"_type":"https://in-toto.io/Statement/v1","predicateType":"https://slsa.dev/provenance/v1","subject":[],"predicate":{}}"#;
+        let payload = base64::engine::general_purpose::STANDARD.encode(statement.as_bytes());
+        let dsse = format!(
+            r#"{{"payloadType":"application/vnd.in-toto+json","payload":"{payload}","signatures":[{{"sig":"abc"}}]}}"#
+        );
+        let docs = parse_slsa_documents_from_material(dsse.as_bytes()).unwrap();
+        assert_eq!(docs.len(), 1);
+        assert!(docs[0].contains("predicateType"));
     }
 }

--- a/rvps/src/provenance_source.rs
+++ b/rvps/src/provenance_source.rs
@@ -1,0 +1,380 @@
+use anyhow::{anyhow, bail, Context, Result};
+use async_trait::async_trait;
+use log::debug;
+use reqwest::header::{ACCEPT, AUTHORIZATION, WWW_AUTHENTICATE};
+use reqwest::{Client, Response, StatusCode};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ProvenanceSource {
+    pub protocol: String,
+    pub uri: String,
+    #[serde(default)]
+    pub artifact: Option<String>,
+}
+
+pub struct FetchedProvenanceMaterial {
+    pub media_type: Option<String>,
+    pub raw_bytes: Vec<u8>,
+}
+
+#[async_trait]
+pub trait ProvenanceFetcher: Send + Sync {
+    async fn fetch(&self, source: &ProvenanceSource) -> Result<FetchedProvenanceMaterial>;
+}
+
+pub struct OciProvenanceFetcher {
+    http: Client,
+}
+
+impl OciProvenanceFetcher {
+    pub fn new() -> Self {
+        Self {
+            http: Client::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct OciReference {
+    scheme: String,
+    registry: String,
+    repository: String,
+    reference: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OciManifest {
+    #[serde(rename = "mediaType")]
+    media_type: Option<String>,
+    layers: Option<Vec<OciDescriptor>>,
+    manifests: Option<Vec<OciDescriptor>>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct OciDescriptor {
+    #[serde(rename = "mediaType")]
+    media_type: Option<String>,
+    digest: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BearerTokenResponse {
+    token: Option<String>,
+    access_token: Option<String>,
+}
+
+#[async_trait]
+impl ProvenanceFetcher for OciProvenanceFetcher {
+    async fn fetch(&self, source: &ProvenanceSource) -> Result<FetchedProvenanceMaterial> {
+        let reference = parse_oci_reference(&source.uri)?;
+        let manifest_url = format!(
+            "{}://{}/v2/{}/manifests/{}",
+            reference.scheme, reference.registry, reference.repository, reference.reference
+        );
+
+        let mut auth_header = None;
+        let manifest_resp = self
+            .get_with_bearer_retry(
+                &manifest_url,
+                Some(
+                    "application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json",
+                ),
+                &mut auth_header,
+            )
+            .await
+            .context("fetch OCI manifest")?;
+
+        let manifest_text = manifest_resp
+            .text()
+            .await
+            .context("read OCI manifest body")?;
+        let manifest: OciManifest =
+            serde_json::from_str(&manifest_text).context("parse OCI manifest JSON")?;
+        debug!("OCI manifest media type: {:?}", manifest.media_type);
+
+        let descriptor = select_provenance_descriptor(&manifest, source.artifact.as_deref())
+            .with_context(|| {
+                format!(
+                    "select provenance descriptor from OCI manifest {}",
+                    source.uri
+                )
+            })?;
+
+        let blob_url = format!(
+            "{}://{}/v2/{}/blobs/{}",
+            reference.scheme, reference.registry, reference.repository, descriptor.digest
+        );
+        let blob_resp = self
+            .get_with_bearer_retry(&blob_url, None, &mut auth_header)
+            .await
+            .context("fetch OCI blob")?;
+
+        let blob_media_type = blob_resp
+            .headers()
+            .get("Content-Type")
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.to_string())
+            .or(descriptor.media_type.clone());
+        let raw_bytes = blob_resp
+            .bytes()
+            .await
+            .context("read OCI blob bytes")?
+            .to_vec();
+
+        Ok(FetchedProvenanceMaterial {
+            media_type: blob_media_type,
+            raw_bytes,
+        })
+    }
+}
+
+impl OciProvenanceFetcher {
+    async fn get_with_bearer_retry(
+        &self,
+        url: &str,
+        accept: Option<&str>,
+        auth_header: &mut Option<String>,
+    ) -> Result<Response> {
+        let mut req = self.http.get(url);
+        if let Some(accept_val) = accept {
+            req = req.header(ACCEPT, accept_val);
+        }
+        if let Some(header_val) = auth_header.as_ref() {
+            req = req.header(AUTHORIZATION, header_val);
+        }
+        let resp = req.send().await.with_context(|| format!("GET {url}"))?;
+
+        if resp.status() != StatusCode::UNAUTHORIZED {
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                bail!("request {url} failed with {status}: {text}");
+            }
+            return Ok(resp);
+        }
+
+        let challenge = resp
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| anyhow!("OCI registry requires auth but WWW-Authenticate missing"))?;
+        let token = self
+            .fetch_bearer_token(challenge)
+            .await
+            .context("fetch OCI bearer token")?;
+        let auth_value = format!("Bearer {token}");
+        *auth_header = Some(auth_value.clone());
+
+        let mut retry_req = self.http.get(url);
+        if let Some(accept_val) = accept {
+            retry_req = retry_req.header(ACCEPT, accept_val);
+        }
+        let retry_resp = retry_req
+            .header(AUTHORIZATION, auth_value)
+            .send()
+            .await
+            .with_context(|| format!("retry GET {url}"))?;
+        if !retry_resp.status().is_success() {
+            let status = retry_resp.status();
+            let text = retry_resp.text().await.unwrap_or_default();
+            bail!("request {url} failed after auth with {status}: {text}");
+        }
+        Ok(retry_resp)
+    }
+
+    async fn fetch_bearer_token(&self, challenge: &str) -> Result<String> {
+        let params = parse_www_authenticate_bearer(challenge)?;
+        let realm = params
+            .get("realm")
+            .cloned()
+            .ok_or_else(|| anyhow!("bearer challenge missing realm"))?;
+
+        let mut req = self.http.get(&realm);
+        let mut query = Vec::new();
+        if let Some(service) = params.get("service") {
+            query.push(("service".to_string(), service.to_string()));
+        }
+        if let Some(scope) = params.get("scope") {
+            query.push(("scope".to_string(), scope.to_string()));
+        }
+        if !query.is_empty() {
+            req = req.query(&query);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .with_context(|| format!("GET bearer realm {realm}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            bail!("bearer token request failed with {status}: {text}");
+        }
+
+        let body: BearerTokenResponse = resp.json().await.context("parse bearer token JSON")?;
+        body.token
+            .or(body.access_token)
+            .ok_or_else(|| anyhow!("token endpoint response missing token/access_token"))
+    }
+}
+
+fn parse_oci_reference(uri: &str) -> Result<OciReference> {
+    let without_scheme = uri
+        .strip_prefix("oci://")
+        .ok_or_else(|| anyhow!("unsupported OCI URI `{uri}`; expected prefix oci://"))?;
+    let (host_and_repo, reference) = split_reference(without_scheme)?;
+    let mut parts = host_and_repo.splitn(2, '/');
+    let registry = parts
+        .next()
+        .ok_or_else(|| anyhow!("invalid OCI URI `{uri}`"))?
+        .to_string();
+    let repository = parts
+        .next()
+        .ok_or_else(|| anyhow!("invalid OCI URI `{uri}`: repository missing"))?
+        .to_string();
+
+    if registry.is_empty() || repository.is_empty() || reference.is_empty() {
+        bail!("invalid OCI URI `{uri}`");
+    }
+
+    Ok(OciReference {
+        scheme: infer_registry_scheme(&registry),
+        registry,
+        repository,
+        reference,
+    })
+}
+
+fn infer_registry_scheme(registry: &str) -> String {
+    if registry.starts_with("127.0.0.1")
+        || registry.starts_with("localhost")
+        || std::env::var("TRUSTEE_OCI_INSECURE")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    {
+        "http".to_string()
+    } else {
+        "https".to_string()
+    }
+}
+
+fn split_reference(path: &str) -> Result<(String, String)> {
+    if let Some((left, digest)) = path.rsplit_once('@') {
+        return Ok((left.to_string(), digest.to_string()));
+    }
+
+    let slash = path
+        .rfind('/')
+        .ok_or_else(|| anyhow!("invalid OCI reference `{path}`"))?;
+    let suffix = &path[slash + 1..];
+    if let Some(colon_pos) = suffix.rfind(':') {
+        let left = format!("{}{}", &path[..slash + 1], &suffix[..colon_pos]);
+        let tag = &suffix[colon_pos + 1..];
+        return Ok((left, tag.to_string()));
+    }
+
+    Ok((path.to_string(), "latest".to_string()))
+}
+
+fn select_provenance_descriptor(
+    manifest: &OciManifest,
+    preferred_artifact: Option<&str>,
+) -> Result<OciDescriptor> {
+    let mut candidates = Vec::new();
+    if let Some(layers) = &manifest.layers {
+        candidates.extend(layers.clone());
+    }
+    if let Some(manifests) = &manifest.manifests {
+        candidates.extend(manifests.clone());
+    }
+    if candidates.is_empty() {
+        bail!("OCI manifest has no layers/manifests");
+    }
+
+    let want_bundle = preferred_artifact
+        .map(|v| v.eq_ignore_ascii_case("bundle"))
+        .unwrap_or(true);
+    let want_provenance = preferred_artifact
+        .map(|v| v.eq_ignore_ascii_case("provenance"))
+        .unwrap_or(false);
+
+    for c in &candidates {
+        if let Some(mt) = &c.media_type {
+            let lower = mt.to_ascii_lowercase();
+            if want_bundle
+                && (lower.contains("in-toto.bundle")
+                    || lower.contains("dev.sigstore.bundle")
+                    || lower.contains("jsonl"))
+            {
+                return Ok(c.clone());
+            }
+            if want_provenance
+                && (lower.contains("in-toto")
+                    || lower.contains("dsse.envelope")
+                    || lower.contains("provenance"))
+            {
+                return Ok(c.clone());
+            }
+        }
+    }
+
+    for c in &candidates {
+        if let Some(mt) = &c.media_type {
+            let lower = mt.to_ascii_lowercase();
+            if lower.contains("in-toto") || lower.contains("dsse.envelope") {
+                return Ok(c.clone());
+            }
+        }
+    }
+
+    Ok(candidates[0].clone())
+}
+
+fn parse_www_authenticate_bearer(header: &str) -> Result<HashMap<String, String>> {
+    let lower = header.to_ascii_lowercase();
+    if !lower.starts_with("bearer ") {
+        bail!("unsupported auth challenge `{header}`");
+    }
+
+    let kv = &header[7..];
+    let mut map = HashMap::new();
+    for part in kv.split(',') {
+        let trimmed = part.trim();
+        let Some((k, v)) = trimmed.split_once('=') else {
+            continue;
+        };
+        map.insert(k.trim().to_string(), v.trim().trim_matches('"').to_string());
+    }
+    Ok(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_oci_reference_tag() {
+        let r = parse_oci_reference("oci://registry.io/ns/repo:1.0.0").unwrap();
+        assert_eq!(r.registry, "registry.io");
+        assert_eq!(r.repository, "ns/repo");
+        assert_eq!(r.reference, "1.0.0");
+    }
+
+    #[test]
+    fn test_parse_oci_reference_digest() {
+        let r = parse_oci_reference("oci://registry.io/ns/repo@sha256:abcd").unwrap();
+        assert_eq!(r.reference, "sha256:abcd");
+    }
+
+    #[test]
+    fn test_parse_www_authenticate() {
+        let m = parse_www_authenticate_bearer(
+            r#"Bearer realm="https://auth.example/token",service="registry.example",scope="repository:ns/repo:pull""#,
+        )
+        .unwrap();
+        assert_eq!(m.get("realm").unwrap(), "https://auth.example/token");
+        assert_eq!(m.get("service").unwrap(), "registry.example");
+    }
+}

--- a/rvps/src/rv_list/mod.rs
+++ b/rvps/src/rv_list/mod.rs
@@ -13,6 +13,8 @@ pub struct ReferenceValueListItem {
     #[serde(rename = "type")]
     pub rv_type: String,
     pub provenance_info: ReferenceValueProvenanceInfo,
+    #[serde(default)]
+    pub provenance_source: Option<ReferenceValueProvenanceSource>,
     pub operation_type: String,
     /// When set, use this as the RVPS reference value name instead of
     /// `measurement.{type}.{id}`.
@@ -25,6 +27,16 @@ pub struct ReferenceValueProvenanceInfo {
     #[serde(rename = "type")]
     pub provenance_type: String,
     pub rekor_url: String,
+    #[serde(default)]
+    pub rekor_api_version: Option<u8>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ReferenceValueProvenanceSource {
+    pub protocol: String,
+    pub uri: String,
+    #[serde(default)]
+    pub artifact: Option<String>,
 }
 
 pub enum ReferenceValueOperation {

--- a/tools/slsa/README.md
+++ b/tools/slsa/README.md
@@ -1,6 +1,6 @@
 # SLSA Provenance 生成与上链工具
 
-本目录包含脚本 `slsa-generator`，用于为制品生成最简SLSA provenance（in-toto Statement），完成签名并上传到 Rekor 透明日志公共实例。
+本目录包含脚本 `slsa-generator`，用于为制品生成最简SLSA provenance（in-toto Statement），完成签名并上传到 Rekor（v1/v2），并可将 provenance 元数据上传到指定存储地址（首期支持 OCI）。
 
 ## 依赖
 
@@ -10,6 +10,9 @@
 - sigstore: `cosign`
 - sigstore: `rekor-cli`
 - `uki` 类型额外需要: Python 3（调用同目录下的 `parse_uki_digest.py`）
+- `jq`
+- `curl`
+- `openssl`
 
 版本说明（已验证环境）:
 
@@ -22,7 +25,7 @@
 
 ```
 ./slsa-generator --artifact-type <type> --artifact <path> --artifact-id <id> \
-  --artifact-version <version> --sign-key <key>
+  --artifact-version <version> --sign-key <key> [更多可选参数]
 ```
 
 参数说明:
@@ -35,6 +38,12 @@
 - `--artifact-id`: 制品自定义ID
 - `--artifact-version`: 制品版本
 - `--sign-key`: 用于签名SLSA provenance的私钥路径(cosign生成)
+- `--rekor-url`: Rekor 地址（默认 `https://rekor.sigstore.dev`）
+- `--rekor-api-version`: Rekor API 主版本，`1` 或 `2`（默认 `1`）
+- `--rekor-v2-key-details`: Rekor v2 verifier key details（默认 `PKIX_ECDSA_P256_SHA_256`）
+- `--provenance-store-protocol`: provenance 存储协议（当前支持 `oci`）
+- `--provenance-store-uri`: provenance 存储地址（如 `oci://127.0.0.1:5000/ns/repo:tag`）
+- `--provenance-store-artifact`: 上传到存储的对象类型（`bundle` 或 `provenance`，默认 `bundle`）
 
 运行完成后会在当前目录生成输出目录，例如:
 
@@ -43,13 +52,19 @@
   ├── statement.json
   ├── statement.attestation.json
   └── statement.dsse.json
+  ├── statement.intoto.jsonl
+  ├── rekor-v1-upload.txt / rekor-v2-entry.json
+  └── provenance.trustee-bundle.json
 ```
 
 各文件说明:
 
 - `statement.json`: 原始 in-toto Statement（SLSA provenance）
 - `statement.attestation.json`: cosign 输出的 attestation 产物
-- `statement.dsse.json`: DSSE envelope（包含 `payload`、`payloadType`、`signatures`），用于以 `intoto` 类型上传 Rekor
+- `statement.dsse.json`: DSSE envelope（包含 `payload`、`payloadType`、`signatures`）
+- `statement.intoto.jsonl`: 单条 DSSE 的 JSONL 形式
+- `rekor-v2-entry.json`: 上传到 Rekor v2 返回的透明日志条目（v2 模式下生成）
+- `provenance.trustee-bundle.json`: 供 RVPS 新链路消费的标准化组合元数据（`sourceBundle` + `dsseEnvelope` + 可选 `rekorEntryV2`）
 
 ## 生成签名密钥
 
@@ -76,7 +91,11 @@ cosign generate-key-pair --output-key-prefix /path/to/mykey
 
 ```
 ./slsa-generator --artifact-type binary --artifact /path/to/app.bin \
-  --artifact-id app-binary --artifact-version 1.0.0 --sign-key /path/to/cosign.key
+  --artifact-id app-binary --artifact-version 1.0.0 --sign-key /path/to/cosign.key \
+  --rekor-url https://log2025-1.rekor.sigstore.dev --rekor-api-version 2 \
+  --provenance-store-protocol oci \
+  --provenance-store-uri oci://127.0.0.1:5000/trustee/provenance:app-binary-1.0.0 \
+  --provenance-store-artifact bundle
 ```
 
 ```
@@ -101,8 +120,11 @@ UKI 示例（`--artifact` 指向 JSON 文件）:
 
 ## 说明
 
-- Rekor 公共实例 URL: `https://rekor.sigstore.dev`
+- Rekor v1 公共实例 URL: `https://rekor.sigstore.dev`
+- Rekor v2 需要使用 `/api/v2/log/entries`，脚本在 `--rekor-api-version 2` 时走 v2 上传逻辑。
 - `model-dir` 的摘要通过 `cryptpilot-verity dump <model-dir-path> --print-root-hash` 获取。
 - 脚本使用 `rekor-cli upload --type intoto`，上传对象为 `statement.dsse.json`（DSSE envelope），而不是原始 `statement.json`。
 - `uki` 会从 `measurement.uki.<algorithm>` 提取摘要算法和值，`<algorithm>` 兼容 `sha256`/`sha384`（大小写及连字符写法均可，例如 `SHA-256`、`SHA-384`）。解析逻辑见 `parse_uki_digest.py`。
 - 上传到 Rekor 后，可用 Gateway/KBS 的 `set_reference_value_list` 或本地 `attestation-challenge-client set-reference-value-list --rv-list <json>` 按 `rv_list`（含每项 `provenance_info.rekor_url`）从 Rekor 拉取并写入 RVPS。每项可选字段 `rv_name` 可覆盖默认参考值名 `measurement.<type>.<id>`（详见 `trustee-gateway/trustee_gateway_api.md` 与 `docs/challenge_ra.md`）。
+- v1 模式下脚本使用 `rekor-cli upload --type intoto`。
+- v2 模式下脚本使用 HTTP API 直接提交 `dsseRequestV002`。

--- a/tools/slsa/audit_reference_value_v2.py
+++ b/tools/slsa/audit_reference_value_v2.py
@@ -1,0 +1,981 @@
+#!/usr/bin/env python3
+"""
+Audit Trustee reference value against Rekor v2 evidence.
+
+Inputs:
+  - reference id / version / value
+  - provenance source protocol + uri (+ optional artifact selector)
+"""
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.serialization import load_der_public_key
+
+
+DEFAULT_TRUSTED_ROOT_URL = (
+    "https://raw.githubusercontent.com/sigstore/root-signing/main/targets/trusted_root.json"
+)
+
+FETCH_PROGRESS_EVERY = 200
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def fail(msg: str, code: int = 1) -> None:
+    log("[FAIL] {}".format(msg))
+    raise SystemExit(code)
+
+
+def normalize_ref_value(value: str) -> str:
+    out = value.strip().lower()
+    if out.startswith("sha256:"):
+        out = out.split(":", 1)[1]
+    return out
+
+
+def infer_scheme(host: str) -> str:
+    insecure = os.getenv("TRUSTEE_OCI_INSECURE", "").lower() in {"1", "true", "yes"}
+    if host.startswith("127.0.0.1") or host.startswith("localhost") or insecure:
+        return "http"
+    return "https"
+
+
+def http_request(
+    method: str,
+    url: str,
+    headers: Optional[Dict[str, str]] = None,
+    data: Optional[bytes] = None,
+    timeout: int = 20,
+) -> urllib.response.addinfourl:
+    req = urllib.request.Request(url=url, method=method, data=data, headers=headers or {})
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def http_get_bytes(
+    url: str, headers: Optional[Dict[str, str]] = None, timeout: int = 20, verbose: bool = False
+) -> bytes:
+    if verbose:
+        log("[HTTP] GET {}".format(url))
+    req = urllib.request.Request(url=url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def init_fetch_stats() -> Dict[str, int]:
+    return {"http_fetches": 0, "cache_hits": 0}
+
+
+def parse_www_authenticate(header: str) -> Dict[str, str]:
+    if not header.lower().startswith("bearer "):
+        return {}
+    attrs = header[len("Bearer ") :]
+    out = {}
+    for part in re.split(r",\s*", attrs):
+        if "=" not in part:
+            continue
+        k, v = part.split("=", 1)
+        out[k.strip()] = v.strip().strip('"')
+    return out
+
+
+def oci_request_with_bearer(
+    method: str,
+    url: str,
+    headers: Optional[Dict[str, str]] = None,
+    data: Optional[bytes] = None,
+    timeout: int = 20,
+    verbose: bool = False,
+) -> bytes:
+    req_headers = dict(headers or {})
+    try:
+        if verbose:
+            log("[HTTP] {} {}".format(method, url))
+        with http_request(method, url, headers=req_headers, data=data, timeout=timeout) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        if e.code != 401:
+            detail = e.read().decode("utf-8", "replace")
+            fail("request {} failed with HTTP {}: {}".format(url, e.code, detail))
+
+        challenge = e.headers.get("WWW-Authenticate", "")
+        params = parse_www_authenticate(challenge)
+        realm = params.get("realm")
+        if not realm:
+            fail("registry auth challenge missing realm")
+
+        qs = {}
+        if params.get("service"):
+            qs["service"] = params["service"]
+        if params.get("scope"):
+            qs["scope"] = params["scope"]
+        token_url = realm + ("?" + urllib.parse.urlencode(qs) if qs else "")
+        if verbose:
+            log("[HTTP] GET {} (bearer token)".format(token_url))
+        with http_request("GET", token_url, timeout=timeout) as token_resp:
+            token_doc = json.loads(token_resp.read().decode("utf-8"))
+        token = token_doc.get("token") or token_doc.get("access_token")
+        if not token:
+            fail("cannot fetch bearer token from `{}`".format(token_url))
+
+        req_headers["Authorization"] = "Bearer {}".format(token)
+        if verbose:
+            log("[HTTP] {} {} (authorized)".format(method, url))
+        with http_request(method, url, headers=req_headers, data=data, timeout=timeout) as resp2:
+            return resp2.read()
+
+
+def parse_oci_uri(uri: str) -> Tuple[str, str, str]:
+    if not uri.startswith("oci://"):
+        fail("invalid OCI uri `{}`: must start with oci://".format(uri))
+    no_scheme = uri[len("oci://") :]
+    if "/" not in no_scheme:
+        fail("invalid OCI uri `{}`: missing repository".format(uri))
+    registry, repo_ref = no_scheme.split("/", 1)
+    if not registry or not repo_ref:
+        fail("invalid OCI uri `{}`".format(uri))
+
+    if "@sha256:" in repo_ref:
+        repository, reference = repo_ref.split("@", 1)
+    else:
+        if ":" in repo_ref.rsplit("/", 1)[-1]:
+            repository, tag = repo_ref.rsplit(":", 1)
+            reference = tag
+        else:
+            repository = repo_ref
+            reference = "latest"
+
+    if not repository or not reference:
+        fail("invalid OCI uri `{}`".format(uri))
+    return registry, repository, reference
+
+
+def choose_descriptor(manifest: dict, artifact: str) -> dict:
+    layers = manifest.get("layers") or []
+    if not layers:
+        fail("OCI manifest has no layers")
+
+    artifact = artifact.lower()
+    artifact_type = str(manifest.get("artifactType", "")).lower()
+
+    def score(layer: dict) -> int:
+        mt = str(layer.get("mediaType", "")).lower()
+        s = 0
+        if artifact == "bundle":
+            if "bundle" in mt:
+                s += 5
+            if "bundle" in artifact_type:
+                s += 2
+            if "json" in mt:
+                s += 1
+        else:
+            if "provenance" in mt:
+                s += 5
+            if "in-toto" in mt:
+                s += 2
+            if "json" in mt:
+                s += 1
+        return s
+
+    ranked = sorted(layers, key=score, reverse=True)
+    return ranked[0]
+
+
+def fetch_provenance_from_oci(uri: str, artifact: str, verbose: bool) -> bytes:
+    registry, repository, reference = parse_oci_uri(uri)
+    scheme = infer_scheme(registry)
+    base = "{}://{}".format(scheme, registry)
+
+    accept_manifest = (
+        "application/vnd.oci.artifact.manifest.v1+json, "
+        "application/vnd.oci.image.manifest.v1+json, "
+        "application/vnd.docker.distribution.manifest.v2+json"
+    )
+    manifest_url = "{}/v2/{}/manifests/{}".format(base, repository, reference)
+    manifest_raw = oci_request_with_bearer(
+        "GET", manifest_url, headers={"Accept": accept_manifest}, verbose=verbose
+    )
+    manifest = json.loads(manifest_raw.decode("utf-8"))
+    desc = choose_descriptor(manifest, artifact)
+
+    digest = desc.get("digest")
+    if not digest:
+        fail("chosen OCI descriptor has no digest")
+    blob_url = "{}/v2/{}/blobs/{}".format(base, repository, digest)
+    blob = oci_request_with_bearer("GET", blob_url, verbose=verbose)
+    if verbose:
+        log("[INFO] OCI manifest artifactType={}".format(manifest.get("artifactType", "")))
+        log("[INFO] OCI selected layer mediaType={}".format(desc.get("mediaType", "")))
+        log("[INFO] OCI selected layer digest={}".format(digest))
+    return blob
+
+
+def extract_material_docs(material: bytes) -> Tuple[dict, dict, dict]:
+    try:
+        doc = json.loads(material.decode("utf-8"))
+    except Exception as e:
+        fail("provenance material is not valid JSON: {}".format(e))
+
+    statement = None
+    dsse = None
+    rekor_v2 = None
+    source_bundle = None
+
+    if isinstance(doc, dict):
+        source_bundle = doc.get("sourceBundle")
+        statement = doc.get("statement")
+        dsse = doc.get("dsseEnvelope") or (doc.get("content") or {}).get("dsseEnvelope")
+        rekor_v2 = doc.get("rekorEntryV2") or (doc.get("verificationMaterial") or {}).get(
+            "tlogEntries", [{}]
+        )[0]
+
+        if isinstance(source_bundle, dict):
+            if dsse is None:
+                dsse = source_bundle.get("dsseEnvelope") or (
+                    source_bundle.get("content") or {}
+                ).get("dsseEnvelope")
+            if rekor_v2 is None or not rekor_v2:
+                rekor_v2 = (source_bundle.get("verificationMaterial") or {}).get(
+                    "tlogEntries", [{}]
+                )[0]
+
+        if statement is None and "_type" in doc and "predicateType" in doc:
+            statement = doc
+
+        if dsse is None and "payloadType" in doc and "payload" in doc and "signatures" in doc:
+            dsse = doc
+
+    if not isinstance(dsse, dict):
+        fail("cannot find dsseEnvelope in provenance material")
+    if not isinstance(rekor_v2, dict) or not rekor_v2:
+        fail("cannot find rekorEntryV2/tlog entry in provenance material")
+
+    if statement is None:
+        payload_b64 = dsse.get("payload")
+        if not isinstance(payload_b64, str):
+            fail("dsseEnvelope.payload missing")
+        try:
+            statement = json.loads(base64.b64decode(payload_b64))
+        except Exception as e:
+            fail("cannot decode statement from dsse payload: {}".format(e))
+
+    if not isinstance(statement, dict):
+        fail("invalid statement document")
+    return statement, dsse, rekor_v2
+
+
+def verify_reference_value(statement: dict, ref_id: str, ref_ver: str, ref_value: str) -> str:
+    subjects = statement.get("subject")
+    if not isinstance(subjects, list):
+        fail("statement.subject missing or invalid")
+
+    matched = None
+    for item in subjects:
+        if isinstance(item, dict) and item.get("name") == ref_id:
+            matched = item
+            break
+    if not matched:
+        names = [s.get("name") for s in subjects if isinstance(s, dict)]
+        fail("reference id `{}` not found in statement subjects: {}".format(ref_id, names))
+
+    digest = (matched.get("digest") or {}).get("sha256")
+    if not isinstance(digest, str):
+        fail("statement subject digest.sha256 missing")
+
+    expected = normalize_ref_value(ref_value)
+    actual = digest.strip().lower()
+    if expected != actual:
+        fail(
+            "reference value mismatch: input={}, statement(subject={}).sha256={}".format(
+                expected, ref_id, actual
+            )
+        )
+
+    actual_ver = (
+        ((statement.get("predicate") or {}).get("invocation") or {})
+        .get("environment", {})
+        .get("artifactVersion")
+    )
+    if actual_ver is not None and str(actual_ver) != ref_ver:
+        fail("reference version mismatch: input={}, statement={}".format(ref_ver, actual_ver))
+    return actual
+
+
+def tile_path_for_index(tile_index: int) -> str:
+    chunks = []
+    s = str(tile_index)
+    while s:
+        chunks.append(s[-3:].zfill(3))
+        s = s[:-3]
+    chunks.reverse()
+    if len(chunks) == 1:
+        return chunks[0]
+    return "/".join(["x" + c for c in chunks[:-1]] + [chunks[-1]])
+
+
+def fetch_tile_hash(
+    rekor_base: str,
+    level: int,
+    node_index: int,
+    tree_size: int,
+    tile_cache: Dict[str, bytes],
+    fetch_stats: Dict[str, int],
+    verbose: bool,
+) -> bytes:
+    tile_index = node_index // 256
+    pos = node_index % 256
+    path = tile_path_for_index(tile_index)
+    full_url = "{}/tile/{}/{}".format(rekor_base, level, path)
+    raw = tile_cache.get(full_url)
+    if raw is None:
+        try:
+            raw = http_get_bytes(full_url, verbose=verbose)
+            tile_cache[full_url] = raw
+            fetch_stats["http_fetches"] += 1
+            if (
+                not verbose
+                and fetch_stats["http_fetches"] > 0
+                and fetch_stats["http_fetches"] % FETCH_PROGRESS_EVERY == 0
+            ):
+                log(
+                    "[PROGRESS] tile HTTP fetches={}, cache_hits={}".format(
+                        fetch_stats["http_fetches"], fetch_stats["cache_hits"]
+                    )
+                )
+        except urllib.error.HTTPError as e:
+            if e.code != 404:
+                detail = e.read().decode("utf-8", "replace")
+                fail("fetch tile failed: {}, HTTP {}, {}".format(full_url, e.code, detail))
+            denom = 256 ** level
+            width = (tree_size // denom) % 256
+            if width == 0:
+                fail("tile not found and not partial: {}".format(full_url))
+            partial_url = "{}/tile/{}/{}.p/{}".format(rekor_base, level, path, width)
+            try:
+                raw = http_get_bytes(partial_url, verbose=verbose)
+                tile_cache[partial_url] = raw
+                fetch_stats["http_fetches"] += 1
+                if (
+                    not verbose
+                    and fetch_stats["http_fetches"] > 0
+                    and fetch_stats["http_fetches"] % FETCH_PROGRESS_EVERY == 0
+                ):
+                    log(
+                        "[PROGRESS] tile HTTP fetches={}, cache_hits={}".format(
+                            fetch_stats["http_fetches"], fetch_stats["cache_hits"]
+                        )
+                    )
+            except urllib.error.HTTPError as e2:
+                detail = e2.read().decode("utf-8", "replace")
+                fail(
+                    "fetch partial tile failed: {}, HTTP {}, {}".format(
+                        partial_url, e2.code, detail
+                    )
+                )
+
+    else:
+        fetch_stats["cache_hits"] += 1
+
+    if len(raw) % 32 != 0:
+        fail("invalid tile payload length at level {}: {}".format(level, len(raw)))
+    count = len(raw) // 32
+    if pos >= count:
+        fail("tile position out of range: level={}, pos={}, count={}".format(level, pos, count))
+    return raw[pos * 32 : (pos + 1) * 32]
+
+
+def fetch_level0_leaf_hash(
+    rekor_base: str,
+    log_index: int,
+    tree_size: int,
+    tile_cache: Dict[str, bytes],
+    fetch_stats: Dict[str, int],
+    verbose: bool,
+) -> bytes:
+    return fetch_tile_hash(
+        rekor_base=rekor_base,
+        level=0,
+        node_index=log_index,
+        tree_size=tree_size,
+        tile_cache=tile_cache,
+        fetch_stats=fetch_stats,
+        verbose=verbose,
+    )
+
+
+def verify_inclusion_root(
+    leaf_hash: bytes, log_index: int, tree_size: int, audit_hashes_b64: List[str]
+) -> bytes:
+    def h_children(left: bytes, right: bytes) -> bytes:
+        return hashlib.sha256(b"\x01" + left + right).digest()
+
+    node = leaf_hash
+    idx = log_index
+    last = tree_size - 1
+    for item in audit_hashes_b64:
+        sibling = base64.b64decode(item)
+        if idx % 2 == 1 or idx == last:
+            node = h_children(sibling, node)
+            while idx % 2 == 0 and idx != 0:
+                idx //= 2
+                last //= 2
+        else:
+            node = h_children(node, sibling)
+        idx //= 2
+        last //= 2
+    if last != 0:
+        fail("invalid inclusion proof: tree reduction did not end at root")
+    return node
+
+
+def parse_checkpoint_note(envelope: str) -> dict:
+    if "\n\n" not in envelope:
+        fail("invalid checkpoint envelope: missing separator blank line")
+    text_part, sig_part = envelope.split("\n\n", 1)
+    text_lines = text_part.splitlines()
+    if len(text_lines) < 3:
+        fail("invalid checkpoint note text lines")
+    origin = text_lines[0].strip()
+    try:
+        tree_size = int(text_lines[1].strip())
+    except Exception:
+        fail("invalid checkpoint tree size")
+    root_hash = text_lines[2].strip()
+
+    sigs = []
+    for line in sig_part.splitlines():
+        if not line.strip():
+            continue
+        if not line.startswith("— "):
+            continue
+        rest = line[2:]
+        if " " not in rest:
+            continue
+        key_name, sig_b64 = rest.split(" ", 1)
+        sigs.append((key_name.strip(), sig_b64.strip()))
+
+    return {
+        "origin": origin,
+        "tree_size": tree_size,
+        "root_hash": root_hash,
+        "note_text": text_part + "\n",
+        "signatures": sigs,
+        "envelope": envelope,
+    }
+
+
+def fetch_latest_checkpoint_note(rekor_base: str, verbose: bool) -> dict:
+    url = "{}/checkpoint".format(rekor_base)
+    raw = http_get_bytes(url, verbose=verbose).decode("utf-8", "replace")
+    return parse_checkpoint_note(raw)
+
+
+def find_tlog_key(trusted_root: dict, rekor_base: str) -> dict:
+    tlogs = trusted_root.get("tlogs") or []
+    base = rekor_base.rstrip("/")
+    for item in tlogs:
+        if str(item.get("baseUrl", "")).rstrip("/") == base:
+            return item
+    fail("cannot find tlog key for `{}` in trusted root".format(rekor_base))
+    return {}
+
+
+def key_id_for_note(key_name: str, sig_type: int, pub_material: bytes) -> bytes:
+    h = hashlib.sha256()
+    h.update(key_name.encode("utf-8"))
+    h.update(b"\n")
+    h.update(bytes([sig_type]))
+    h.update(pub_material)
+    return h.digest()[:4]
+
+
+def run_ed25519_verify(pubkey_der: bytes, msg: bytes, sig: bytes) -> bool:
+    try:
+        key = load_der_public_key(pubkey_der)
+    except Exception:
+        return False
+    try:
+        key.verify(sig, msg)  # type: ignore[attr-defined]
+        return True
+    except InvalidSignature:
+        return False
+    except Exception:
+        return False
+
+
+def verify_checkpoint_signature(
+    checkpoint_note: dict, trusted_root_url: str, rekor_base: str, verbose: bool
+) -> None:
+    log("[AUDIT] checkpoint 签名校验: trusted_root={}".format(trusted_root_url))
+    trusted_root = json.loads(http_get_bytes(trusted_root_url, verbose=verbose).decode("utf-8"))
+    tlog_key = find_tlog_key(trusted_root, rekor_base)
+    key_details = ((tlog_key.get("publicKey") or {}).get("keyDetails") or "").upper()
+    key_raw_b64 = (tlog_key.get("publicKey") or {}).get("rawBytes")
+    if not isinstance(key_raw_b64, str):
+        fail("trusted root tlog publicKey.rawBytes missing")
+    key_der = base64.b64decode(key_raw_b64)
+    key_name = checkpoint_note["origin"]
+
+    if key_details != "PKIX_ED25519":
+        fail(
+            "unsupported checkpoint signature keyDetails `{}` (current script supports PKIX_ED25519)".format(
+                key_details
+            )
+        )
+
+    # Ed25519 SPKI DER; public key is the trailing 32 bytes.
+    if len(key_der) < 32:
+        fail("invalid Ed25519 DER key")
+    pub_material = key_der[-32:]
+    expect_key_id = key_id_for_note(key_name, 0x01, pub_material)
+    expect_key_id_hex = expect_key_id.hex()
+    log("[AUDIT] checkpoint verifier keyDetails={}".format(key_details))
+    log("[AUDIT] checkpoint verifier keyId(prefix4)={}".format(expect_key_id_hex))
+
+    ok = False
+    for sign_name, sig_b64 in checkpoint_note.get("signatures", []):
+        if sign_name != key_name:
+            continue
+        raw = base64.b64decode(sig_b64)
+        if len(raw) < 5:
+            continue
+        got_key_id = raw[:4]
+        sig = raw[4:]
+        log(
+            "[AUDIT] checkpoint signature candidate: signer={}, keyId(prefix4)={}".format(
+                sign_name, got_key_id.hex()
+            )
+        )
+        if got_key_id != expect_key_id:
+            continue
+        if run_ed25519_verify(key_der, checkpoint_note["note_text"].encode("utf-8"), sig):
+            ok = True
+            break
+    if not ok:
+        fail("checkpoint signature verification failed")
+    log("[OK] checkpoint signature verified")
+
+
+def largest_power_of_two_less_than(n: int) -> int:
+    if n < 2:
+        return 0
+    p = 1 << (n.bit_length() - 1)
+    if p == n:
+        p >>= 1
+    return p
+
+
+def power256_level(size: int) -> int:
+    if size < 1:
+        return -1
+    lvl = 0
+    s = size
+    while s > 1 and s % 256 == 0:
+        s //= 256
+        lvl += 1
+    return lvl if s == 1 else -1
+
+
+def range_hash_from_tiles(
+    start: int,
+    size: int,
+    tree_size: int,
+    rekor_base: str,
+    tile_cache: Dict[str, bytes],
+    fetch_stats: Dict[str, int],
+    memo: Dict[Tuple[int, int, int], bytes],
+    verbose: bool,
+) -> bytes:
+    key = (start, size, tree_size)
+    if key in memo:
+        return memo[key]
+    if size <= 0:
+        fail("invalid range size for Merkle hash reconstruction")
+    if size == 1:
+        out = fetch_tile_hash(
+            rekor_base=rekor_base,
+            level=0,
+            node_index=start,
+            tree_size=tree_size,
+            tile_cache=tile_cache,
+            fetch_stats=fetch_stats,
+            verbose=verbose,
+        )
+        memo[key] = out
+        return out
+
+    lvl = power256_level(size)
+    if lvl >= 0 and start % size == 0:
+        out = fetch_tile_hash(
+            rekor_base=rekor_base,
+            level=lvl,
+            node_index=start // size,
+            tree_size=tree_size,
+            tile_cache=tile_cache,
+            fetch_stats=fetch_stats,
+            verbose=verbose,
+        )
+        memo[key] = out
+        return out
+
+    split = largest_power_of_two_less_than(size)
+    if split <= 0 or split >= size:
+        fail("cannot split Merkle range")
+    left = range_hash_from_tiles(
+        start,
+        split,
+        tree_size,
+        rekor_base,
+        tile_cache,
+        fetch_stats,
+        memo,
+        verbose=verbose,
+    )
+    right = range_hash_from_tiles(
+        start + split,
+        size - split,
+        tree_size,
+        rekor_base,
+        tile_cache,
+        fetch_stats,
+        memo,
+        verbose=verbose,
+    )
+    out = hashlib.sha256(b"\x01" + left + right).digest()
+    memo[key] = out
+    return out
+
+
+def reconstruct_root_from_tiles(
+    tree_size: int,
+    rekor_base: str,
+    tile_cache: Dict[str, bytes],
+    fetch_stats: Dict[str, int],
+    verbose: bool,
+) -> str:
+    memo = {}
+    root = range_hash_from_tiles(
+        start=0,
+        size=tree_size,
+        tree_size=tree_size,
+        rekor_base=rekor_base,
+        tile_cache=tile_cache,
+        fetch_stats=fetch_stats,
+        memo=memo,
+        verbose=verbose,
+    )
+    return base64.b64encode(root).decode("utf-8")
+
+
+def load_state(path: Path) -> Optional[dict]:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
+
+
+def save_state(path: Path, checkpoint_note: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "origin": checkpoint_note["origin"],
+        "tree_size": checkpoint_note["tree_size"],
+        "root_hash": checkpoint_note["root_hash"],
+        "checkpoint_envelope": checkpoint_note["envelope"],
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Audit Trustee reference value with Rekor v2 evidence (OCI provenance source)."
+    )
+    parser.add_argument("--reference-id", required=True, help="Reference value id")
+    parser.add_argument("--reference-version", required=True, help="Reference value version")
+    parser.add_argument("--reference-value", required=True, help="Reference value digest (sha256 hex)")
+    parser.add_argument("--provenance-source-protocol", required=True, help="Provenance source protocol")
+    parser.add_argument("--provenance-source-uri", required=True, help="Provenance source uri")
+    parser.add_argument(
+        "--provenance-source-artifact",
+        default="bundle",
+        choices=["bundle", "provenance"],
+        help="Provenance source artifact kind",
+    )
+    parser.add_argument(
+        "--rekor-url",
+        default="",
+        help="Optional Rekor base URL override, otherwise derived from checkpoint origin",
+    )
+    parser.add_argument(
+        "--trusted-root-url",
+        default=DEFAULT_TRUSTED_ROOT_URL,
+        help="Trusted root JSON URL for checkpoint signature verification",
+    )
+    parser.add_argument(
+        "--state-file",
+        default="",
+        help="Optional checkpoint state file for append-only continuity checks",
+    )
+    parser.add_argument(
+        "--verbose-http",
+        action="store_true",
+        help="Print HTTP access details",
+    )
+    args = parser.parse_args()
+
+    log("== Trustee Rekor v2 审计脚本 ==")
+    log("[INPUT] id={}, version={}".format(args.reference_id, args.reference_version))
+    log("[INPUT] value={}".format(normalize_ref_value(args.reference_value)))
+    log(
+        "[INPUT] provenance_source=({}) {} [{}]".format(
+            args.provenance_source_protocol, args.provenance_source_uri, args.provenance_source_artifact
+        )
+    )
+
+    if args.provenance_source_protocol.lower() != "oci":
+        fail("currently only `oci` provenance source protocol is supported")
+
+    log("\n[STEP 1/7] 从 OCI provenance source 拉取审计材料...")
+    material = fetch_provenance_from_oci(
+        args.provenance_source_uri,
+        artifact=args.provenance_source_artifact,
+        verbose=args.verbose_http,
+    )
+    log("[OK] 已获取 provenance 材料，bytes={}".format(len(material)))
+
+    log("\n[STEP 2/7] 解析 statement / dsse / rekorEntryV2 ...")
+    statement, dsse, rekor_entry = extract_material_docs(material)
+    log("[OK] 解析成功")
+
+    log("\n[STEP 3/7] 校验参考值（id/version/value）与 statement 一致...")
+    matched_digest = verify_reference_value(
+        statement, args.reference_id, args.reference_version, args.reference_value
+    )
+    log("[OK] 参考值匹配，subject.digest.sha256={}".format(matched_digest))
+
+    log("\n[STEP 4/7] 校验 DSSE 与 Rekor canonicalizedBody 摘要一致...")
+    payload_b64 = dsse.get("payload")
+    if not isinstance(payload_b64, str):
+        fail("dsseEnvelope.payload missing")
+    payload = base64.b64decode(payload_b64)
+    payload_sha256_b64 = base64.b64encode(hashlib.sha256(payload).digest()).decode()
+
+    canonicalized_body_b64 = rekor_entry.get("canonicalizedBody") or rekor_entry.get(
+        "canonicalized_body"
+    )
+    if not isinstance(canonicalized_body_b64, str):
+        fail("rekor entry missing canonicalizedBody")
+    canonicalized_body = base64.b64decode(canonicalized_body_b64)
+    canonicalized_json = json.loads(canonicalized_body.decode("utf-8"))
+    kind = str(canonicalized_json.get("kind", "")).lower()
+    if kind != "dsse":
+        fail("unexpected Rekor entry kind `{}` (expect dsse)".format(kind))
+    rekor_payload_digest = (
+        ((canonicalized_json.get("spec") or {}).get("dsseV002") or {})
+        .get("payloadHash", {})
+        .get("digest")
+    ) or (
+        ((canonicalized_json.get("spec") or {}).get("dsseV002") or {}).get("data", {}).get("digest")
+    )
+    if payload_sha256_b64 != rekor_payload_digest:
+        fail(
+            "dsse payload digest mismatch: local={}, rekor={}".format(
+                payload_sha256_b64, rekor_payload_digest
+            )
+        )
+    log("[OK] payload digest match: {}".format(payload_sha256_b64))
+
+    inclusion = rekor_entry.get("inclusionProof") or {}
+    try:
+        log_index = int(rekor_entry.get("logIndex"))
+        tree_size = int(inclusion.get("treeSize"))
+    except Exception:
+        fail("invalid rekor logIndex/treeSize")
+    root_hash_b64 = inclusion.get("rootHash")
+    audit_hashes = inclusion.get("hashes") or []
+    cp_env = (inclusion.get("checkpoint") or {}).get("envelope", "")
+    if not isinstance(root_hash_b64, str) or not isinstance(audit_hashes, list):
+        fail("invalid inclusion proof fields")
+    if not isinstance(cp_env, str) or not cp_env.strip():
+        fail("inclusion proof checkpoint envelope missing")
+    proof_cp = parse_checkpoint_note(cp_env)
+
+    rekor_base = args.rekor_url.strip().rstrip("/")
+    if not rekor_base:
+        rekor_base = "{}://{}".format(infer_scheme(proof_cp["origin"]), proof_cp["origin"])
+    log("[INFO] Rekor base URL: {}".format(rekor_base))
+    log("[INFO] Rekor logIndex={}, proof.treeSize={}".format(log_index, tree_size))
+    log("[INFO] Rekor proof.rootHash={}".format(root_hash_b64))
+
+    log("\n[STEP 5/7] 校验 checkpoint 签名（proof checkpoint + latest checkpoint）...")
+    if proof_cp["tree_size"] != tree_size or proof_cp["root_hash"] != root_hash_b64:
+        fail("proof checkpoint text does not match inclusionProof fields")
+    verify_checkpoint_signature(
+        checkpoint_note=proof_cp,
+        trusted_root_url=args.trusted_root_url,
+        rekor_base=rekor_base,
+        verbose=args.verbose_http,
+    )
+    latest_cp = fetch_latest_checkpoint_note(rekor_base, verbose=args.verbose_http)
+    verify_checkpoint_signature(
+        checkpoint_note=latest_cp,
+        trusted_root_url=args.trusted_root_url,
+        rekor_base=rekor_base,
+        verbose=args.verbose_http,
+    )
+    if latest_cp["origin"] != proof_cp["origin"]:
+        fail(
+            "latest checkpoint origin mismatch: latest={}, proof={}".format(
+                latest_cp["origin"], proof_cp["origin"]
+            )
+        )
+    if latest_cp["tree_size"] < proof_cp["tree_size"]:
+        fail(
+            "latest checkpoint older than proof checkpoint: latest_size={}, proof_size={}".format(
+                latest_cp["tree_size"], proof_cp["tree_size"]
+            )
+        )
+    log(
+        "[OK] checkpoint continuity: proof(size={}) -> latest(size={})".format(
+            proof_cp["tree_size"], latest_cp["tree_size"]
+        )
+    )
+
+    log("\n[STEP 6/7] 校验 entry 存在性与包含性证明（访问 Rekor v2 tile）...")
+    tile_cache = {}
+    fetch_stats = init_fetch_stats()
+    leaf_hash = hashlib.sha256(b"\x00" + canonicalized_body).digest()
+    server_leaf = fetch_level0_leaf_hash(
+        rekor_base=rekor_base,
+        log_index=log_index,
+        tree_size=tree_size,
+        tile_cache=tile_cache,
+        fetch_stats=fetch_stats,
+        verbose=args.verbose_http,
+    )
+    if server_leaf != leaf_hash:
+        fail("entry existence check failed: tile leaf hash != local leaf hash")
+    calc_root = verify_inclusion_root(leaf_hash, log_index, tree_size, audit_hashes)
+    calc_root_b64 = base64.b64encode(calc_root).decode("utf-8")
+    if calc_root_b64 != root_hash_b64:
+        fail(
+            "inclusion proof verification failed: calculated_root={}, proof_root={}".format(
+                calc_root_b64, root_hash_b64
+            )
+        )
+    log("[OK] entry exists at logIndex={}, and inclusion proof is valid".format(log_index))
+
+    log("\n[STEP 7/7] append-only 严格校验（重构两棵树根）...")
+    if args.state_file:
+        state_file = Path(args.state_file)
+    else:
+        safe_origin = latest_cp["origin"].replace("/", "_")
+        state_file = Path.home() / ".cache" / "trustee-rekor-audit" / "{}.json".format(safe_origin)
+
+    prev_state = load_state(state_file)
+    if prev_state is None:
+        log(
+            "[WARN] 未发现历史 checkpoint 状态；已建立基线。下一次运行将执行严格 append-only 重构校验。"
+        )
+        strict_append_only_done = False
+    else:
+        prev_env = prev_state.get("checkpoint_envelope")
+        if not isinstance(prev_env, str) or not prev_env.strip():
+            fail("previous state missing checkpoint_envelope; cannot run strict append-only check")
+        prev_cp = parse_checkpoint_note(prev_env)
+        verify_checkpoint_signature(
+            checkpoint_note=prev_cp,
+            trusted_root_url=args.trusted_root_url,
+            rekor_base=rekor_base,
+            verbose=args.verbose_http,
+        )
+        if prev_cp["origin"] != latest_cp["origin"]:
+            fail(
+                "previous checkpoint origin mismatch: previous={}, latest={}".format(
+                    prev_cp["origin"], latest_cp["origin"]
+                )
+            )
+        if latest_cp["tree_size"] < prev_cp["tree_size"]:
+            fail(
+                "append-only failed: latest tree size {} < previous {}".format(
+                    latest_cp["tree_size"], prev_cp["tree_size"]
+                )
+            )
+
+        log(
+            "[AUDIT] reconstruct previous root from Rekor tiles: size={}".format(
+                prev_cp["tree_size"]
+            )
+        )
+        prev_rebuilt = reconstruct_root_from_tiles(
+            tree_size=prev_cp["tree_size"],
+            rekor_base=rekor_base,
+            tile_cache=tile_cache,
+            fetch_stats=fetch_stats,
+            verbose=args.verbose_http,
+        )
+        log(
+            "[AUDIT] previous root expected={}, rebuilt={}".format(
+                prev_cp["root_hash"], prev_rebuilt
+            )
+        )
+        if prev_rebuilt != prev_cp["root_hash"]:
+            fail("previous checkpoint root reconstruction mismatch")
+
+        log(
+            "[AUDIT] reconstruct latest root from Rekor tiles: size={}".format(
+                latest_cp["tree_size"]
+            )
+        )
+        latest_rebuilt = reconstruct_root_from_tiles(
+            tree_size=latest_cp["tree_size"],
+            rekor_base=rekor_base,
+            tile_cache=tile_cache,
+            fetch_stats=fetch_stats,
+            verbose=args.verbose_http,
+        )
+        log(
+            "[AUDIT] latest root expected={}, rebuilt={}".format(
+                latest_cp["root_hash"], latest_rebuilt
+            )
+        )
+        if latest_rebuilt != latest_cp["root_hash"]:
+            fail("latest checkpoint root reconstruction mismatch")
+
+        strict_append_only_done = True
+        log("[OK] strict append-only verification passed (previous root -> latest root)")
+        log(
+            "[AUDIT] tile fetch summary: http_fetches={}, cache_hits={}".format(
+                fetch_stats["http_fetches"], fetch_stats["cache_hits"]
+            )
+        )
+
+    save_state(state_file, latest_cp)
+    log("[OK] checkpoint state saved: {}".format(state_file))
+
+    log("\n================ AUDIT RESULT ================")
+    log("[PASS] 1) 参考值与 statement/rekor 中内容一致")
+    log("[PASS] 2) entry 在 Rekor v2 上存在且包含性证明通过")
+    log("[PASS] 3) checkpoint 签名校验通过（proof + latest）")
+    if strict_append_only_done:
+        log("[PASS] 4) append-only 严格校验通过（两次 checkpoint 树根重构一致）")
+    else:
+        log("[PASS] 4) append-only：已建立基线，下一次运行将执行严格校验")
+    log("=============================================")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/slsa/slsa-generator
+++ b/tools/slsa/slsa-generator
@@ -7,7 +7,10 @@ usage() {
   cat <<'EOF'
 用法:
   slsa-generator --artifact-type <type> --artifact <path> --artifact-id <id> \
-    --artifact-version <version> --sign-key <key>
+    --artifact-version <version> --sign-key <key> [--rekor-url <url>] \
+    [--rekor-api-version <1|2>] \
+    [--provenance-store-protocol <oci>] [--provenance-store-uri <uri>] \
+    [--provenance-store-artifact <bundle|provenance>]
 
 参数:
   --artifact-type     制品类型: binary | model-dir | uki
@@ -18,6 +21,12 @@ usage() {
   --artifact-id       制品自定义ID
   --artifact-version  制品版本
   --sign-key          用于签名SLSA provenance的私钥路径(cosign生成)
+  --rekor-url         Rekor 服务地址（默认: https://rekor.sigstore.dev）
+  --rekor-api-version Rekor API 主版本: 1 或 2（默认: 1）
+  --rekor-v2-key-details Rekor v2 verifier keyDetails（默认: PKIX_ECDSA_P256_SHA_256）
+  --provenance-store-protocol provenance存储协议（当前支持: oci）
+  --provenance-store-uri provenance存储地址（如 oci://127.0.0.1:5000/ns/repo:tag）
+  --provenance-store-artifact 存储对象类型: bundle | provenance（默认: bundle）
 EOF
 }
 
@@ -46,11 +55,209 @@ hash_dir_sha256() {
   cryptpilot-verity dump "$dir" --print-root-hash | awk 'NF{print $1; exit}'
 }
 
+sha256_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+infer_registry_scheme() {
+  local registry="$1"
+  if [[ "$registry" == localhost* ]] || [[ "$registry" == 127.0.0.1* ]] || [[ "${TRUSTEE_OCI_INSECURE:-}" == "1" ]] || [[ "${TRUSTEE_OCI_INSECURE:-}" == "true" ]]; then
+    printf 'http'
+  else
+    printf 'https'
+  fi
+}
+
+parse_oci_push_ref() {
+  local uri="$1"
+  local no_scheme="${uri#oci://}"
+  if [[ "$no_scheme" == "$uri" ]]; then
+    echo "不支持的OCI URI: $uri（必须以 oci:// 开头）" >&2
+    return 1
+  fi
+  if [[ "$no_scheme" == *"@"* ]]; then
+    echo "OCI push 不支持 digest 引用，请使用 tag: $uri" >&2
+    return 1
+  fi
+
+  local registry="${no_scheme%%/*}"
+  local repo_ref="${no_scheme#*/}"
+  if [[ -z "$registry" || -z "$repo_ref" || "$repo_ref" == "$no_scheme" ]]; then
+    echo "无效的 OCI URI: $uri" >&2
+    return 1
+  fi
+
+  local last_segment="${repo_ref##*/}"
+  local repository="$repo_ref"
+  local tag="latest"
+  if [[ "$last_segment" == *:* ]]; then
+    tag="${last_segment##*:}"
+    repository="${repo_ref%:*}"
+  fi
+  if [[ -z "$repository" || -z "$tag" ]]; then
+    echo "无效的 OCI push 引用: $uri" >&2
+    return 1
+  fi
+
+  printf '%s\n%s\n%s\n' "$registry" "$repository" "$tag"
+}
+
+upload_blob_oci() {
+  local scheme="$1"
+  local registry="$2"
+  local repository="$3"
+  local file="$4"
+  local digest="$5"
+
+  local headers location upload_url
+  headers=$(curl -sS -D - -o /dev/null -X POST "${scheme}://${registry}/v2/${repository}/blobs/uploads/")
+  location=$(printf '%s' "$headers" | awk '/^[Ll]ocation:/ {print $2}' | tr -d '\r' | tail -n1)
+  if [[ -z "$location" ]]; then
+    echo "上传 OCI blob 失败: 未返回 Location 头" >&2
+    return 1
+  fi
+
+  if [[ "$location" == http* ]]; then
+    upload_url="$location"
+  else
+    upload_url="${scheme}://${registry}${location}"
+  fi
+
+  local sep='?'
+  if [[ "$upload_url" == *\?* ]]; then
+    sep='&'
+  fi
+  curl -sS -X PUT "${upload_url}${sep}digest=sha256:${digest}" \
+    -H 'Content-Type: application/octet-stream' \
+    --data-binary @"$file" >/dev/null
+}
+
+upload_to_oci_storage() {
+  local uri="$1"
+  local artifact_file="$2"
+  local artifact_media_type="$3"
+  local artifact_type="$4"
+
+  mapfile -t ref_parts < <(parse_oci_push_ref "$uri")
+  local registry="${ref_parts[0]}"
+  local repository="${ref_parts[1]}"
+  local tag="${ref_parts[2]}"
+  local scheme
+  scheme=$(infer_registry_scheme "$registry")
+
+  local cfg_file="$out_dir/oci-empty-config.json"
+  printf '{}' > "$cfg_file"
+  local cfg_digest cfg_size art_digest art_size
+  cfg_digest=$(sha256_file "$cfg_file")
+  cfg_size=$(wc -c < "$cfg_file")
+  art_digest=$(sha256_file "$artifact_file")
+  art_size=$(wc -c < "$artifact_file")
+
+  upload_blob_oci "$scheme" "$registry" "$repository" "$cfg_file" "$cfg_digest"
+  upload_blob_oci "$scheme" "$registry" "$repository" "$artifact_file" "$art_digest"
+
+  local manifest_file="$out_dir/provenance-storage-manifest.json"
+  cat > "$manifest_file" <<EOF
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "${artifact_type}",
+  "config": {
+    "mediaType": "application/vnd.oci.empty.v1+json",
+    "digest": "sha256:${cfg_digest}",
+    "size": ${cfg_size}
+  },
+  "layers": [
+    {
+      "mediaType": "${artifact_media_type}",
+      "digest": "sha256:${art_digest}",
+      "size": ${art_size}
+    }
+  ]
+}
+EOF
+
+  curl -sS -X PUT "${scheme}://${registry}/v2/${repository}/manifests/${tag}" \
+    -H 'Content-Type: application/vnd.oci.image.manifest.v1+json' \
+    --data-binary @"$manifest_file" >/dev/null
+}
+
+upload_rekor_v1() {
+  local rekor_url="$1"
+  local envelope="$2"
+  local pubkey="$3"
+  local output_file="$4"
+  rekor-cli upload \
+    --rekor_server "$rekor_url" \
+    --artifact "$envelope" \
+    --public-key "$pubkey" \
+    --type intoto | tee "$output_file"
+}
+
+upload_rekor_v2() {
+  local rekor_url="$1"
+  local envelope="$2"
+  local pubkey="$3"
+  local key_details="$4"
+  local output_file="$5"
+  local req_file="$6"
+
+  local payload payload_type sig pub_der_b64
+  payload=$(jq -r '.payload // empty' "$envelope")
+  payload_type=$(jq -r '.payloadType // empty' "$envelope")
+  sig=$(jq -r '.signatures[0].sig // empty' "$envelope")
+  if [[ -z "$payload" || -z "$payload_type" || -z "$sig" ]]; then
+    echo "DSSE envelope 缺少 payload/payloadType/signatures[0].sig" >&2
+    return 1
+  fi
+
+  pub_der_b64=$(openssl pkey -pubin -in "$pubkey" -outform DER | base64 -w0)
+  jq -n \
+    --arg payload "$payload" \
+    --arg payloadType "$payload_type" \
+    --arg sig "$sig" \
+    --arg keyDetails "$key_details" \
+    --arg rawBytes "$pub_der_b64" \
+    '{
+      dsseRequestV002: {
+        envelope: {
+          payload: $payload,
+          payloadType: $payloadType,
+          signatures: [{ sig: $sig, keyid: "" }]
+        },
+        verifiers: [
+          {
+            publicKey: { rawBytes: $rawBytes },
+            keyDetails: $keyDetails
+          }
+        ]
+      }
+    }' > "$req_file"
+
+  local base="${rekor_url%/}"
+  local code
+  code=$(curl -sS -o "$output_file" -w '%{http_code}' \
+    -X POST "${base}/api/v2/log/entries" \
+    -H 'Content-Type: application/json' \
+    --data-binary @"$req_file")
+  if [[ "$code" -lt 200 || "$code" -ge 300 ]]; then
+    echo "上传 Rekor v2 失败，HTTP $code，响应：" >&2
+    cat "$output_file" >&2 || true
+    return 1
+  fi
+}
+
 artifact_type=""
 artifact_path=""
 artifact_id=""
 artifact_version=""
 sign_key=""
+rekor_url="https://rekor.sigstore.dev"
+rekor_api_version="1"
+rekor_v2_key_details="PKIX_ECDSA_P256_SHA_256"
+provenance_store_protocol=""
+provenance_store_uri=""
+provenance_store_artifact="bundle"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -74,6 +281,30 @@ while [ $# -gt 0 ]; do
       sign_key="${2:-}"
       shift 2
       ;;
+    --rekor-url)
+      rekor_url="${2:-}"
+      shift 2
+      ;;
+    --rekor-api-version)
+      rekor_api_version="${2:-}"
+      shift 2
+      ;;
+    --rekor-v2-key-details)
+      rekor_v2_key_details="${2:-}"
+      shift 2
+      ;;
+    --provenance-store-protocol)
+      provenance_store_protocol="${2:-}"
+      shift 2
+      ;;
+    --provenance-store-uri)
+      provenance_store_uri="${2:-}"
+      shift 2
+      ;;
+    --provenance-store-artifact)
+      provenance_store_artifact="${2:-}"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -88,6 +319,29 @@ done
 
 if [ -z "$artifact_type" ] || [ -z "$artifact_path" ] || [ -z "$artifact_id" ] || [ -z "$artifact_version" ] || [ -z "$sign_key" ]; then
   usage >&2
+  exit 1
+fi
+
+require_cmd sha256sum
+require_cmd cosign
+require_cmd jq
+require_cmd curl
+require_cmd openssl
+
+if [ "$artifact_type" = "model-dir" ]; then
+  require_cmd cryptpilot-verity
+fi
+
+case "$rekor_api_version" in
+  1|2) ;;
+  *)
+    echo "不支持的 --rekor-api-version: $rekor_api_version（仅支持 1 或 2）" >&2
+    exit 1
+    ;;
+esac
+
+if [ -n "$provenance_store_protocol" ] && [ -z "$provenance_store_uri" ]; then
+  echo "指定 --provenance-store-protocol 时必须提供 --provenance-store-uri" >&2
   exit 1
 fi
 
@@ -153,10 +407,17 @@ mkdir -p "$out_dir"
 statement_file="$out_dir/statement.json"
 envelope_file="$out_dir/statement.dsse.json"
 attestation_file="$out_dir/statement.attestation.json"
+
 if [ "$artifact_type" = "uki" ]; then
   attest_blob_path="$out_dir/uki-artifact.json"
   cp -- "$artifact_path" "$attest_blob_path"
 fi
+
+bundle_jsonl_file="$out_dir/statement.intoto.jsonl"
+rekor_v1_output_file="$out_dir/rekor-v1-upload.txt"
+rekor_v2_output_file="$out_dir/rekor-v2-entry.json"
+rekor_v2_req_file="$out_dir/rekor-v2-request.json"
+trustee_bundle_file="$out_dir/provenance.trustee-bundle.json"
 
 cat >"$statement_file" <<EOF
 {
@@ -192,6 +453,7 @@ cat >"$statement_file" <<EOF
 EOF
 
 cosign attest-blob \
+  --new-bundle-format=false \
   --key "$sign_key" \
   --yes \
   --use-signing-config=false \
@@ -199,6 +461,8 @@ cosign attest-blob \
   --output-attestation "$attestation_file" \
   --output-signature "$envelope_file" \
   "$attest_blob_path"
+
+jq -c . "$envelope_file" > "$bundle_jsonl_file"
 
 pub_key=""
 if [ -f "${sign_key}.pub" ]; then
@@ -210,11 +474,50 @@ else
   exit 1
 fi
 
-rekor-cli upload \
-  --rekor_server https://rekor.sigstore.dev \
-  --artifact "$envelope_file" \
-  --public-key "$pub_key" \
-  --type intoto
+if [ "$rekor_api_version" = "1" ]; then
+  require_cmd rekor-cli
+  upload_rekor_v1 "$rekor_url" "$envelope_file" "$pub_key" "$rekor_v1_output_file"
+else
+  upload_rekor_v2 "$rekor_url" "$envelope_file" "$pub_key" "$rekor_v2_key_details" "$rekor_v2_output_file" "$rekor_v2_req_file"
+fi
+
+if [ "$provenance_store_artifact" = "bundle" ]; then
+  if [ -f "$rekor_v2_output_file" ]; then
+    jq -n \
+      --argfile sourceBundle "$bundle_jsonl_file" \
+      --argfile dsse "$envelope_file" \
+      --argfile rekor "$rekor_v2_output_file" \
+      '{sourceBundle: $sourceBundle, dsseEnvelope: $dsse, rekorEntryV2: $rekor}' > "$trustee_bundle_file"
+  else
+    jq -n \
+      --argfile sourceBundle "$bundle_jsonl_file" \
+      --argfile dsse "$envelope_file" \
+      '{sourceBundle: $sourceBundle, dsseEnvelope: $dsse}' > "$trustee_bundle_file"
+  fi
+fi
+
+if [ -n "$provenance_store_protocol" ]; then
+  case "$provenance_store_protocol" in
+    oci)
+      case "$provenance_store_artifact" in
+        bundle)
+          upload_to_oci_storage "$provenance_store_uri" "$trustee_bundle_file" "application/vnd.in-toto.bundle+json" "application/vnd.in-toto.bundle"
+          ;;
+        provenance)
+          upload_to_oci_storage "$provenance_store_uri" "$statement_file" "application/vnd.in-toto.provenance+json" "application/vnd.in-toto.provenance"
+          ;;
+        *)
+          echo "不支持的 --provenance-store-artifact: $provenance_store_artifact（仅支持 bundle|provenance）" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "不支持的 --provenance-store-protocol: $provenance_store_protocol（当前仅支持 oci）" >&2
+      exit 1
+      ;;
+  esac
+fi
 
 echo "完成: SLSA provenance生成并上传Rekor"
 echo "输出目录: $out_dir"

--- a/trustee-gateway/trustee_gateway_api.md
+++ b/trustee-gateway/trustee_gateway_api.md
@@ -1271,8 +1271,8 @@ EOF
 *   **端点:** `POST /api/rvps/set_reference_value_list`
     
 *   **说明:** 通过 gRPC 向后端 RVPS 服务批量设置参考值。RVPS 会遍历 `rv_list` 中的每一项：
-    1. 计算 `SHA256($artifact-id || $artifact-version)` 作为 Rekor 索引。
-    2. 使用 `provenance_info.rekor_url` 查询 Rekor，读取条目并校验签名。
+    1. 若未提供 `provenance_source`，计算 `SHA256($artifact-id || $artifact-version)` 作为索引并走 Rekor v1 兼容查询路径。
+    2. 若提供 `provenance_source`，按 `provenance_source.protocol` 拉取 provenance/bundle 元数据（当前支持 OCI）。
     3. 解析 SLSA in-toto statement，提取制品哈希摘要值。
     4. 确定参考值名称：若该项提供可选字段 `rv_name`，则使用该字符串（去首尾空白后非空）；否则默认 `measurement.$type.$artifact-id`。
     5. 若该名称已存在且新旧参考值不同，根据 `operation_type` 进行追加或覆盖。
@@ -1289,9 +1289,15 @@ cat << EOF > rvps-set-list.json
       "type": "model",
       "provenance_info": {
         "type": "slsa-intoto-statements",
-        "rekor_url": "https://rekor.sigstore.dev"
+        "rekor_url": "https://log2025-1.rekor.sigstore.dev",
+        "rekor_api_version": 2
       },
-      "operation_type": "add"
+      "provenance_source": {
+        "protocol": "oci",
+        "uri": "oci://127.0.0.1:5000/trustee/provenance:v1",
+        "artifact": "bundle"
+      },
+      "operation_type": "refresh"
     }
   ]
 }
@@ -1319,10 +1325,16 @@ curl -k -X POST http://<gateway-host>:<port>/api/rvps/set_reference_value_list \
       "type": "model",
       "provenance_info": {
         "type": "slsa-intoto-statements",
-        "rekor_url": "https://rekor.sigstore.dev"
+        "rekor_url": "https://log2025-1.rekor.sigstore.dev",
+        "rekor_api_version": 2
       },
-      "operation_type": "add",
-      "rv_name": "optional.custom.reference.name"
+      "rv_name": "optional.custom.reference.name",
+      "provenance_source": {
+        "protocol": "oci",
+        "uri": "oci://127.0.0.1:5000/trustee/provenance:v1",
+        "artifact": "bundle"
+      },
+      "operation_type": "add"
     }
   ]
 }
@@ -1337,6 +1349,10 @@ curl -k -X POST http://<gateway-host>:<port>/api/rvps/set_reference_value_list \
     *   `rv_name`（可选）: 显式指定写入 RVPS 的参考值名称；不得为空或仅空白。省略时行为与原先一致，使用 `measurement.$type.$artifact-id`。
     *   `provenance_info.type`: 目前仅支持 `slsa-intoto-statements`。
     *   `provenance_info.rekor_url`: Rekor 透明日志地址。
+    *   `provenance_info.rekor_api_version`: Rekor API 大版本（`1`/`2`，可选）。
+    *   `provenance_source.protocol`: provenance/bundle 获取协议，当前支持 `oci`。
+    *   `provenance_source.uri`: provenance/bundle 地址，如 `oci://<registry>/<repo>:<tag>`。
+    *   `provenance_source.artifact`: 拉取对象类型，建议 `bundle`（可选 `provenance`）。
     *   `operation_type`: `add` 或 `refresh`。当名称已存在且新旧参考值不同：
         *   `add`: 将新参考值追加到该名称的参考值数组中。
         *   `refresh`: 清空旧参考值，仅保留最新参考值。


### PR DESCRIPTION


Add end-to-end Rekor v2 support across generator, RVPS, client, and release workflow. Standardize provenance metadata to sourceBundle + dsseEnvelope (+ rekorEntryV2).

Add OCI provenance fetch/parse in RVPS and enforce DSSE-Rekor digest consistency checks. Introduce a v2 audit script with checkpoint signature, inclusion proof, and append-only verification. Update challenge-client args plus API/docs to align with provenance_source fields and release-asset flow.