### PR TITLE
kbs: support key rotation for EncryptedLocalFs backend

### DIFF
--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -210,13 +210,44 @@ This is also called "Repository" in old versions. The properties to be configure
 
 | Property | Type   | Description                                                                   | Required | Default   |
 |----------|--------|-------------------------------------------------------------------------------|----------|-----------|
-| `type`   | String | The resource repository type. Valid values: `LocalFs`, `Aliyun`, `ExternalKms` | Yes      | `LocalFs` |
+| `type`   | String | The resource repository type. Valid values: `LocalFs`, `EncryptedLocalFs`, `Aliyun`, `ExternalKms` | Yes      | `LocalFs` |
 
 **`LocalFs` Properties**
 
 | Property   | Type   | Description                     | Required | Default                                             |
 |------------|--------|---------------------------------|----------|-----------------------------------------------------|
 | `dir_path` | String | Path to a repository directory. | No       | `/opt/confidential-containers/kbs/repository`       |
+
+**`EncryptedLocalFs` Properties**
+
+The `EncryptedLocalFs` backend stores resources on the local filesystem as
+RSA + AES-256-GCM encrypted envelopes and transparently decrypts them on read.
+It is guarded by the Cargo feature `encrypted-local-fs`. See
+[Resource Storage Backend](./resource_storage_backend.md#encrypted-local-file-system-backend)
+for the envelope format, and
+[Encrypted Local FS Key Rotation](./encrypted_local_fs_key_rotation.md) for the
+rotation procedure.
+
+| Property            | Type           | Description                                                                                                                                  | Required | Default                                             |
+|---------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------|
+| `dir_path`          | String         | Path to a repository directory.                                                                                                              | No       | `/opt/confidential-containers/kbs/repository`       |
+| `private_key_path`  | String         | Primary RSA private key (PEM, PKCS#8 or PKCS#1). Tried first when decrypting, and used as the target when re-wrapping resources.             | No\*     | None                                                |
+| `private_key_dir`   | String         | Directory of additional RSA private keys (`*.pem`), retained so resources encrypted with previous keys still decrypt after a rotation.       | No\*     | None                                                |
+| `private_key_paths` | Array\<String> | Additional RSA private keys given as explicit paths (alternative to `private_key_dir`). Tried after the primary and the directory keys.       | No\*     | `[]`                                                |
+
+\* At least one key must be provided through `private_key_path`,
+`private_key_dir`, or `private_key_paths`, otherwise KBS fails to start.
+
+The decryption key ring can be rotated at runtime without a restart through two
+admin-authenticated endpoints:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/kbs/v0/resource/reload` | POST | Re-read the configured keys (primary file, `private_key_dir`, `private_key_paths`) and swap the key ring atomically. Returns `{ "reloaded_keys": <n> }`. |
+| `/kbs/v0/resource/rewrap` | POST | Re-wrap every stored resource's CEK onto the current primary key, so a rotated-out key can be retired. Returns `{ "total", "rewrapped", "skipped", "failed" }`. |
+
+See [EncryptedLocalFs Key Rotation](./encrypted_local_fs_key_rotation.md) for the
+full procedure.
 
 **`Aliyun` Properties**
 

--- a/kbs/docs/encrypted_local_fs_key_rotation.md
+++ b/kbs/docs/encrypted_local_fs_key_rotation.md
@@ -1,0 +1,133 @@
+# EncryptedLocalFs 密钥轮转
+
+`EncryptedLocalFs` 资源后端会用一把 RSA 公钥来包裹每个资源的内容加密密钥
+(CEK),因此解密资源时必须使用对应的 RSA 私钥。如果直接替换私钥,所有用旧密钥
+加密过的资源都会立即无法解密。
+
+为此,`EncryptedLocalFs` 把密钥轮转设计成**零停机、无需手动迁移文件、无需改配置
+重启**,整个过程通过 admin API 驱动:
+
+- **密钥环(key ring)**:KBS 同时持有多把解密私钥。`private_key_path` 是**主
+  密钥**(解密时最先尝试,也是重包裹的目标);`private_key_dir` 是一个存放额外
+  `*.pem` 私钥的目录;`private_key_paths` 则按路径列出额外私钥。读取时逐把尝试,
+  所以用旧密钥加密的资源在轮转期间照常可解。
+- **热加载**:`POST /kbs/v0/resource/reload`(需 admin 鉴权)会重新读取主密钥
+  文件、重新扫描 `private_key_dir`、重新读取 `private_key_paths`,并原子地替换
+  密钥环,**无需重启**。
+- **服务端重包裹(rewrap)**:`POST /kbs/v0/resource/rewrap`(需 admin 鉴权)
+  遍历所有存量资源,把每个资源的 CEK 重新用**主密钥**的公钥包裹(公钥由主私钥直接
+  推导,无需外部传入)。只改写信封的 `enc_key`/`alg` 字段,**AES-256-GCM 密文原样
+  不动**;已经在主密钥上的资源、以及明文资源都会被跳过。
+
+> 阅读本文前,建议你已经熟悉
+> [`EncryptedLocalFs` 后端](./resource_storage_backend.md#encrypted-local-file-system-backend)
+> 及其 JSON 信封(envelope)格式。加密在客户端完成,KBS 只负责解密与重包裹。
+
+## 密钥环的工作方式
+
+后端按以下顺序构建解密私钥列表:
+
+1. `private_key_path` —— 主(当前)密钥,最先尝试,也是 rewrap 的目标。
+2. `private_key_dir` 中的 `*.pem` —— 按文件名排序依次尝试。
+3. `private_key_paths` —— 按列表顺序依次尝试。
+
+每次读取加密资源时,KBS 按上述顺序尝试,返回第一把成功解密的密钥的结果。错误的
+密钥绝不会产生错误数据:它会被 RSA padding 校验、CEK 长度检查,或最终的
+AES-256-GCM 认证标签(tag)所拒绝。如果资源是加密信封但**没有任何**已配置密钥能
+解开,读取直接失败(绝不会把密文当明文返回)。明文(非信封)资源仍原样透传。
+
+至少要配置一把密钥(三种来源任一即可)。rewrap 需要有主密钥(`private_key_path`)
+作为目标,否则会报错。
+
+配置示例:
+
+```toml
+[[plugins]]
+name = "resource"
+type = "EncryptedLocalFs"
+dir_path = "/opt/confidential-containers/kbs/repository"
+private_key_path = "/etc/kbs/resource-keys/primary.pem"   # 主密钥(rewrap 目标,最先尝试)
+private_key_dir  = "/etc/kbs/resource-keys/archive"       # 退役密钥,仅保留用于解密
+```
+
+## admin API 调用
+
+`reload` 与 `rewrap` 都是 admin 接口,需要在请求头携带 admin 的 `Bearer` 令牌
+(由 `[admin]` 段的 `auth_public_key` 对应私钥签发;详见
+[Admin API 配置](./config.md#admin-api-configuration))。下文示例用
+`$ADMIN_TOKEN` 表示该令牌,`$KBS` 表示 KBS 地址。
+
+## 轮转步骤
+
+假设 KBS 当前主密钥文件是 `/etc/kbs/resource-keys/primary.pem`,退役密钥目录是
+`/etc/kbs/resource-keys/archive`,现在要轮转到一对新密钥。
+
+### 1. 生成新密钥对
+
+```shell
+openssl genrsa -out /tmp/resource-private-new.pem 3072
+openssl rsa -in /tmp/resource-private-new.pem -pubout -out /tmp/resource-public-new.pem
+```
+
+### 2. 归档旧主密钥,换上新主密钥,然后热加载
+
+```shell
+# 旧主密钥移入归档目录,继续用于解密存量资源
+cp /etc/kbs/resource-keys/primary.pem /etc/kbs/resource-keys/archive/old-$(date +%Y%m%d).pem
+# 新私钥写为主密钥
+cp /tmp/resource-private-new.pem /etc/kbs/resource-keys/primary.pem
+
+# 热加载,无需重启
+curl -X POST "$KBS/kbs/v0/resource/reload" -H "Authorization: Bearer $ADMIN_TOKEN"
+# -> {"reloaded_keys": 2}
+```
+
+此刻:存量资源(旧公钥加密)仍可用归档的旧密钥解密;新资源则应由客户端/控制台用
+**新公钥**(`resource-public-new.pem`)加密后写入。
+
+### 3. 服务端重包裹存量资源
+
+```shell
+curl -X POST "$KBS/kbs/v0/resource/rewrap" -H "Authorization: Bearer $ADMIN_TOKEN"
+# -> {"total": 128, "rewrapped": 100, "skipped": 28, "failed": 0}
+```
+
+KBS 会把所有用旧密钥加密的资源就地重包裹到新主密钥(只换 `enc_key`,不重新加密
+数据)。已在新主密钥上的资源、明文资源会计入 `skipped`;无法用任何已配置密钥解密
+的资源计入 `failed` 并记录日志,但不会中断整个过程。可重复调用,幂等。
+
+> rewrap 会就地重写仓库目录中的文件,需要 KBS 对仓库有写权限。建议在维护窗口执行,
+> 避免与对同一资源的写入并发。
+
+### 4. 退役旧密钥
+
+确认 `rewrap` 后 `failed` 为 0、所有资源都已迁移,再删除归档目录里的旧密钥并热加载:
+
+```shell
+rm /etc/kbs/resource-keys/archive/old-*.pem
+curl -X POST "$KBS/kbs/v0/resource/reload" -H "Authorization: Bearer $ADMIN_TOKEN"
+# -> {"reloaded_keys": 1}
+```
+
+安全销毁旧私钥材料。轮转至此完成 —— 全程无重启、无手动改写文件内容、客户端无感。
+
+## 仓库只读 / 带外迁移(可选)
+
+如果你的部署把资源仓库对 KBS 设为只读、由控制台带外写入,服务端 `rewrap` 不适用。
+此时仍可用热加载免重启,迁移则用带外脚本
+`kbs/sdk/python/reencrypt_resource.py` 完成:它用旧私钥解出信封、用新公钥重新加密,
+支持原地重写与 `--check` 校验。
+
+```shell
+kbs/sdk/python/reencrypt_resource.py \
+    --old-privkey /etc/kbs/resource-keys/archive/old.pem \
+    --new-pubkey  /tmp/resource-public-new.pem \
+    --in  /path/to/resource --out /path/to/resource
+```
+
+## 说明
+
+- 密钥环只用于**解密**;加密在客户端进行,新资源请用新公钥加密。
+- 密钥可以是 PKCS#8 或 PKCS#1 的 PEM 格式;主密钥的公钥由其私钥推导,无需单独配置。
+- 仅当较靠前的密钥解密失败时,才会对每把额外密钥多做一次 RSA 运算,因此轮转期间
+  保留少数几把密钥的开销可忽略。

--- a/kbs/docs/resource_storage_backend.md
+++ b/kbs/docs/resource_storage_backend.md
@@ -24,9 +24,12 @@ as well, and the default value is `/opt/confidential-containers/kbs/repository`.
 ### Encrypted Local File System Backend
 
 The encrypted local backend (`EncryptedLocalFs`) keeps resources on the local
-filesystem. Reads attempt to decrypt with a configured RSA private key; if the
+filesystem. Reads attempt to decrypt with the configured RSA private key ring
+(one or more keys); the first key able to decrypt a resource is used. If the
 payload is not in the expected encrypted format, it is returned as-is
-(plaintext passthrough).
+(plaintext passthrough). If the payload *is* an encrypted envelope but none of
+the configured keys can decrypt it, the read fails (the ciphertext is never
+returned as plaintext).
 
 **Payload format (JSON, Base64 fields)**
 ```
@@ -62,6 +65,43 @@ type = "EncryptedLocalFs"
 dir_path = "/opt/confidential-containers/kbs/repository"
 private_key_path = "/etc/kbs/resource-private.pem"
 ```
+
+**Key rotation**
+
+Because the CEK is wrapped with an RSA public key, decryption requires the
+matching private key. `EncryptedLocalFs` is built so a key can be rotated with
+**no downtime, no manual file migration, and no config edits**, driven entirely
+through the admin API:
+
+- **Key ring.** KBS holds multiple decryption keys. `private_key_path` is the
+  *primary* key (tried first, and the target of re-wrapping). `private_key_dir`
+  is a directory of additional `*.pem` keys, and `private_key_paths` lists extra
+  keys by path. On read each key is tried in turn, so resources encrypted with
+  an old key keep working while a new key is in use.
+- **Hot reload.** `POST /kbs/v0/resource/reload` (admin authenticated) re-reads
+  the primary key file, re-scans `private_key_dir`, and re-reads
+  `private_key_paths`, swapping the key ring atomically without a restart.
+- **Server-side re-wrap.** `POST /kbs/v0/resource/rewrap` (admin authenticated)
+  walks every stored resource and re-wraps its CEK to the **primary** key's
+  public key (derived from the primary private key). Only the `enc_key`/`alg`
+  envelope fields change; the AES-256-GCM ciphertext is untouched. Resources
+  already on the primary key, and plaintext resources, are skipped. The response
+  is a JSON report `{ "total", "rewrapped", "skipped", "failed" }`.
+
+```
+[[plugins]]
+name = "resource"
+type = "EncryptedLocalFs"
+dir_path = "/opt/confidential-containers/kbs/repository"
+private_key_path = "/etc/kbs/resource-keys/primary.pem"   # primary key (rewrap target, tried first)
+private_key_dir  = "/etc/kbs/resource-keys/archive"       # retired keys kept for decryption
+```
+
+At least one key must be configured (via any of the three options). For the full
+step-by-step rotation procedure, see
+[EncryptedLocalFs Key Rotation](./encrypted_local_fs_key_rotation.md).
+`kbs/sdk/python/reencrypt_resource.py` remains available for out-of-band
+migration when the repository is not writable by KBS.
 
 ### Aliyun KMS
 

--- a/kbs/sdk/python/reencrypt_resource.py
+++ b/kbs/sdk/python/reencrypt_resource.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Re-encrypt a KBS EncryptedLocalFs resource from an old key to a new key.
+
+This is the migration step of a key rotation: after the new private key has
+been added to the KBS key ring (`private_key_path` / `private_key_paths`), use
+this tool to rewrite each existing resource envelope so it is encrypted with the
+new public key. Once every resource has been migrated, the old private key can
+be removed from the KBS configuration.
+
+The resource content (the decrypted plaintext) is never changed; only the
+envelope's encryption keys are rotated.
+
+Usage:
+  ./reencrypt_resource.py --old-privkey old.pem --new-pubkey new_pub.pem \
+      --in resource.json --out resource.json [--alg RSA-OAEP-256]
+
+  # Decryption-only sanity check (no re-encryption, no output written):
+  ./reencrypt_resource.py --old-privkey old.pem --in resource.json --check
+
+In-place rewrite is allowed (`--in` and `--out` may be the same path); the file
+is only overwritten after re-encryption succeeds.
+
+Dependencies: cryptography (pip install cryptography)
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+# Reuse the envelope encryption logic from the sibling helper.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from encrypt_resource import ALGS, encrypt_resource  # noqa: E402
+
+
+def _b64decode(name, value):
+    try:
+        return base64.b64decode(value)
+    except Exception as exc:
+        raise ValueError("invalid base64 in `{}`: {}".format(name, exc))
+
+
+def load_rsa_private_key(path):
+    if not os.path.isfile(path):
+        raise FileNotFoundError("private key not found: {}".format(path))
+
+    raw = open(path, "rb").read()
+    key = serialization.load_pem_private_key(raw, password=None)
+    if not isinstance(key, rsa.RSAPrivateKey):
+        raise TypeError("private key must be RSA")
+    return key
+
+
+def load_rsa_public_key(path):
+    if not os.path.isfile(path):
+        raise FileNotFoundError("public key not found: {}".format(path))
+
+    raw = open(path, "rb").read()
+    pub = serialization.load_pem_public_key(raw)
+    if not isinstance(pub, rsa.RSAPublicKey):
+        raise TypeError("public key must be RSA")
+    return pub
+
+
+def decrypt_envelope(priv, envelope):
+    alg = envelope.get("alg")
+    if alg not in ALGS:
+        raise ValueError("unsupported alg: {}".format(alg))
+
+    enc_key = _b64decode("enc_key", envelope["enc_key"])
+    iv = _b64decode("iv", envelope["iv"])
+    ciphertext = _b64decode("ciphertext", envelope["ciphertext"])
+    tag = _b64decode("tag", envelope["tag"])
+
+    if alg == "RSA1_5":
+        cek = priv.decrypt(enc_key, padding.PKCS1v15())
+    else:
+        cek = priv.decrypt(
+            enc_key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None,
+            ),
+        )
+
+    if len(cek) != 32:
+        raise ValueError("unexpected CEK length {}, expect 32".format(len(cek)))
+
+    aesgcm = AESGCM(cek)
+    return aesgcm.decrypt(iv, ciphertext + tag, None)
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Re-encrypt a KBS EncryptedLocalFs resource from an old key to a new key."
+    )
+    parser.add_argument("--old-privkey", required=True, help="Old RSA private key (PEM)")
+    parser.add_argument("--new-pubkey", help="New RSA public key (PEM); required unless --check")
+    parser.add_argument("--in", dest="input_path", required=True, help="Input envelope JSON")
+    parser.add_argument("--out", dest="output_path", help="Output envelope JSON")
+    parser.add_argument(
+        "--alg",
+        choices=ALGS,
+        default="RSA-OAEP-256",
+        help="RSA algorithm for the new envelope (default: RSA-OAEP-256)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only verify the resource decrypts with the old key; do not re-encrypt",
+    )
+    args = parser.parse_args(argv)
+    if not args.check and (not args.new_pubkey or not args.output_path):
+        parser.error("--new-pubkey and --out are required unless --check is given")
+    return args
+
+
+def main(argv):
+    args = parse_args(argv)
+    try:
+        priv = load_rsa_private_key(args.old_privkey)
+        with open(args.input_path) as f:
+            envelope = json.load(f)
+
+        plaintext = decrypt_envelope(priv, envelope)
+
+        if args.check:
+            print("ok: {} decrypts with the old key".format(args.input_path))
+            return 0
+
+        pub = load_rsa_public_key(args.new_pubkey)
+        new_envelope = encrypt_resource(pub, plaintext, args.alg)
+        with open(args.output_path, "w") as f:
+            json.dump(new_envelope, f, ensure_ascii=False, indent=2)
+        print("re-encrypted: {}".format(args.output_path))
+    except Exception as e:
+        print("error: {}".format(e), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, OnceLock};
 
 use anyhow::{bail, Context, Error, Result};
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[cfg(feature = "encrypted-local-fs")]
@@ -29,6 +29,34 @@ pub trait StorageBackend: Send + Sync {
 
     /// List secret resources from repository
     async fn list_secret_resources(&self) -> Result<Vec<ResourceDesc>>;
+
+    /// Reload key material from the backend's configured source without a
+    /// restart. Returns the number of keys now active. Backends that do not
+    /// manage keys return an error.
+    async fn reload_keys(&self) -> Result<usize> {
+        bail!("this storage backend does not support key reload")
+    }
+
+    /// Re-wrap all encrypted resources onto the backend's current primary key,
+    /// so that a rotated-out key can be retired. Backends that do not encrypt
+    /// resources return an error.
+    async fn rewrap_resources(&self) -> Result<RewrapReport> {
+        bail!("this storage backend does not support resource re-wrapping")
+    }
+}
+
+/// Outcome of a re-wrap (key rotation migration) pass over the repository.
+#[derive(Debug, Default, Serialize)]
+pub struct RewrapReport {
+    /// Total number of resources scanned.
+    pub total: usize,
+    /// Resources re-wrapped onto the primary key.
+    pub rewrapped: usize,
+    /// Resources left untouched (plaintext, or already on the primary key).
+    pub skipped: usize,
+    /// Resources that could not be re-wrapped (e.g. no configured key decrypts
+    /// them).
+    pub failed: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -158,6 +186,14 @@ impl ResourceStorage {
 
     pub(crate) async fn list_secret_resources(&self) -> Result<Vec<ResourceDesc>> {
         self.backend.list_secret_resources().await
+    }
+
+    pub(crate) async fn reload_keys(&self) -> Result<usize> {
+        self.backend.reload_keys().await
+    }
+
+    pub(crate) async fn rewrap_resources(&self) -> Result<RewrapReport> {
+        self.backend.rewrap_resources().await
     }
 }
 

--- a/kbs/src/plugins/implementations/resource/encrypted_local_fs.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_local_fs.rs
@@ -4,7 +4,7 @@
 
 use super::{
     local_fs::{LocalFs, LocalFsRepoDesc},
-    ResourceDesc, StorageBackend,
+    ResourceDesc, RewrapReport, StorageBackend,
 };
 use aes_gcm::{
     aead::{generic_array::GenericArray, AeadInPlace, KeyInit},
@@ -15,9 +15,13 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 use rsa::sha2::Sha256;
 use rsa::{
     pkcs1::DecodeRsaPrivateKey, pkcs8::DecodePrivateKey, Oaep, Pkcs1v15Encrypt, RsaPrivateKey,
+    RsaPublicKey,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fs;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
 
 const ALG_RSA1_5: &str = "RSA1_5";
 const ALG_RSA_OAEP_256: &str = "RSA-OAEP-256";
@@ -39,16 +43,53 @@ struct Envelope {
     pub tag: String,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Default)]
 pub struct EncryptedLocalFsRepoDesc {
     #[serde(default)]
     pub dir_path: String,
+    /// Primary (current) RSA private key. Tried first when decrypting, and used
+    /// as the target key when re-wrapping resources. Its file is read fresh on
+    /// every key reload, so rotating the primary key is just a matter of
+    /// replacing this file and reloading.
+    #[serde(default)]
     pub private_key_path: String,
+    /// A directory of additional RSA private keys (`*.pem`). All keys found here
+    /// are kept available for decryption, so resources encrypted with a previous
+    /// key keep working during a rotation. Dropping a retired key into this
+    /// directory (and reloading) needs no config change or restart.
+    #[serde(default)]
+    pub private_key_dir: String,
+    /// Additional RSA private keys given as explicit paths. Equivalent to
+    /// `private_key_dir` but for keys that live outside a single directory.
+    #[serde(default)]
+    pub private_key_paths: Vec<String>,
+}
+
+/// The set of places keys are loaded from. Held so the key ring can be rebuilt
+/// on a hot reload without re-reading the whole KBS config.
+struct KeySources {
+    primary_path: String,
+    dir: String,
+    extra_paths: Vec<String>,
+}
+
+/// A loaded, immutable snapshot of the decryption keys. Swapped atomically on
+/// reload.
+struct KeyRing {
+    /// Decryption keys, in the order they are tried. When a primary key is
+    /// configured it is `keys[0]`.
+    keys: Vec<RsaPrivateKey>,
+    /// Public key of the primary private key, used as the re-wrap target. `None`
+    /// when no `private_key_path` is configured.
+    primary_public: Option<RsaPublicKey>,
 }
 
 pub struct EncryptedLocalFs {
     inner: LocalFs,
-    private_key: RsaPrivateKey,
+    sources: KeySources,
+    /// Hot-swappable key ring. Reads take a cheap snapshot (clone the `Arc`);
+    /// reloads replace it wholesale.
+    ring: RwLock<Arc<KeyRing>>,
 }
 
 #[async_trait::async_trait]
@@ -74,32 +115,208 @@ impl StorageBackend for EncryptedLocalFs {
     async fn list_secret_resources(&self) -> Result<Vec<ResourceDesc>> {
         self.inner.list_secret_resources().await
     }
+
+    async fn reload_keys(&self) -> Result<usize> {
+        let ring = Self::load_ring(&self.sources)?;
+        let count = ring.keys.len();
+        *self.ring.write().expect("key ring lock poisoned") = Arc::new(ring);
+        Ok(count)
+    }
+
+    async fn rewrap_resources(&self) -> Result<RewrapReport> {
+        let ring = self.ring_snapshot();
+        let primary_public = ring.primary_public.clone().ok_or_else(|| {
+            anyhow!("cannot re-wrap: no primary key configured (set `private_key_path`)")
+        })?;
+
+        let mut report = RewrapReport::default();
+        for desc in self.inner.list_secret_resources().await? {
+            report.total += 1;
+            match self
+                .rewrap_one(&desc, &ring, &primary_public)
+                .await
+                .with_context(|| format!("re-wrap resource `{desc}`"))
+            {
+                Ok(true) => report.rewrapped += 1,
+                Ok(false) => report.skipped += 1,
+                Err(e) => {
+                    report.failed += 1;
+                    log::warn!("{e:#}");
+                }
+            }
+        }
+        Ok(report)
+    }
 }
 
 impl EncryptedLocalFs {
     pub fn new(desc: &EncryptedLocalFsRepoDesc) -> Result<Self> {
-        if desc.private_key_path.is_empty() {
-            bail!("`private_key_path` is required for encrypted local fs backend");
-        }
+        let sources = KeySources {
+            primary_path: desc.private_key_path.clone(),
+            dir: desc.private_key_dir.clone(),
+            extra_paths: desc.private_key_paths.clone(),
+        };
+
+        let ring = Self::load_ring(&sources)?;
 
         let dir_path = if desc.dir_path.is_empty() {
             LocalFsRepoDesc::default().dir_path
         } else {
             desc.dir_path.clone()
         };
-
         let inner = LocalFs::new(&LocalFsRepoDesc { dir_path })?;
-        let private_key = Self::load_private_key(&desc.private_key_path)?;
 
-        Ok(Self { inner, private_key })
+        Ok(Self {
+            inner,
+            sources,
+            ring: RwLock::new(Arc::new(ring)),
+        })
+    }
+
+    /// Build the key ring from the configured sources. The primary key is first
+    /// (so it is tried first and is the re-wrap target), followed by the keys
+    /// from `private_key_dir` and `private_key_paths`. Duplicate files are
+    /// loaded once.
+    fn load_ring(sources: &KeySources) -> Result<KeyRing> {
+        let mut ordered_paths: Vec<String> = Vec::new();
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+        let mut push = |path: &str, ordered: &mut Vec<String>| {
+            if path.is_empty() {
+                return;
+            }
+            let canonical = fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path));
+            if seen.insert(canonical) {
+                ordered.push(path.to_string());
+            }
+        };
+
+        push(&sources.primary_path, &mut ordered_paths);
+        if !sources.dir.is_empty() {
+            for path in Self::scan_key_dir(&sources.dir)? {
+                push(&path, &mut ordered_paths);
+            }
+        }
+        for path in &sources.extra_paths {
+            push(path, &mut ordered_paths);
+        }
+
+        if ordered_paths.is_empty() {
+            bail!(
+                "at least one of `private_key_path`, `private_key_dir`, or `private_key_paths` is required for encrypted local fs backend"
+            );
+        }
+
+        let keys = ordered_paths
+            .iter()
+            .map(|p| Self::load_private_key(p))
+            .collect::<Result<Vec<_>>>()?;
+
+        // The primary public key (re-wrap target) is the public part of the
+        // primary private key, which is `keys[0]` iff a primary path is set.
+        let primary_public = if sources.primary_path.is_empty() {
+            None
+        } else {
+            Some(keys[0].to_public_key())
+        };
+
+        Ok(KeyRing {
+            keys,
+            primary_public,
+        })
+    }
+
+    /// Return the `*.pem` files in a key directory, sorted for a deterministic
+    /// load order.
+    fn scan_key_dir(dir: &str) -> Result<Vec<String>> {
+        let mut paths = Vec::new();
+        let entries = fs::read_dir(dir).with_context(|| format!("read private key dir `{dir}`"))?;
+        for entry in entries {
+            let path = entry
+                .with_context(|| format!("read entry in `{dir}`"))?
+                .path();
+            if path.extension().and_then(|e| e.to_str()) == Some("pem") && path.is_file() {
+                paths.push(path.to_string_lossy().into_owned());
+            }
+        }
+        paths.sort();
+        Ok(paths)
+    }
+
+    fn ring_snapshot(&self) -> Arc<KeyRing> {
+        self.ring.read().expect("key ring lock poisoned").clone()
     }
 
     fn load_private_key(path: &str) -> Result<RsaPrivateKey> {
-        let pem = fs::read_to_string(path).context("read private key file")?;
+        let pem =
+            fs::read_to_string(path).with_context(|| format!("read private key file `{path}`"))?;
 
         RsaPrivateKey::from_pkcs8_pem(&pem)
             .or_else(|_| RsaPrivateKey::from_pkcs1_pem(&pem))
-            .context("parse RSA private key from PEM")
+            .with_context(|| format!("parse RSA private key from PEM `{path}`"))
+    }
+
+    /// Re-wrap a single resource's CEK to `primary_public`. Returns `Ok(true)`
+    /// if it was re-wrapped, `Ok(false)` if it was left untouched (plaintext, or
+    /// already wrapped with the primary key).
+    async fn rewrap_one(
+        &self,
+        desc: &ResourceDesc,
+        ring: &KeyRing,
+        primary_public: &RsaPublicKey,
+    ) -> Result<bool> {
+        let raw = self.inner.read_secret_resource(desc.clone()).await?;
+        let Ok(env) = serde_json::from_slice::<Envelope>(&raw) else {
+            return Ok(false); // not an envelope -> plaintext, leave as-is
+        };
+
+        let enc_key = Self::decode_b64("enc_key", &env.enc_key)?;
+        let iv = Self::decode_b64("iv", &env.iv)?;
+        let ciphertext = Self::decode_b64("ciphertext", &env.ciphertext)?;
+        let tag = Self::decode_b64("tag", &env.tag)?;
+
+        // `keys[0]` is the primary key here (rewrap_resources verified one
+        // exists). If it already decrypts an OAEP envelope, the resource is
+        // current; skip rewriting.
+        if env.alg == ALG_RSA_OAEP_256 {
+            if let Ok(cek) = Self::recover_cek(&ring.keys[0], &env.alg, &enc_key) {
+                if Self::aes_decrypt(&cek, &iv, &ciphertext, &tag).is_ok() {
+                    return Ok(false);
+                }
+            }
+        }
+
+        // Recover the CEK with whichever key works, verifying via the AES-GCM tag.
+        let cek = ring
+            .keys
+            .iter()
+            .find_map(|key| {
+                let cek = Self::recover_cek(key, &env.alg, &enc_key).ok()?;
+                Self::aes_decrypt(&cek, &iv, &ciphertext, &tag).ok()?;
+                Some(cek)
+            })
+            .context("no configured key can decrypt this resource")?;
+
+        // Re-wrap the same CEK with the primary public key (RSA-OAEP-256). The
+        // RNG is scoped so the non-Send `ThreadRng` is dropped before the await.
+        let new_enc_key = {
+            let mut rng = rand::thread_rng();
+            primary_public
+                .encrypt(&mut rng, Oaep::new::<Sha256>(), &cek)
+                .context("re-wrap CEK with primary public key")?
+        };
+
+        let new_env = Envelope {
+            alg: ALG_RSA_OAEP_256.to_string(),
+            enc_key: STANDARD.encode(new_enc_key),
+            iv: env.iv,
+            ciphertext: env.ciphertext,
+            tag: env.tag,
+        };
+        let bytes = serde_json::to_vec(&new_env).context("serialize re-wrapped envelope")?;
+        self.inner
+            .write_secret_resource(desc.clone(), &bytes)
+            .await?;
+        Ok(true)
     }
 
     fn try_decrypt(&self, data: &[u8]) -> Result<Option<Vec<u8>>> {
@@ -119,31 +336,15 @@ impl EncryptedLocalFs {
     }
 
     fn decrypt_envelope(&self, env: &Envelope) -> Result<Vec<u8>> {
+        // Key-independent decoding and validation. A failure here means the
+        // envelope itself is malformed, so no key could ever decrypt it.
         let enc_key = Self::decode_b64("enc_key", &env.enc_key)?;
-        let cek = match env.alg.as_str() {
-            ALG_RSA1_5 => self
-                .private_key
-                .decrypt(Pkcs1v15Encrypt, &enc_key)
-                .context("RSA1_5 decrypt content encryption key (simple envelope)")?,
-            ALG_RSA_OAEP_256 => {
-                let padding = Oaep::new::<Sha256>();
-                self.private_key
-                    .decrypt(padding, &enc_key)
-                    .context("RSA-OAEP-256 decrypt content encryption key (simple envelope)")?
-            }
-            _ => bail!("unsupported simple envelope alg `{}`", env.alg),
-        };
-
         let iv = Self::decode_b64("iv", &env.iv)?;
         let ciphertext = Self::decode_b64("ciphertext", &env.ciphertext)?;
         let tag = Self::decode_b64("tag", &env.tag)?;
 
-        if cek.len() != AES_GCM_KEY_LEN {
-            bail!(
-                "unexpected CEK length {}, expect {} bytes for AES-256-GCM",
-                cek.len(),
-                AES_GCM_KEY_LEN
-            );
+        if !matches!(env.alg.as_str(), ALG_RSA1_5 | ALG_RSA_OAEP_256) {
+            bail!("unsupported simple envelope alg `{}`", env.alg);
         }
 
         if tag.len() != AES_GCM_TAG_LEN {
@@ -162,11 +363,63 @@ impl EncryptedLocalFs {
             );
         }
 
-        let cipher =
-            Aes256Gcm::new_from_slice(&cek).context("build AES-256-GCM cipher with CEK")?;
-        let nonce = Nonce::from_slice(&iv);
-        let mut plaintext = ciphertext.clone();
-        let tag = GenericArray::from_slice(&tag);
+        // Try each key in the ring; the first one able to decrypt wins. This is
+        // what allows resources encrypted with a previous key to keep working
+        // after a key rotation. A wrong key is always rejected: RSA padding
+        // fails, the CEK length check fails, or the AES-GCM tag check fails.
+        let ring = self.ring_snapshot();
+        let mut last_err = None;
+        for key in &ring.keys {
+            match Self::recover_cek(key, &env.alg, &enc_key)
+                .and_then(|cek| Self::aes_decrypt(&cek, &iv, &ciphertext, &tag))
+            {
+                Ok(plaintext) => return Ok(plaintext),
+                Err(e) => last_err = Some(e),
+            }
+        }
+
+        Err(anyhow!(
+            "failed to decrypt resource with any of the {} configured private key(s): {}",
+            ring.keys.len(),
+            last_err.expect("key ring is never empty")
+        ))
+    }
+
+    /// Unwrap the content encryption key with one RSA private key. Does not
+    /// verify the CEK is correct; the caller must confirm via the AES-GCM tag.
+    fn recover_cek(private_key: &RsaPrivateKey, alg: &str, enc_key: &[u8]) -> Result<Vec<u8>> {
+        let cek = match alg {
+            ALG_RSA1_5 => private_key
+                .decrypt(Pkcs1v15Encrypt, enc_key)
+                .context("RSA1_5 decrypt content encryption key (simple envelope)")?,
+            ALG_RSA_OAEP_256 => {
+                let padding = Oaep::new::<Sha256>();
+                private_key
+                    .decrypt(padding, enc_key)
+                    .context("RSA-OAEP-256 decrypt content encryption key (simple envelope)")?
+            }
+            _ => bail!("unsupported simple envelope alg `{alg}`"),
+        };
+
+        if cek.len() != AES_GCM_KEY_LEN {
+            bail!(
+                "unexpected CEK length {}, expect {} bytes for AES-256-GCM",
+                cek.len(),
+                AES_GCM_KEY_LEN
+            );
+        }
+
+        Ok(cek)
+    }
+
+    /// AES-256-GCM decrypt the payload. A wrong CEK fails the authentication tag
+    /// here, which is the final guarantee that only correctly decrypted data is
+    /// ever returned.
+    fn aes_decrypt(cek: &[u8], iv: &[u8], ciphertext: &[u8], tag: &[u8]) -> Result<Vec<u8>> {
+        let cipher = Aes256Gcm::new_from_slice(cek).context("build AES-256-GCM cipher with CEK")?;
+        let nonce = Nonce::from_slice(iv);
+        let mut plaintext = ciphertext.to_vec();
+        let tag = GenericArray::from_slice(tag);
 
         cipher
             .decrypt_in_place_detached(nonce, b"", &mut plaintext, tag)
@@ -197,16 +450,27 @@ mod tests {
 
     const TEST_DATA: &[u8] = b"testdata";
 
+    fn write_key(
+        tmp_dir: &tempfile::TempDir,
+        name: &str,
+        rsa: &Rsa<openssl::pkey::Private>,
+    ) -> String {
+        let key_path = tmp_dir.path().join(name);
+        std::fs::write(&key_path, rsa.private_key_to_pem().unwrap()).unwrap();
+        key_path.to_string_lossy().into()
+    }
+
     fn build_backend(
         tmp_dir: &tempfile::TempDir,
         rsa: &Rsa<openssl::pkey::Private>,
     ) -> EncryptedLocalFs {
-        let key_path = tmp_dir.path().join("rsa.pem");
-        std::fs::write(&key_path, rsa.private_key_to_pem().unwrap()).unwrap();
+        let key_path = write_key(tmp_dir, "rsa.pem", rsa);
 
         EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
             dir_path: tmp_dir.path().to_string_lossy().into(),
-            private_key_path: key_path.to_string_lossy().into(),
+            private_key_path: key_path,
+            private_key_paths: vec![],
+            ..Default::default()
         })
         .expect("create encrypted local fs backend")
     }
@@ -299,5 +563,282 @@ mod tests {
         let data = backend.read_secret_resource(resource_desc).await.unwrap();
 
         assert_eq!(data, TEST_DATA);
+    }
+
+    fn resource_desc(tag: &str) -> ResourceDesc {
+        ResourceDesc {
+            repository_name: "default".into(),
+            resource_type: "encrypted".into(),
+            resource_tag: tag.into(),
+        }
+    }
+
+    // A resource encrypted with an old key is still readable after rotation, as
+    // long as the old key is kept in `private_key_paths`. The new (primary) key
+    // is configured but does not match this resource.
+    #[tokio::test]
+    async fn decrypts_with_rotated_old_key() {
+        let tmp_dir = tempdir().unwrap();
+        let old_rsa = Rsa::generate(2048).unwrap();
+        let new_rsa = Rsa::generate(2048).unwrap();
+
+        let backend = EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
+            dir_path: tmp_dir.path().to_string_lossy().into(),
+            private_key_path: write_key(&tmp_dir, "new.pem", &new_rsa),
+            private_key_paths: vec![write_key(&tmp_dir, "old.pem", &old_rsa)],
+            ..Default::default()
+        })
+        .expect("create backend with rotated key ring");
+
+        let desc = resource_desc("legacy");
+        let encrypted = encrypt_envelope(&old_rsa, ALG_RSA_OAEP_256, TEST_DATA);
+        backend
+            .write_secret_resource(desc.clone(), &serde_json::to_vec(&encrypted).unwrap())
+            .await
+            .unwrap();
+
+        let data = backend
+            .read_secret_resource(desc)
+            .await
+            .expect("legacy resource must decrypt with the retained old key");
+        assert_eq!(data, TEST_DATA);
+    }
+
+    // Within a single key ring, resources encrypted with either key both decrypt
+    // regardless of which key is primary.
+    #[tokio::test]
+    async fn decrypts_with_either_key_in_ring() {
+        let tmp_dir = tempdir().unwrap();
+        let rsa_a = Rsa::generate(2048).unwrap();
+        let rsa_b = Rsa::generate(2048).unwrap();
+
+        let backend = EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
+            dir_path: tmp_dir.path().to_string_lossy().into(),
+            private_key_path: write_key(&tmp_dir, "a.pem", &rsa_a),
+            private_key_paths: vec![write_key(&tmp_dir, "b.pem", &rsa_b)],
+            ..Default::default()
+        })
+        .expect("create backend");
+
+        for (tag, rsa) in [("with-a", &rsa_a), ("with-b", &rsa_b)] {
+            let desc = resource_desc(tag);
+            let encrypted = encrypt_envelope(rsa, ALG_RSA_OAEP_256, TEST_DATA);
+            backend
+                .write_secret_resource(desc.clone(), &serde_json::to_vec(&encrypted).unwrap())
+                .await
+                .unwrap();
+            let data = backend.read_secret_resource(desc).await.expect("decrypt");
+            assert_eq!(data, TEST_DATA);
+        }
+    }
+
+    // A resource whose key is in none of the configured keys must error, not be
+    // returned as ciphertext-as-plaintext.
+    #[tokio::test]
+    async fn errors_when_no_key_matches() {
+        let tmp_dir = tempdir().unwrap();
+        let configured_rsa = Rsa::generate(2048).unwrap();
+        let foreign_rsa = Rsa::generate(2048).unwrap();
+        let backend = build_backend(&tmp_dir, &configured_rsa);
+
+        let desc = resource_desc("unknown");
+        let encrypted = encrypt_envelope(&foreign_rsa, ALG_RSA_OAEP_256, TEST_DATA);
+        backend
+            .write_secret_resource(desc.clone(), &serde_json::to_vec(&encrypted).unwrap())
+            .await
+            .unwrap();
+
+        let err = backend
+            .read_secret_resource(desc)
+            .await
+            .expect_err("must not decrypt with a foreign key");
+        assert!(err.to_string().contains("any of the"));
+    }
+
+    // RSA1_5 envelopes also work through the key ring, exercising the path where
+    // a wrong key may yield a wrong-length CEK rather than a clean padding error.
+    #[tokio::test]
+    async fn decrypts_rsa1_5_through_ring() {
+        let tmp_dir = tempdir().unwrap();
+        let old_rsa = Rsa::generate(2048).unwrap();
+        let new_rsa = Rsa::generate(2048).unwrap();
+
+        let backend = EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
+            dir_path: tmp_dir.path().to_string_lossy().into(),
+            private_key_path: write_key(&tmp_dir, "new.pem", &new_rsa),
+            private_key_paths: vec![write_key(&tmp_dir, "old.pem", &old_rsa)],
+            ..Default::default()
+        })
+        .expect("create backend");
+
+        let desc = resource_desc("rsa15");
+        let encrypted = encrypt_envelope(&old_rsa, ALG_RSA1_5, TEST_DATA);
+        backend
+            .write_secret_resource(desc.clone(), &serde_json::to_vec(&encrypted).unwrap())
+            .await
+            .unwrap();
+
+        let data = backend.read_secret_resource(desc).await.expect("decrypt");
+        assert_eq!(data, TEST_DATA);
+    }
+
+    #[test]
+    fn rejects_empty_key_configuration() {
+        let tmp_dir = tempdir().unwrap();
+        let err = EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
+            dir_path: tmp_dir.path().to_string_lossy().into(),
+            private_key_path: String::new(),
+            private_key_paths: vec![],
+            ..Default::default()
+        })
+        .err()
+        .expect("a backend with no keys must fail to initialize");
+        assert!(err.to_string().contains("private_key"));
+    }
+
+    // A backend can pick up keys from `private_key_dir`, and `reload_keys`
+    // re-reads the configured sources at runtime: after the primary file is
+    // replaced with a new key (old key retained in the dir), both the old and
+    // new resources decrypt without a restart.
+    #[tokio::test]
+    async fn reload_picks_up_rotated_keys() {
+        let tmp_dir = tempdir().unwrap();
+        let keys_dir = tmp_dir.path().join("keys");
+        std::fs::create_dir(&keys_dir).unwrap();
+
+        let old_rsa = Rsa::generate(2048).unwrap();
+        let new_rsa = Rsa::generate(2048).unwrap();
+
+        // Start with the old key as primary.
+        let primary_path = keys_dir.join("primary.pem");
+        std::fs::write(&primary_path, old_rsa.private_key_to_pem().unwrap()).unwrap();
+
+        let backend = EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
+            dir_path: tmp_dir.path().to_string_lossy().into(),
+            private_key_path: primary_path.to_string_lossy().into(),
+            private_key_dir: keys_dir.to_string_lossy().into(),
+            ..Default::default()
+        })
+        .expect("create backend");
+
+        // Resource encrypted with the old key.
+        let legacy = resource_desc("legacy");
+        let enc_old = encrypt_envelope(&old_rsa, ALG_RSA_OAEP_256, TEST_DATA);
+        backend
+            .write_secret_resource(legacy.clone(), &serde_json::to_vec(&enc_old).unwrap())
+            .await
+            .unwrap();
+
+        // Rotate: archive old key into the dir, write new key as primary, reload.
+        std::fs::write(
+            keys_dir.join("old.pem"),
+            old_rsa.private_key_to_pem().unwrap(),
+        )
+        .unwrap();
+        std::fs::write(&primary_path, new_rsa.private_key_to_pem().unwrap()).unwrap();
+        let count = backend.reload_keys().await.expect("reload");
+        assert_eq!(count, 2, "primary + archived old key");
+
+        // Old resource still decrypts (old key retained)...
+        assert_eq!(
+            backend.read_secret_resource(legacy).await.expect("old"),
+            TEST_DATA
+        );
+        // ...and a resource freshly encrypted with the new key decrypts too.
+        let fresh = resource_desc("fresh");
+        let enc_new = encrypt_envelope(&new_rsa, ALG_RSA_OAEP_256, TEST_DATA);
+        backend
+            .write_secret_resource(fresh.clone(), &serde_json::to_vec(&enc_new).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.read_secret_resource(fresh).await.expect("new"),
+            TEST_DATA
+        );
+    }
+
+    // Server-side re-wrap migrates an old-key resource onto the primary key, so
+    // the old key can later be retired. Resources already on the primary key are
+    // skipped, and plaintext resources are left untouched.
+    #[tokio::test]
+    async fn rewrap_migrates_to_primary_key() {
+        let tmp_dir = tempdir().unwrap();
+        let old_rsa = Rsa::generate(2048).unwrap();
+        let new_rsa = Rsa::generate(2048).unwrap();
+
+        let backend = EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
+            dir_path: tmp_dir.path().to_string_lossy().into(),
+            private_key_path: write_key(&tmp_dir, "new.pem", &new_rsa),
+            private_key_paths: vec![write_key(&tmp_dir, "old.pem", &old_rsa)],
+            ..Default::default()
+        })
+        .expect("create backend");
+
+        // One resource on the old key, one already on the new (primary) key, and
+        // one plaintext resource.
+        let legacy = resource_desc("legacy");
+        backend
+            .write_secret_resource(
+                legacy.clone(),
+                &serde_json::to_vec(&encrypt_envelope(&old_rsa, ALG_RSA_OAEP_256, TEST_DATA))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let current = resource_desc("current");
+        backend
+            .write_secret_resource(
+                current.clone(),
+                &serde_json::to_vec(&encrypt_envelope(&new_rsa, ALG_RSA_OAEP_256, TEST_DATA))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let plain = resource_desc("plain");
+        backend
+            .write_secret_resource(plain.clone(), TEST_DATA)
+            .await
+            .unwrap();
+
+        let report = backend.rewrap_resources().await.expect("rewrap");
+        assert_eq!(report.total, 3);
+        assert_eq!(report.rewrapped, 1, "only the legacy resource");
+        assert_eq!(report.skipped, 2, "current (already primary) + plaintext");
+        assert_eq!(report.failed, 0);
+
+        // The migrated resource must now decrypt with ONLY the new key.
+        let new_only = EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
+            dir_path: tmp_dir.path().to_string_lossy().into(),
+            private_key_path: write_key(&tmp_dir, "new2.pem", &new_rsa),
+            ..Default::default()
+        })
+        .expect("new-only backend");
+        assert_eq!(
+            new_only
+                .read_secret_resource(legacy)
+                .await
+                .expect("migrated"),
+            TEST_DATA
+        );
+    }
+
+    // Re-wrap requires a primary key (the target). Without `private_key_path`
+    // it must error rather than silently doing nothing.
+    #[tokio::test]
+    async fn rewrap_without_primary_key_errors() {
+        let tmp_dir = tempdir().unwrap();
+        let rsa = Rsa::generate(2048).unwrap();
+        let backend = EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
+            dir_path: tmp_dir.path().to_string_lossy().into(),
+            private_key_paths: vec![write_key(&tmp_dir, "only.pem", &rsa)],
+            ..Default::default()
+        })
+        .expect("create backend with no primary");
+
+        let err = backend
+            .rewrap_resources()
+            .await
+            .expect_err("rewrap without a primary key must fail");
+        assert!(err.to_string().contains("no primary key"));
     }
 }

--- a/kbs/src/plugins/implementations/resource/mod.rs
+++ b/kbs/src/plugins/implementations/resource/mod.rs
@@ -33,6 +33,18 @@ impl ClientPlugin for ResourceStorage {
             .strip_prefix('/')
             .context("accessed path is illegal, should start with `/`")?;
         match method.as_str() {
+            // Reserved single-segment maintenance paths (admin authenticated, as
+            // all POSTs to this plugin are). They cannot collide with a resource
+            // URI, which always has three segments.
+            "POST" if resource_desc == "reload" => {
+                let count = self.reload_keys().await?;
+                serde_json::to_vec(&serde_json::json!({ "reloaded_keys": count }))
+                    .context("serialize reload response")
+            }
+            "POST" if resource_desc == "rewrap" => {
+                let report = self.rewrap_resources().await?;
+                serde_json::to_vec(&report).context("serialize rewrap report")
+            }
             "POST" => {
                 let resource_description = ResourceDesc::try_from(resource_desc)?;
                 self.set_secret_resource(resource_description, body).await?;


### PR DESCRIPTION
## Summary

The `EncryptedLocalFs` resource backend wrapped each resource's content
encryption key (CEK) with a single RSA key, so rotating that key made every
resource encrypted with the previous key permanently undecryptable. This PR
makes key rotation a **zero-downtime, admin-driven** operation.

- **Decryption key ring**: a primary key (`private_key_path`), a directory of
  additional keys (`private_key_dir`), and explicit extra keys
  (`private_key_paths`). On read each key is tried until one decrypts the
  envelope, so old and new resources coexist during a rotation.
- **Hot reload** — `POST /kbs/v0/resource/reload` re-reads the configured keys
  and swaps the key ring atomically, without a restart.
- **Server-side re-wrap** — `POST /kbs/v0/resource/rewrap` re-wraps every
  resource's CEK onto the primary key (public key derived from the primary
  private key), rewriting only the envelope's `enc_key`/`alg` and leaving the
  AES-256-GCM ciphertext untouched, so a rotated-out key can be retired with no
  manual file migration. Returns `{ "total", "rewrapped", "skipped", "failed" }`.
- **Tooling/docs**: `kbs/sdk/python/reencrypt_resource.py` for the out-of-band
  (read-only repository) case; docs for the key ring, the admin endpoints, and a
  step-by-step rotation guide.

Rotation becomes: drop the new key in as primary (old key retained) → `reload`
→ `rewrap` → remove the old key → `reload`. No restart, no scripts, client
unaffected (encryption stays client-side).

## Compatibility & safety

- Both admin endpoints are admin authenticated (all POSTs to the resource
  plugin are).
- Backward compatible: existing single-`private_key_path` configs and the
  envelope format are unchanged.
- A wrong key is always rejected (RSA padding, CEK length, or the AES-GCM tag);
  a payload that no configured key can decrypt errors out rather than being
  returned as plaintext. Non-envelope payloads are still passed through.

## Test plan

- [x] `cargo test -p kbs --no-default-features --features encrypted-local-fs` — 10 tests pass (key ring, rotation, foreign-key rejection, RSA1_5, empty-config, hot reload, server-side rewrap incl. skip/idempotency, rewrap-without-primary error)
- [x] `cargo fmt -p kbs -- --check` clean; `cargo clippy` clean for the changed files
- [ ] CI (`rust-check.yml`)