### PR TITLE
Support private cloud Aliyun KMS endpoints for KBS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,6 +3347,7 @@ dependencies = [
  "thiserror 2.0.12",
  "time",
  "tokio",
+ "toml 0.8.23",
  "tonic",
  "tonic-build",
  "uuid",

--- a/deps/kms/src/plugins/aliyun/client/client_key_client/mod.rs
+++ b/deps/kms/src/plugins/aliyun/client/client_key_client/mod.rs
@@ -10,7 +10,7 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 use chrono::Utc;
 use log::{error, info};
 use prost::Message;
-use reqwest::{header::HeaderMap, Certificate, ClientBuilder};
+use reqwest::{header::HeaderMap, Certificate, Client, ClientBuilder};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -53,11 +53,51 @@ impl ClientKeyClient {
         Ok(kms_instance_ca_cert)
     }
 
+    fn build_http_client(cert_pem: Option<&str>, insecure_skip_tls_verify: bool) -> Result<Client> {
+        let mut builder = ClientBuilder::new().use_rustls_tls();
+
+        if let Some(cert_pem) = cert_pem.filter(|v| !v.is_empty()) {
+            let cert = Self::read_kms_instance_cert(cert_pem.as_bytes())?;
+            builder = builder.add_root_certificate(cert);
+        } else if !insecure_skip_tls_verify {
+            return Err(Error::AliyunKmsError(
+                "kms instance ca cert is required unless insecure_skip_tls_verify is enabled"
+                    .to_string(),
+            ));
+        }
+
+        if insecure_skip_tls_verify {
+            builder = builder.danger_accept_invalid_certs(true);
+        }
+
+        builder
+            .build()
+            .map_err(|e| Error::AliyunKmsError(format!("build http client failed: {e:?}")))
+    }
+
     pub fn new(
         client_key: &str,
         kms_instance_id: &str,
         password: &str,
         cert_pem: &str,
+    ) -> Result<Self> {
+        Self::new_with_options(
+            client_key,
+            kms_instance_id,
+            password,
+            Some(cert_pem),
+            None,
+            false,
+        )
+    }
+
+    pub fn new_with_options(
+        client_key: &str,
+        kms_instance_id: &str,
+        password: &str,
+        cert_pem: Option<&str>,
+        endpoint: Option<&str>,
+        insecure_skip_tls_verify: bool,
     ) -> Result<Self> {
         let credential = CredentialClientKey::new(client_key, password).map_err(|e| {
             Error::AliyunKmsError(format!(
@@ -65,15 +105,13 @@ impl ClientKeyClient {
             ))
         })?;
 
-        let endpoint = format!("{kms_instance_id}.cryptoservice.kms.aliyuncs.com");
+        let endpoint = endpoint
+            .filter(|v| !v.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("{kms_instance_id}.cryptoservice.kms.aliyuncs.com"));
         let config = ConfigClientKey::new(kms_instance_id, &endpoint);
 
-        let cert = Self::read_kms_instance_cert(cert_pem.as_bytes())?;
-        let http_client = ClientBuilder::new()
-            .use_rustls_tls()
-            .add_root_certificate(cert)
-            .build()
-            .map_err(|e| Error::AliyunKmsError(format!("build http client failed: {e:?}")))?;
+        let http_client = Self::build_http_client(cert_pem, insecure_skip_tls_verify)?;
 
         Ok(Self {
             credential,

--- a/deps/kms/src/plugins/aliyun/client/mod.rs
+++ b/deps/kms/src/plugins/aliyun/client/mod.rs
@@ -63,6 +63,26 @@ impl AliyunKmsClient {
         Ok(Self::ClientKey { inner })
     }
 
+    pub fn new_client_key_client_with_options(
+        client_key: &str,
+        kms_instance_id: &str,
+        password: &str,
+        cert_pem: Option<&str>,
+        endpoint: Option<&str>,
+        insecure_skip_tls_verify: bool,
+    ) -> Result<Self> {
+        let inner = ClientKeyClient::new_with_options(
+            client_key,
+            kms_instance_id,
+            password,
+            cert_pem,
+            endpoint,
+            insecure_skip_tls_verify,
+        )?;
+
+        Ok(Self::ClientKey { inner })
+    }
+
     pub fn new_ecs_ram_role_client(ecs_ram_role_name: &str, region_id: &str) -> Self {
         let ecs_ram_role_client =
             EcsRamRoleClient::new(ecs_ram_role_name.to_string(), region_id.to_string());
@@ -77,12 +97,35 @@ impl AliyunKmsClient {
         access_key_secret: &str,
         region_id: &str,
     ) -> Result<Self> {
-        let endpoint = format!("kms.{region_id}.aliyuncs.com");
-        let client = StsTokenClient::from_access_key(
+        Self::new_access_key_client_with_options(
+            access_key_id,
+            access_key_secret,
+            region_id,
+            None,
+            None,
+            false,
+        )
+    }
+
+    pub fn new_access_key_client_with_options(
+        access_key_id: &str,
+        access_key_secret: &str,
+        region_id: &str,
+        endpoint: Option<&str>,
+        ca_cert_pem: Option<&str>,
+        insecure_skip_tls_verify: bool,
+    ) -> Result<Self> {
+        let endpoint = endpoint
+            .filter(|v| !v.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("kms.{region_id}.aliyuncs.com"));
+        let client = StsTokenClient::from_access_key_with_options(
             access_key_id.to_string(),
             access_key_secret.to_string(),
             endpoint,
             region_id.to_string(),
+            ca_cert_pem,
+            insecure_skip_tls_verify,
         )?;
         Ok(Self::AccessKey { client })
     }

--- a/deps/kms/src/plugins/aliyun/client/sts_token_client/mod.rs
+++ b/deps/kms/src/plugins/aliyun/client/sts_token_client/mod.rs
@@ -15,7 +15,7 @@ use chrono::Utc;
 use credential::StsCredential;
 use log::error;
 use rand::{distributions::Alphanumeric, Rng};
-use reqwest::{header::HeaderMap, ClientBuilder};
+use reqwest::{header::HeaderMap, Certificate, Client, ClientBuilder};
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::fs;
@@ -43,11 +43,29 @@ pub struct StsSettings {
 }
 
 impl StsTokenClient {
-    pub fn from_sts_token(sts: StsCredential, endpoint: String, region_id: String) -> Result<Self> {
-        let http_client = ClientBuilder::new()
-            .use_rustls_tls()
+    fn build_http_client(
+        ca_cert_pem: Option<&str>,
+        insecure_skip_tls_verify: bool,
+    ) -> Result<Client> {
+        let mut builder = ClientBuilder::new().use_rustls_tls();
+
+        if let Some(ca_cert_pem) = ca_cert_pem.filter(|v| !v.is_empty()) {
+            let ca_cert = Certificate::from_pem(ca_cert_pem.as_bytes())
+                .map_err(|e| Error::AliyunKmsError(format!("read kms ca cert failed: {e:?}")))?;
+            builder = builder.add_root_certificate(ca_cert);
+        }
+
+        if insecure_skip_tls_verify {
+            builder = builder.danger_accept_invalid_certs(true);
+        }
+
+        builder
             .build()
-            .map_err(|e| Error::AliyunKmsError(format!("build http client failed: {e:?}")))?;
+            .map_err(|e| Error::AliyunKmsError(format!("build http client failed: {e:?}")))
+    }
+
+    pub fn from_sts_token(sts: StsCredential, endpoint: String, region_id: String) -> Result<Self> {
+        let http_client = Self::build_http_client(None, false)?;
         Ok(Self {
             ak: sts.ak,
             sk: sts.sk,
@@ -64,10 +82,25 @@ impl StsTokenClient {
         endpoint: String,
         region_id: String,
     ) -> Result<Self> {
-        let http_client = ClientBuilder::new()
-            .use_rustls_tls()
-            .build()
-            .map_err(|e| Error::AliyunKmsError(format!("build http client failed: {e:?}")))?;
+        Self::from_access_key_with_options(
+            access_key_id,
+            access_key_secret,
+            endpoint,
+            region_id,
+            None,
+            false,
+        )
+    }
+
+    pub fn from_access_key_with_options(
+        access_key_id: String,
+        access_key_secret: String,
+        endpoint: String,
+        region_id: String,
+        ca_cert_pem: Option<&str>,
+        insecure_skip_tls_verify: bool,
+    ) -> Result<Self> {
+        let http_client = Self::build_http_client(ca_cert_pem, insecure_skip_tls_verify)?;
         Ok(Self {
             ak: access_key_id,
             sk: access_key_secret,

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,1 +1,49 @@
 # Trustee Helm Chart
+
+## Aliyun KMS Resource Backend
+
+KBS can use Aliyun KMS generic secrets as the resource backend when the KBS image
+is built with the `aliyun` feature.
+
+Set `kbs.aliyunKms.enabled=true` and choose one authentication mode:
+
+- AAP client key: set `clientKey`, `kmsInstanceId`, `password`, and `certPem`.
+- AccessKey: set `regionId` and inject `ALIYUN_KMS_ACCESS_KEY_ID` and
+  `ALIYUN_KMS_ACCESS_KEY_SECRET` through the pod environment. The recommended
+  Helm path is to set `accessKeyExistingSecret` so the credentials come from an
+  existing Kubernetes Secret.
+
+For private cloud deployments, also set `endpoint` to the KMS intranet endpoint
+provided by the private cloud KMS owner. If the endpoint uses a private CA, set
+`certPem` to the CA certificate. `insecureSkipTlsVerify=true` is only intended
+for temporary test environments where the certificate chain cannot yet be
+trusted.
+
+Example:
+
+```yaml
+kbs:
+  aliyunKms:
+    enabled: true
+    regionId: "cn-test"
+    endpoint: "kms-intranet.cn-test.example.com"
+    certPem: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    accessKeyExistingSecret: "aliyun-kms-credential"
+    accessKeyIdSecretKey: "access_key_id"
+    accessKeySecretSecretKey: "access_key_secret"
+    insecureSkipTlsVerify: false
+```
+
+Create the referenced secret before installing or upgrading the chart:
+
+```shell
+kubectl create secret generic aliyun-kms-credential \
+  --from-literal=access_key_id='LTAI...' \
+  --from-literal=access_key_secret='secret...'
+```
+
+The old `kmsIntanceId` value key is still accepted for compatibility, but new
+deployments should use `kmsInstanceId`.

--- a/helm-chart/trustee/templates/kbs-configmap.yaml
+++ b/helm-chart/trustee/templates/kbs-configmap.yaml
@@ -22,9 +22,11 @@ data:
     {{- if .Values.kbs.aliyunKms.enabled }}
     type = "Aliyun"
     client_key = {{ .Values.kbs.aliyunKms.clientKey | quote }}
-    kms_instance_id = "{{ .Values.kbs.aliyunKms.kmsIntanceId }}"
+    kms_instance_id = "{{ default .Values.kbs.aliyunKms.kmsIntanceId .Values.kbs.aliyunKms.kmsInstanceId }}"
     password = "{{ .Values.kbs.aliyunKms.password }}"
     cert_pem = {{ .Values.kbs.aliyunKms.certPem | quote}}
+    endpoint = {{ .Values.kbs.aliyunKms.endpoint | quote }}
+    insecure_skip_tls_verify = {{ .Values.kbs.aliyunKms.insecureSkipTlsVerify }}
     {{- else }}
     type = "LocalFs"
     dir_path = "/opt/confidential-containers/kbs/repository"

--- a/helm-chart/trustee/templates/kbs-statefulset.yaml
+++ b/helm-chart/trustee/templates/kbs-statefulset.yaml
@@ -43,6 +43,33 @@ spec:
           env:
             - name: RUST_LOG
               value: {{ .Values.log_level }}
+            {{- if .Values.kbs.aliyunKms.enabled }}
+            {{- if .Values.kbs.aliyunKms.regionId }}
+            - name: ALIYUN_KMS_REGION_ID
+              value: {{ .Values.kbs.aliyunKms.regionId | quote }}
+            {{- end }}
+            {{- if .Values.kbs.aliyunKms.accessKeyExistingSecret }}
+            - name: ALIYUN_KMS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.kbs.aliyunKms.accessKeyExistingSecret | quote }}
+                  key: {{ .Values.kbs.aliyunKms.accessKeyIdSecretKey | quote }}
+            - name: ALIYUN_KMS_ACCESS_KEY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.kbs.aliyunKms.accessKeyExistingSecret | quote }}
+                  key: {{ .Values.kbs.aliyunKms.accessKeySecretSecretKey | quote }}
+            {{- else }}
+            {{- if .Values.kbs.aliyunKms.accessKeyId }}
+            - name: ALIYUN_KMS_ACCESS_KEY_ID
+              value: {{ .Values.kbs.aliyunKms.accessKeyId | quote }}
+            {{- end }}
+            {{- if .Values.kbs.aliyunKms.accessKeySecret }}
+            - name: ALIYUN_KMS_ACCESS_KEY_SECRET
+              value: {{ .Values.kbs.aliyunKms.accessKeySecret | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.kbs.service.port }}

--- a/helm-chart/trustee/values.yaml
+++ b/helm-chart/trustee/values.yaml
@@ -70,10 +70,25 @@ kbs:
 
   aliyunKms:
     enabled: false
+    # kmsIntanceId is kept for backward compatibility with older chart values.
     kmsIntanceId:
+    kmsInstanceId:
     password: 
     clientKey:
     certPem:
+    # Recommended AccessKey configuration path: inject credentials through
+    # ALIYUN_KMS_* environment variables. Prefer accessKeyExistingSecret for
+    # production deployments.
+    accessKeyId:
+    accessKeySecret:
+    accessKeyExistingSecret:
+    accessKeyIdSecretKey: access_key_id
+    accessKeySecretSecretKey: access_key_secret
+    regionId:
+    # Private cloud KMS intranet endpoint, for example kms-intranet.<region>.<domain>.
+    endpoint:
+    # Use only for test environments where the private cloud KMS certificate cannot be trusted.
+    insecureSkipTlsVerify: false
 
 as:
   pccsURL: ''

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -99,6 +99,7 @@ tempfile.workspace = true
 rstest.workspace = true
 reference-value-provider-service.path = "../rvps"
 serial_test = "3.0"
+toml.workspace = true
 
 [build-dependencies]
 tonic-build = { workspace = true, optional = true }

--- a/kbs/README.md
+++ b/kbs/README.md
@@ -107,7 +107,7 @@ If you want a self-signed cert for test cases, please refer to [the document](do
 
 The KBS can use different backend storage. `LocalFs` will always be builtin.
 `ALIYUN` determines whether aliyun kms support will be built. The options
-are `true` or `false` (by defult). Please refer to [the document](docs/config.md#repository-configuration)
+are `true` or `false` (by default). Please refer to [the document](docs/config.md#resource-configuration)
 for more details.
 
 ## References

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -220,21 +220,66 @@ This is also called "Repository" in old versions. The properties to be configure
 
 **`Aliyun` Properties**
 
-| Property          | Type   | Description                       | Required | Example                                             |
-|-------------------|--------|-----------------------------------|----------|-----------------------------------------------------|
-| `client_key`      | String | The KMS instance's AAP client key | No       | `{"KeyId": "KA..", "PrivateKeyData": "MIIJqwI..."}` |
-| `kms_instance_id` | String | The KMS instance id               | No       | `kst-shh668f7...`                                   |
-| `password`        | String | AAP client key password           | No       | `8f9989c18d27...`                                   |
-| `cert_pem`        | String | CA cert for the KMS instance      | No       | `-----BEGIN CERTIFICATE----- ...`                   |
+The Aliyun backend reads KBS resources from Aliyun KMS generic secrets. It
+supports AAP client key authentication and AccessKey authentication.
+
+| Property                   | Type    | Description                                                                                                                                      | Required | Example                                             |
+|----------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------|
+| `client_key`               | String  | The KMS instance's AAP client key                                                                                                                | No       | `{"KeyId": "KA..", "PrivateKeyData": "MIIJqwI..."}` |
+| `kms_instance_id`          | String  | The KMS instance id                                                                                                                              | No       | `kst-shh668f7...`                                   |
+| `password`                 | String  | AAP client key password                                                                                                                          | No       | `8f9989c18d27...`                                   |
+| `access_key_id`            | String  | AccessKey ID. The recommended approach is to omit this field and set `ALIYUN_KMS_ACCESS_KEY_ID` in the environment.                              | No       | `LTAI...`                                           |
+| `access_key_secret`        | String  | AccessKey Secret. The recommended approach is to omit this field and set `ALIYUN_KMS_ACCESS_KEY_SECRET` in the environment.                      | No       | `secret...`                                         |
+| `region_id`                | String  | Region ID used by AccessKey authentication. The recommended approach is to omit this field and set `ALIYUN_KMS_REGION_ID` in the environment.    | No       | `cn-hangzhou`                                       |
+| `endpoint`                 | String  | Optional KMS endpoint. If omitted, KBS uses the public cloud defaults: `{kms_instance_id}.cryptoservice.kms.aliyuncs.com` for AAP or `kms.{region_id}.aliyuncs.com` for AccessKey. Private cloud deployments should set the intranet endpoint provided by the KMS owner. | No       | `kms-intranet.cn-test.example.com`                  |
+| `cert_pem`                 | String  | CA cert used to verify the KMS HTTPS endpoint. For AAP authentication this is the KMS instance CA cert. For private cloud AccessKey authentication, set this when the endpoint uses a private CA. | No       | `-----BEGIN CERTIFICATE----- ...`                   |
+| `insecure_skip_tls_verify` | Boolean | Skip HTTPS certificate verification. This should only be used for development or temporary private cloud tests.                                 | No       | `false`                                             |
 
 If the AAP client key fields above are not fully provided, KBS will fall back to
-AccessKey authentication by reading the following environment variables:
+AccessKey authentication. For AccessKey authentication, the recommended approach
+is to provide credentials through the following environment variables so secrets
+do not need to be stored in the KBS config file:
 
 | Environment Variable            | Description                          |
 |---------------------------------|--------------------------------------|
 | `ALIYUN_KMS_ACCESS_KEY_ID`      | AccessKey ID                         |
 | `ALIYUN_KMS_ACCESS_KEY_SECRET`  | AccessKey Secret                     |
 | `ALIYUN_KMS_REGION_ID`          | Region ID (e.g. `cn-hangzhou`)       |
+
+Private cloud AccessKey example:
+
+```toml
+[[plugins]]
+name = "resource"
+type = "Aliyun"
+endpoint = "kms-intranet.cn-test.example.com"
+cert_pem = """-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----"""
+```
+
+Set the credentials and region in the KBS process environment:
+
+```shell
+export ALIYUN_KMS_ACCESS_KEY_ID="LTAI..."
+export ALIYUN_KMS_ACCESS_KEY_SECRET="secret..."
+export ALIYUN_KMS_REGION_ID="cn-test"
+```
+
+Private cloud AAP client key example:
+
+```toml
+[[plugins]]
+name = "resource"
+type = "Aliyun"
+client_key = """{"KeyId":"KA...","PrivateKeyData":"..."}"""
+kms_instance_id = "kst-..."
+password = "..."
+endpoint = "kst-....cryptoservice.kms-private.example.com"
+cert_pem = """-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----"""
+```
 
 **`ExternalKms` Properties**
 

--- a/kbs/docs/resource_storage_backend.md
+++ b/kbs/docs/resource_storage_backend.md
@@ -68,9 +68,30 @@ private_key_path = "/etc/kbs/resource-private.pem"
 [Alibaba Cloud KMS](https://www.alibabacloud.com/en/product/kms?_p_lc=1)(a.k.a Aliyun KMS)
 can also work as the KBS resource storage backend.
 In this mode, resources will be stored with [generic secrets](https://www.alibabacloud.com/help/en/kms/user-guide/manage-and-use-generic-secrets?spm=a2c63.p38356.0.0.dc4d24f7s0ZuW7) in a [KMS instance](https://www.alibabacloud.com/help/en/kms/user-guide/kms-overview?spm=a2c63.p38356.0.0.4aacf9e6V7IQGW).
-One KBS can be configured with a specified KMS instance in `repository_config` field of KBS launch config. For config, see the [document](./config.md#repository-configuration).
-These materials can be found in KMS instance's [AAP](https://www.alibabacloud.com/help/en/kms/user-guide/manage-aaps?spm=a3c0i.23458820.2359477120.1.4fd96e9bmEFST4).
-When being accessed, a resource URI of `kbs:///repo/type/tag` will be translated into the generic secret with name `tag`. Hinting that `repo/type` field will be ignored.
+One KBS can be configured with a specified KMS instance by setting a
+`[[plugins]]` section whose `name` is `resource` and whose `type` is `Aliyun`.
+For config, see the [document](./config.md#resource-configuration).
+
+The Aliyun backend supports two authentication modes:
+- AAP client key authentication with `client_key`, `kms_instance_id`,
+  `password`, and `cert_pem`. These materials can be found in the KMS
+  instance's [AAP](https://www.alibabacloud.com/help/en/kms/user-guide/manage-aaps?spm=a3c0i.23458820.2359477120.1.4fd96e9bmEFST4).
+- AccessKey authentication. The recommended approach is to set
+  `ALIYUN_KMS_ACCESS_KEY_ID`, `ALIYUN_KMS_ACCESS_KEY_SECRET`, and
+  `ALIYUN_KMS_REGION_ID` in the KBS process environment. The config file fields
+  `access_key_id`, `access_key_secret`, and `region_id` are also supported for
+  compatibility and local experiments.
+
+Public cloud deployments can omit `endpoint` and use the built-in Aliyun public
+cloud endpoint conventions. Private cloud deployments should set `endpoint` to
+the KMS intranet endpoint provided by the private cloud KMS owner. If the private
+cloud endpoint uses a private CA, set `cert_pem` to the CA certificate. The
+`insecure_skip_tls_verify` option is available for temporary test environments
+where the private cloud certificate cannot yet be trusted.
+
+When being accessed, a resource URI of `kbs:///repo/type/tag` will be translated
+into the generic secret with name `tag`. This means that the `repo/type` fields
+will be ignored by the Aliyun backend.
 
 ### External KMS (Dynamic Provider)
 

--- a/kbs/src/plugins/implementations/resource/aliyun_kms.rs
+++ b/kbs/src/plugins/implementations/resource/aliyun_kms.rs
@@ -19,6 +19,14 @@ pub struct AliyunKmsBackendConfig {
     #[derivative(Debug = "ignore")]
     password: Option<String>,
     cert_pem: Option<String>,
+    #[derivative(Debug = "ignore")]
+    access_key_id: Option<String>,
+    #[derivative(Debug = "ignore")]
+    access_key_secret: Option<String>,
+    region_id: Option<String>,
+    endpoint: Option<String>,
+    #[serde(default)]
+    insecure_skip_tls_verify: bool,
 }
 
 pub struct AliyunKmsBackend {
@@ -80,34 +88,133 @@ impl AliyunKmsBackend {
             .as_ref()
             .map(|v| !v.is_empty())
             .unwrap_or(false);
+        let has_endpoint = repo_desc
+            .endpoint
+            .as_ref()
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let has_access_key_id = repo_desc
+            .access_key_id
+            .as_ref()
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let has_access_key_secret = repo_desc
+            .access_key_secret
+            .as_ref()
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let has_region_id = repo_desc
+            .region_id
+            .as_ref()
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
 
-        let client = if has_client_key && has_instance_id && has_password && has_cert {
-            AliyunKmsClient::new(
+        let client = if has_client_key
+            && has_instance_id
+            && has_password
+            && (has_cert || repo_desc.insecure_skip_tls_verify)
+        {
+            AliyunKmsClient::new_client_key_client_with_options(
                 repo_desc.client_key.as_ref().expect("checked"),
                 repo_desc.kms_instance_id.as_ref().expect("checked"),
                 repo_desc.password.as_ref().expect("checked"),
-                repo_desc.cert_pem.as_ref().expect("checked"),
+                repo_desc.cert_pem.as_deref(),
+                has_endpoint.then(|| repo_desc.endpoint.as_ref().expect("checked").as_str()),
+                repo_desc.insecure_skip_tls_verify,
             )
             .context("create aliyun KMS backend with AAP client key")?
         } else {
-            let access_key_id = env::var("ALIYUN_KMS_ACCESS_KEY_ID").map_err(|_| {
-                anyhow!(
-                    "missing ALIYUN_KMS_ACCESS_KEY_ID env var and AAP client key config is incomplete"
-                )
-            })?;
-            let access_key_secret = env::var("ALIYUN_KMS_ACCESS_KEY_SECRET").map_err(|_| {
-                anyhow!(
-                    "missing ALIYUN_KMS_ACCESS_KEY_SECRET env var and AAP client key config is incomplete"
-                )
-            })?;
-            let region_id = env::var("ALIYUN_KMS_REGION_ID").map_err(|_| {
-                anyhow!(
-                    "missing ALIYUN_KMS_REGION_ID env var and AAP client key config is incomplete"
-                )
-            })?;
-            AliyunKmsClient::new_access_key_client(&access_key_id, &access_key_secret, &region_id)
-                .context("create aliyun KMS backend with AccessKey")?
+            if has_access_key_id != has_access_key_secret {
+                return Err(anyhow!(
+                    "access_key_id and access_key_secret must be configured together"
+                ));
+            }
+
+            let access_key_id = if has_access_key_id {
+                repo_desc.access_key_id.as_ref().expect("checked").clone()
+            } else {
+                env::var("ALIYUN_KMS_ACCESS_KEY_ID").map_err(|_| {
+                    anyhow!(
+                        "missing ALIYUN_KMS_ACCESS_KEY_ID env var and AAP client key config is incomplete"
+                    )
+                })?
+            };
+            let access_key_secret = if has_access_key_secret {
+                repo_desc
+                    .access_key_secret
+                    .as_ref()
+                    .expect("checked")
+                    .clone()
+            } else {
+                env::var("ALIYUN_KMS_ACCESS_KEY_SECRET").map_err(|_| {
+                    anyhow!(
+                        "missing ALIYUN_KMS_ACCESS_KEY_SECRET env var and AAP client key config is incomplete"
+                    )
+                })?
+            };
+            let region_id = if has_region_id {
+                repo_desc.region_id.as_ref().expect("checked").clone()
+            } else {
+                env::var("ALIYUN_KMS_REGION_ID").map_err(|_| {
+                    anyhow!(
+                        "missing ALIYUN_KMS_REGION_ID env var and AAP client key config is incomplete"
+                    )
+                })?
+            };
+
+            AliyunKmsClient::new_access_key_client_with_options(
+                &access_key_id,
+                &access_key_secret,
+                &region_id,
+                has_endpoint.then(|| repo_desc.endpoint.as_ref().expect("checked").as_str()),
+                repo_desc.cert_pem.as_deref(),
+                repo_desc.insecure_skip_tls_verify,
+            )
+            .context("create aliyun KMS backend with AccessKey")?
         };
         Ok(Self { client })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AliyunKmsBackendConfig;
+
+    #[test]
+    fn parse_access_key_private_cloud_config() {
+        let config: AliyunKmsBackendConfig = toml::from_str(
+            r#"
+            access_key_id = "ak"
+            access_key_secret = "sk"
+            region_id = "cn-test"
+            endpoint = "kms-intranet.cn-test.example.com"
+            cert_pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
+            insecure_skip_tls_verify = false
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.access_key_id.as_deref(), Some("ak"));
+        assert_eq!(config.access_key_secret.as_deref(), Some("sk"));
+        assert_eq!(config.region_id.as_deref(), Some("cn-test"));
+        assert_eq!(
+            config.endpoint.as_deref(),
+            Some("kms-intranet.cn-test.example.com")
+        );
+        assert!(!config.insecure_skip_tls_verify);
+    }
+
+    #[test]
+    fn default_tls_verify_is_enabled() {
+        let config: AliyunKmsBackendConfig = toml::from_str(
+            r#"
+            access_key_id = "ak"
+            access_key_secret = "sk"
+            region_id = "cn-test"
+            "#,
+        )
+        .unwrap();
+
+        assert!(!config.insecure_skip_tls_verify);
     }
 }


### PR DESCRIPTION
Allow the KBS Aliyun resource backend to use private cloud KMS endpoints with configurable TLS trust, while keeping the existing public cloud defaults. Recommend AccessKey credentials through environment variables and document the private cloud deployment and test flow.