### PR TITLE
kbs: self-managed keys and one-shot rotation for EncryptedLocalFs

### DIFF
--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -228,23 +228,32 @@ for the envelope format, and
 [Encrypted Local FS Key Rotation](./encrypted_local_fs_key_rotation.md) for the
 rotation procedure.
 
+By default KBS manages the keys itself (no key configuration needed): it
+generates a key pair into `key_dir` on first start and rotates keys via the
+`rotate` API. Alternatively, bring your own keys with `private_key_path` /
+`private_key_dir` / `private_key_paths`.
+
 | Property            | Type           | Description                                                                                                                                  | Required | Default                                             |
 |---------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------|
 | `dir_path`          | String         | Path to a repository directory.                                                                                                              | No       | `/opt/confidential-containers/kbs/repository`       |
-| `private_key_path`  | String         | Primary RSA private key (PEM, PKCS#8 or PKCS#1). Tried first when decrypting, and used as the target when re-wrapping resources.             | No\*     | None                                                |
-| `private_key_dir`   | String         | Directory of additional RSA private keys (`*.pem`), retained so resources encrypted with previous keys still decrypt after a rotation.       | No\*     | None                                                |
-| `private_key_paths` | Array\<String> | Additional RSA private keys given as explicit paths (alternative to `private_key_dir`). Tried after the primary and the directory keys.       | No\*     | `[]`                                                |
+| `key_dir`           | String         | KBS-managed key store directory. KBS generates and rotates RSA keys here itself. Active when set, or when no other key is configured.        | No       | `/opt/confidential-containers/kbs/resource-keys` (when managed) |
+| `private_key_path`  | String         | Bring-your-own primary RSA private key (PEM, PKCS#8 or PKCS#1). Primary / re-wrap target when no managed key store is in effect.             | No\*     | None                                                |
+| `private_key_dir`   | String         | Bring-your-own directory of additional RSA private keys (`*.pem`), retained for decryption so previously encrypted resources still decrypt.   | No\*     | None                                                |
+| `private_key_paths` | Array\<String> | Additional bring-your-own RSA private keys given as explicit paths.                                                                          | No\*     | `[]`                                                |
 
-\* At least one key must be provided through `private_key_path`,
-`private_key_dir`, or `private_key_paths`, otherwise KBS fails to start.
+\* If none of `key_dir` / `private_key_path` / `private_key_dir` /
+`private_key_paths` is set, KBS runs in managed mode at the default `key_dir`
+and generates a key pair on first start.
 
-The decryption key ring can be rotated at runtime without a restart through two
-admin-authenticated endpoints:
+Keys can be rotated at runtime, without a restart, through admin-authenticated
+endpoints:
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/kbs/v0/resource/reload` | POST | Re-read the configured keys (primary file, `private_key_dir`, `private_key_paths`) and swap the key ring atomically. Returns `{ "reloaded_keys": <n> }`. |
-| `/kbs/v0/resource/rewrap` | POST | Re-wrap every stored resource's CEK onto the current primary key, so a rotated-out key can be retired. Returns `{ "total", "rewrapped", "skipped", "failed" }`. |
+| `/kbs/v0/resource/rotate` | POST | **Managed keys, one-shot.** Generate a new key pair, re-wrap all resources onto it, and retire the old key. Returns `{ "public_key", "rewrapped", "skipped", "failed", "retired_keys" }`. |
+| `/kbs/v0/resource/pubkey` | GET  | Return the current primary public key (PEM) for clients to encrypt with. |
+| `/kbs/v0/resource/reload` | POST | Re-read the configured keys and swap the key ring atomically. Returns `{ "reloaded_keys": <n> }`. |
+| `/kbs/v0/resource/rewrap` | POST | Re-wrap every resource's CEK onto the current primary key (no new key generated). Returns `{ "total", "rewrapped", "skipped", "failed" }`. |
 
 See [EncryptedLocalFs Key Rotation](./encrypted_local_fs_key_rotation.md) for the
 full procedure.

--- a/kbs/docs/encrypted_local_fs_key_rotation.md
+++ b/kbs/docs/encrypted_local_fs_key_rotation.md
@@ -4,130 +4,106 @@
 (CEK),因此解密资源时必须使用对应的 RSA 私钥。如果直接替换私钥,所有用旧密钥
 加密过的资源都会立即无法解密。
 
-为此,`EncryptedLocalFs` 把密钥轮转设计成**零停机、无需手动迁移文件、无需改配置
-重启**,整个过程通过 admin API 驱动:
-
-- **密钥环(key ring)**:KBS 同时持有多把解密私钥。`private_key_path` 是**主
-  密钥**(解密时最先尝试,也是重包裹的目标);`private_key_dir` 是一个存放额外
-  `*.pem` 私钥的目录;`private_key_paths` 则按路径列出额外私钥。读取时逐把尝试,
-  所以用旧密钥加密的资源在轮转期间照常可解。
-- **热加载**:`POST /kbs/v0/resource/reload`(需 admin 鉴权)会重新读取主密钥
-  文件、重新扫描 `private_key_dir`、重新读取 `private_key_paths`,并原子地替换
-  密钥环,**无需重启**。
-- **服务端重包裹(rewrap)**:`POST /kbs/v0/resource/rewrap`(需 admin 鉴权)
-  遍历所有存量资源,把每个资源的 CEK 重新用**主密钥**的公钥包裹(公钥由主私钥直接
-  推导,无需外部传入)。只改写信封的 `enc_key`/`alg` 字段,**AES-256-GCM 密文原样
-  不动**;已经在主密钥上的资源、以及明文资源都会被跳过。
+为此,KBS **默认自管理密钥**:启用 `EncryptedLocalFs` 时它自己生成密钥对,轮转也
+由它自己完成。对运维/管控而言,轮转就是**调一个接口**的事——KBS 自动完成"生成新
+密钥 → 重包裹所有资源 → 清理旧密钥",轮转完再调一个接口把新公钥读走即可。**无需
+手动生成密钥,无需改配置,无需重启。**
 
 > 阅读本文前,建议你已经熟悉
 > [`EncryptedLocalFs` 后端](./resource_storage_backend.md#encrypted-local-file-system-backend)
-> 及其 JSON 信封(envelope)格式。加密在客户端完成,KBS 只负责解密与重包裹。
+> 及其 JSON 信封(envelope)格式。加密在客户端完成,KBS 只负责解密、重包裹与密钥
+> 生命周期管理。
 
-## 密钥环的工作方式
+## 两种密钥来源
 
-后端按以下顺序构建解密私钥列表:
+- **KBS 自管理(默认,推荐)**:配置 `key_dir`(不配则用默认目录
+  `/opt/confidential-containers/kbs/resource-keys`)。KBS 首次启动时在该目录生成
+  一对 RSA 密钥;目录中**最新**的密钥即当前主密钥(rewrap 目标、`pubkey` 返回的
+  公钥)。一键 `rotate` 接口完成整套轮转。
+- **自带密钥(BYOK)**:配置 `private_key_path`(主/ rewrap 目标)以及可选的
+  `private_key_dir` / `private_key_paths`(仅用于解密)。此模式下用 `reload` /
+  `rewrap` 等更底层的接口轮转(见文末)。两者也可并存:managed 的 `key_dir` 为主,
+  BYOK 的密钥作为只读解密来源(便于从 BYOK 迁移到 managed)。
 
-1. `private_key_path` —— 主(当前)密钥,最先尝试,也是 rewrap 的目标。
-2. `private_key_dir` 中的 `*.pem` —— 按文件名排序依次尝试。
-3. `private_key_paths` —— 按列表顺序依次尝试。
+## admin API
 
-每次读取加密资源时,KBS 按上述顺序尝试,返回第一把成功解密的密钥的结果。错误的
-密钥绝不会产生错误数据:它会被 RSA padding 校验、CEK 长度检查,或最终的
-AES-256-GCM 认证标签(tag)所拒绝。如果资源是加密信封但**没有任何**已配置密钥能
-解开,读取直接失败(绝不会把密文当明文返回)。明文(非信封)资源仍原样透传。
+下列接口都需要 admin 的 `Bearer` 令牌(由 `[admin]` 段 `auth_public_key` 对应
+私钥签发,详见 [Admin API 配置](./config.md#admin-api-configuration))。下文
+`$KBS` 表示 KBS 地址,`$ADMIN_TOKEN` 表示该令牌。
 
-至少要配置一把密钥(三种来源任一即可)。rewrap 需要有主密钥(`private_key_path`)
-作为目标,否则会报错。
+| 接口 | 方法 | 作用 |
+|------|------|------|
+| `/kbs/v0/resource/rotate` | POST | **一键轮转(自管理)**:生成新密钥 → 重包裹全部资源 → 退役旧密钥。 |
+| `/kbs/v0/resource/pubkey` | GET  | 读取当前主公钥(PEM),供客户端加密。 |
+| `/kbs/v0/resource/reload` | POST | 重读配置的密钥并原子换环(免重启)。 |
+| `/kbs/v0/resource/rewrap` | POST | 把所有资源 CEK 重包裹到当前主密钥(不生成新密钥)。 |
 
-配置示例:
+## 自管理模式:一键轮转(推荐)
+
+### 1. 配置(通常无需任何密钥配置)
 
 ```toml
 [[plugins]]
 name = "resource"
 type = "EncryptedLocalFs"
 dir_path = "/opt/confidential-containers/kbs/repository"
-private_key_path = "/etc/kbs/resource-keys/primary.pem"   # 主密钥(rewrap 目标,最先尝试)
-private_key_dir  = "/etc/kbs/resource-keys/archive"       # 退役密钥,仅保留用于解密
+# key_dir 默认为 /opt/confidential-containers/kbs/resource-keys;需要时再显式覆盖。
 ```
 
-## admin API 调用
-
-`reload` 与 `rewrap` 都是 admin 接口,需要在请求头携带 admin 的 `Bearer` 令牌
-(由 `[admin]` 段的 `auth_public_key` 对应私钥签发;详见
-[Admin API 配置](./config.md#admin-api-configuration))。下文示例用
-`$ADMIN_TOKEN` 表示该令牌,`$KBS` 表示 KBS 地址。
-
-## 轮转步骤
-
-假设 KBS 当前主密钥文件是 `/etc/kbs/resource-keys/primary.pem`,退役密钥目录是
-`/etc/kbs/resource-keys/archive`,现在要轮转到一对新密钥。
-
-### 1. 生成新密钥对
+KBS 首次启动即在 `key_dir` 生成一对密钥。客户端先取公钥:
 
 ```shell
-openssl genrsa -out /tmp/resource-private-new.pem 3072
-openssl rsa -in /tmp/resource-private-new.pem -pubout -out /tmp/resource-public-new.pem
+curl -s "$KBS/kbs/v0/resource/pubkey" -H "Authorization: Bearer $ADMIN_TOKEN" > resource-public.pem
+# 用该公钥加密资源(见 kbs/sdk/python/encrypt_resource.py),再写入 KBS。
 ```
 
-### 2. 归档旧主密钥,换上新主密钥,然后热加载
+### 2. 轮转 —— 一个接口搞定
 
 ```shell
-# 旧主密钥移入归档目录,继续用于解密存量资源
-cp /etc/kbs/resource-keys/primary.pem /etc/kbs/resource-keys/archive/old-$(date +%Y%m%d).pem
-# 新私钥写为主密钥
-cp /tmp/resource-private-new.pem /etc/kbs/resource-keys/primary.pem
-
-# 热加载,无需重启
-curl -X POST "$KBS/kbs/v0/resource/reload" -H "Authorization: Bearer $ADMIN_TOKEN"
-# -> {"reloaded_keys": 2}
+curl -X POST "$KBS/kbs/v0/resource/rotate" -H "Authorization: Bearer $ADMIN_TOKEN"
+# -> {"public_key":"-----BEGIN PUBLIC KEY-----\n...","rewrapped":100,"skipped":28,"failed":0,"retired_keys":1}
 ```
 
-此刻:存量资源(旧公钥加密)仍可用归档的旧密钥解密;新资源则应由客户端/控制台用
-**新公钥**(`resource-public-new.pem`)加密后写入。
+这一个调用里,KBS 自动完成:
 
-### 3. 服务端重包裹存量资源
+1. 生成一对新 RSA 密钥(作为新的主密钥)。
+2. 把所有存量资源的 CEK 重包裹到新主密钥(只改 `enc_key`/`alg`,不动 AES 密文)。
+3. 若全部成功(`failed == 0`),退役并删除旧的自管理密钥(`retired_keys` 为删除
+   数量);**若有资源 rewrap 失败,则保留旧密钥**以保证其仍可解密,`failed` 会
+   大于 0,需排查后重试。
+
+返回体里的 `public_key` 就是新公钥。
+
+### 3. 取走新公钥
 
 ```shell
-curl -X POST "$KBS/kbs/v0/resource/rewrap" -H "Authorization: Bearer $ADMIN_TOKEN"
-# -> {"total": 128, "rewrapped": 100, "skipped": 28, "failed": 0}
+curl -s "$KBS/kbs/v0/resource/pubkey" -H "Authorization: Bearer $ADMIN_TOKEN" > resource-public.pem
 ```
 
-KBS 会把所有用旧密钥加密的资源就地重包裹到新主密钥(只换 `enc_key`,不重新加密
-数据)。已在新主密钥上的资源、明文资源会计入 `skipped`;无法用任何已配置密钥解密
-的资源计入 `failed` 并记录日志,但不会中断整个过程。可重复调用,幂等。
+之后客户端用新公钥加密新资源即可。整个轮转无重启、无手动生成密钥、无改配置。
 
-> rewrap 会就地重写仓库目录中的文件,需要 KBS 对仓库有写权限。建议在维护窗口执行,
-> 避免与对同一资源的写入并发。
+> `rotate` 会就地重写仓库中的资源文件,需要 KBS 对仓库有写权限。建议在维护窗口执行,
+> 避免与对同一资源的写入并发;轮转期间若客户端仍用旧公钥写入新资源,请在 `rotate`
+> 完成后改用新公钥(或对这些资源再跑一次 `rewrap`)。
 
-### 4. 退役旧密钥
+## 自带密钥(BYOK)模式的轮转
 
-确认 `rewrap` 后 `failed` 为 0、所有资源都已迁移,再删除归档目录里的旧密钥并热加载:
+若你坚持自管密钥材料(`private_key_path` 等),则没有一键 `rotate`(它属于自管理
+模式),改用以下手动流程:
 
-```shell
-rm /etc/kbs/resource-keys/archive/old-*.pem
-curl -X POST "$KBS/kbs/v0/resource/reload" -H "Authorization: Bearer $ADMIN_TOKEN"
-# -> {"reloaded_keys": 1}
-```
+1. 把旧主密钥归档进 `private_key_dir`,把新私钥写到 `private_key_path`,调用
+   `POST /kbs/v0/resource/reload` 热加载(免重启)。
+2. 调用 `POST /kbs/v0/resource/rewrap` 把存量资源重包裹到新主密钥。
+3. 从 `private_key_dir` 删除旧密钥,再次 `reload`。
 
-安全销毁旧私钥材料。轮转至此完成 —— 全程无重启、无手动改写文件内容、客户端无感。
-
-## 仓库只读 / 带外迁移(可选)
-
-如果你的部署把资源仓库对 KBS 设为只读、由控制台带外写入,服务端 `rewrap` 不适用。
-此时仍可用热加载免重启,迁移则用带外脚本
-`kbs/sdk/python/reencrypt_resource.py` 完成:它用旧私钥解出信封、用新公钥重新加密,
-支持原地重写与 `--check` 校验。
-
-```shell
-kbs/sdk/python/reencrypt_resource.py \
-    --old-privkey /etc/kbs/resource-keys/archive/old.pem \
-    --new-pubkey  /tmp/resource-public-new.pem \
-    --in  /path/to/resource --out /path/to/resource
-```
+仓库对 KBS 只读、需带外迁移时,用 `kbs/sdk/python/reencrypt_resource.py`(旧私钥
+解、新公钥重加密,支持 `--check` 校验)。
 
 ## 说明
 
-- 密钥环只用于**解密**;加密在客户端进行,新资源请用新公钥加密。
-- 密钥可以是 PKCS#8 或 PKCS#1 的 PEM 格式;主密钥的公钥由其私钥推导,无需单独配置。
-- 仅当较靠前的密钥解密失败时,才会对每把额外密钥多做一次 RSA 运算,因此轮转期间
-  保留少数几把密钥的开销可忽略。
+- 密钥环只用于**解密**;加密在客户端进行,新资源请用最新公钥加密。
+- 自管理密钥由 KBS 生成并以 `0600` 权限保存在 `key_dir`(目录 `0700`);文件名形如
+  `mkey-<纳秒时间戳>.pem`,最新者为当前主密钥。
+- 主密钥的公钥由其私钥推导,无需单独配置或分发私钥。
+- 仅当较靠前的密钥解密失败时,才会对每把额外密钥多做一次 RSA 运算,因此轮转过渡期
+  保留少量旧密钥的开销可忽略。

--- a/kbs/docs/resource_storage_backend.md
+++ b/kbs/docs/resource_storage_backend.md
@@ -56,49 +56,66 @@ returned as plaintext).
 This backend is guarded by the Cargo feature `encrypted-local-fs`. Enable it
 when building KBS to use this backend.
 
-Config example:
+**Key management: KBS-managed (default) or bring-your-own**
+
+By default KBS manages the RSA keys itself, so operators never have to generate
+keys or edit config to rotate them:
+
+- On first start KBS generates an RSA key pair into the managed key store
+  (`key_dir`, default `/opt/confidential-containers/kbs/resource-keys`).
+- Clients fetch the current public key from `GET /kbs/v0/resource/pubkey` and
+  encrypt resources with it.
+- A single `POST /kbs/v0/resource/rotate` performs the entire rotation
+  server-side (see below).
 
 ```
 [[plugins]]
 name = "resource"
 type = "EncryptedLocalFs"
 dir_path = "/opt/confidential-containers/kbs/repository"
-private_key_path = "/etc/kbs/resource-private.pem"
+# key_dir defaults to /opt/confidential-containers/kbs/resource-keys; set it to override.
 ```
 
-**Key rotation**
+Alternatively, bring your own keys: set `private_key_path` (primary / re-wrap
+target), and optionally `private_key_dir` / `private_key_paths` for additional
+decryption keys. Bring-your-own keys can also coexist with a managed `key_dir`
+as decrypt-only sources (useful when migrating to managed keys).
+
+```
+[[plugins]]
+name = "resource"
+type = "EncryptedLocalFs"
+dir_path = "/opt/confidential-containers/kbs/repository"
+private_key_path = "/etc/kbs/resource-keys/primary.pem"
+private_key_dir  = "/etc/kbs/resource-keys/archive"
+```
+
+**Key rotation (admin API)**
 
 Because the CEK is wrapped with an RSA public key, decryption requires the
-matching private key. `EncryptedLocalFs` is built so a key can be rotated with
-**no downtime, no manual file migration, and no config edits**, driven entirely
-through the admin API:
+matching private key. KBS holds a *ring* of decryption keys (the newest managed
+key, or the bring-your-own primary, is tried first and is the re-wrap target),
+so resources encrypted with an old key keep working while a new key is adopted.
+Rotation runs with **no downtime, no manual file migration, and no config
+edits**, through admin-authenticated endpoints:
 
-- **Key ring.** KBS holds multiple decryption keys. `private_key_path` is the
-  *primary* key (tried first, and the target of re-wrapping). `private_key_dir`
-  is a directory of additional `*.pem` keys, and `private_key_paths` lists extra
-  keys by path. On read each key is tried in turn, so resources encrypted with
-  an old key keep working while a new key is in use.
-- **Hot reload.** `POST /kbs/v0/resource/reload` (admin authenticated) re-reads
-  the primary key file, re-scans `private_key_dir`, and re-reads
-  `private_key_paths`, swapping the key ring atomically without a restart.
-- **Server-side re-wrap.** `POST /kbs/v0/resource/rewrap` (admin authenticated)
-  walks every stored resource and re-wraps its CEK to the **primary** key's
-  public key (derived from the primary private key). Only the `enc_key`/`alg`
-  envelope fields change; the AES-256-GCM ciphertext is untouched. Resources
-  already on the primary key, and plaintext resources, are skipped. The response
-  is a JSON report `{ "total", "rewrapped", "skipped", "failed" }`.
+- **One-shot rotate (managed keys).** `POST /kbs/v0/resource/rotate` generates a
+  new key pair, re-wraps every resource onto it, and retires the old key — all
+  server-side in one call. Returns `{ "public_key", "rewrapped", "skipped",
+  "failed", "retired_keys" }`. If any resource fails to re-wrap, the old key is
+  *kept* (not retired) so it stays decryptable. After rotation, read the new key
+  from `GET /kbs/v0/resource/pubkey`.
+- **Get public key.** `GET /kbs/v0/resource/pubkey` returns the current primary
+  public key (PEM), for clients to encrypt with.
+- **Hot reload.** `POST /kbs/v0/resource/reload` re-reads the configured keys
+  (`key_dir`, `private_key_path`, `private_key_dir`, `private_key_paths`) and
+  swaps the ring atomically without a restart.
+- **Server-side re-wrap.** `POST /kbs/v0/resource/rewrap` re-wraps every resource
+  onto the current primary key without generating a new one. Only the
+  `enc_key`/`alg` envelope fields change; the AES-256-GCM ciphertext is
+  untouched. Useful for bring-your-own-key rotations.
 
-```
-[[plugins]]
-name = "resource"
-type = "EncryptedLocalFs"
-dir_path = "/opt/confidential-containers/kbs/repository"
-private_key_path = "/etc/kbs/resource-keys/primary.pem"   # primary key (rewrap target, tried first)
-private_key_dir  = "/etc/kbs/resource-keys/archive"       # retired keys kept for decryption
-```
-
-At least one key must be configured (via any of the three options). For the full
-step-by-step rotation procedure, see
+For the full step-by-step procedures, see
 [EncryptedLocalFs Key Rotation](./encrypted_local_fs_key_rotation.md).
 `kbs/sdk/python/reencrypt_resource.py` remains available for out-of-band
 migration when the repository is not writable by KBS.

--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -43,6 +43,19 @@ pub trait StorageBackend: Send + Sync {
     async fn rewrap_resources(&self) -> Result<RewrapReport> {
         bail!("this storage backend does not support resource re-wrapping")
     }
+
+    /// Return the backend's current primary public key, PEM-encoded, for clients
+    /// that encrypt resources. Backends that do not manage keys return an error.
+    async fn current_public_key_pem(&self) -> Result<String> {
+        bail!("this storage backend does not expose a public key")
+    }
+
+    /// Rotate keys in one shot: generate a new key pair, re-wrap all resources
+    /// onto it, and retire the old keys. Backends that do not self-manage keys
+    /// return an error.
+    async fn rotate_keys(&self) -> Result<RotateReport> {
+        bail!("this storage backend does not support key rotation")
+    }
 }
 
 /// Outcome of a re-wrap (key rotation migration) pass over the repository.
@@ -57,6 +70,22 @@ pub struct RewrapReport {
     /// Resources that could not be re-wrapped (e.g. no configured key decrypts
     /// them).
     pub failed: usize,
+}
+
+/// Outcome of a one-shot `rotate` operation.
+#[derive(Debug, Default, Serialize)]
+pub struct RotateReport {
+    /// The new primary public key (PEM), ready for clients to encrypt with.
+    pub public_key: String,
+    /// Resources re-wrapped onto the new key.
+    pub rewrapped: usize,
+    /// Resources left untouched (plaintext, or already on the new key).
+    pub skipped: usize,
+    /// Resources that could not be re-wrapped; when non-zero the old keys are
+    /// kept (not retired) so those resources stay decryptable.
+    pub failed: usize,
+    /// Number of old managed keys retired after a clean migration.
+    pub retired_keys: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -194,6 +223,14 @@ impl ResourceStorage {
 
     pub(crate) async fn rewrap_resources(&self) -> Result<RewrapReport> {
         self.backend.rewrap_resources().await
+    }
+
+    pub(crate) async fn current_public_key_pem(&self) -> Result<String> {
+        self.backend.current_public_key_pem().await
+    }
+
+    pub(crate) async fn rotate_keys(&self) -> Result<RotateReport> {
+        self.backend.rotate_keys().await
     }
 }
 

--- a/kbs/src/plugins/implementations/resource/encrypted_local_fs.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_local_fs.rs
@@ -4,7 +4,7 @@
 
 use super::{
     local_fs::{LocalFs, LocalFsRepoDesc},
-    ResourceDesc, RewrapReport, StorageBackend,
+    ResourceDesc, RewrapReport, RotateReport, StorageBackend,
 };
 use aes_gcm::{
     aead::{generic_array::GenericArray, AeadInPlace, KeyInit},
@@ -12,6 +12,7 @@ use aes_gcm::{
 };
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
+use rsa::pkcs8::{EncodePublicKey, LineEnding};
 use rsa::sha2::Sha256;
 use rsa::{
     pkcs1::DecodeRsaPrivateKey, pkcs8::DecodePrivateKey, Oaep, Pkcs1v15Encrypt, RsaPrivateKey,
@@ -20,14 +21,26 @@ use rsa::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
-use std::path::PathBuf;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const ALG_RSA1_5: &str = "RSA1_5";
 const ALG_RSA_OAEP_256: &str = "RSA-OAEP-256";
 const AES_GCM_KEY_LEN: usize = 32;
 const AES_GCM_TAG_LEN: usize = 16;
 const AES_GCM_NONCE_LEN: usize = 12;
+
+/// Bit size of RSA key pairs generated and managed by KBS itself.
+const RSA_KEY_BITS: u32 = 3072;
+/// Default directory for the KBS-managed key store, used when the backend is
+/// enabled without any key configuration at all.
+const DEFAULT_MANAGED_KEY_DIR: &str = "/opt/confidential-containers/kbs/resource-keys";
+/// Filename prefix for KBS-managed keys: `mkey-<unix_nanos>.pem`. The numeric
+/// suffix orders generations, so the newest file is the current primary key.
+const MANAGED_KEY_PREFIX: &str = "mkey-";
+const MANAGED_KEY_EXT: &str = "pem";
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 struct Envelope {
@@ -47,20 +60,25 @@ struct Envelope {
 pub struct EncryptedLocalFsRepoDesc {
     #[serde(default)]
     pub dir_path: String,
-    /// Primary (current) RSA private key. Tried first when decrypting, and used
-    /// as the target key when re-wrapping resources. Its file is read fresh on
-    /// every key reload, so rotating the primary key is just a matter of
-    /// replacing this file and reloading.
+    /// Directory of the KBS-managed key store. When set (or when no key is
+    /// configured at all, in which case a default location is used), KBS owns
+    /// the RSA key pairs here: it generates one on first start, picks the newest
+    /// as the primary, and rotates them via the `rotate` API. Operators never
+    /// have to generate keys or edit config to rotate.
+    #[serde(default)]
+    pub key_dir: String,
+    /// Bring-your-own primary RSA private key. Used as the primary (re-wrap
+    /// target) only when no managed key store is in effect. Tried first when
+    /// decrypting in that case.
     #[serde(default)]
     pub private_key_path: String,
-    /// A directory of additional RSA private keys (`*.pem`). All keys found here
-    /// are kept available for decryption, so resources encrypted with a previous
-    /// key keep working during a rotation. Dropping a retired key into this
-    /// directory (and reloading) needs no config change or restart.
+    /// Bring-your-own directory of additional RSA private keys (`*.pem`), kept
+    /// available for decryption so resources encrypted with a previous key keep
+    /// working. Also serves as a decrypt-only source when migrating to a managed
+    /// key store.
     #[serde(default)]
     pub private_key_dir: String,
-    /// Additional RSA private keys given as explicit paths. Equivalent to
-    /// `private_key_dir` but for keys that live outside a single directory.
+    /// Additional bring-your-own RSA private keys given as explicit paths.
     #[serde(default)]
     pub private_key_paths: Vec<String>,
 }
@@ -68,9 +86,20 @@ pub struct EncryptedLocalFsRepoDesc {
 /// The set of places keys are loaded from. Held so the key ring can be rebuilt
 /// on a hot reload without re-reading the whole KBS config.
 struct KeySources {
+    /// KBS-managed key store directory. Empty in bring-your-own-key mode.
+    key_dir: String,
+    /// Bring-your-own primary key path. Empty in managed mode.
     primary_path: String,
-    dir: String,
+    /// Bring-your-own additional key directory.
+    byok_dir: String,
+    /// Bring-your-own additional key paths.
     extra_paths: Vec<String>,
+}
+
+impl KeySources {
+    fn managed(&self) -> bool {
+        !self.key_dir.is_empty()
+    }
 }
 
 /// A loaded, immutable snapshot of the decryption keys. Swapped atomically on
@@ -147,15 +176,78 @@ impl StorageBackend for EncryptedLocalFs {
         }
         Ok(report)
     }
+
+    async fn current_public_key_pem(&self) -> Result<String> {
+        let ring = self.ring_snapshot();
+        let public = ring
+            .primary_public
+            .clone()
+            .ok_or_else(|| anyhow!("no primary key available to export a public key"))?;
+        public
+            .to_public_key_pem(LineEnding::LF)
+            .context("encode primary public key as PEM")
+    }
+
+    async fn rotate_keys(&self) -> Result<RotateReport> {
+        if !self.sources.managed() {
+            bail!("key rotation requires a KBS-managed key store; set `key_dir` (or enable the backend with no bring-your-own key)");
+        }
+
+        // 1. Generate a new key pair; being the newest, it becomes the primary.
+        let new_key = Self::generate_managed_key(&self.sources.key_dir)?;
+        // 2. Reload so the new key is primary while old keys stay for decryption.
+        self.reload_keys().await?;
+        // 3. Re-wrap every resource onto the new primary key.
+        let rewrap = self.rewrap_resources().await?;
+        // 4. Retire the old managed keys, but only if everything migrated; if any
+        //    resource failed, keep the old keys so it stays decryptable.
+        let mut retired = 0;
+        if rewrap.failed == 0 {
+            retired = Self::retire_managed_keys_except(&self.sources.key_dir, &new_key)?;
+            self.reload_keys().await?;
+        }
+        let public_key = self.current_public_key_pem().await?;
+
+        Ok(RotateReport {
+            public_key,
+            rewrapped: rewrap.rewrapped,
+            skipped: rewrap.skipped,
+            failed: rewrap.failed,
+            retired_keys: retired,
+        })
+    }
 }
 
 impl EncryptedLocalFs {
     pub fn new(desc: &EncryptedLocalFsRepoDesc) -> Result<Self> {
+        let byok_empty = desc.private_key_path.is_empty()
+            && desc.private_key_dir.is_empty()
+            && desc.private_key_paths.is_empty();
+
+        // Managed mode is active when `key_dir` is set, or when no key is
+        // configured at all (then KBS manages keys at the default location).
+        let key_dir = if !desc.key_dir.is_empty() {
+            desc.key_dir.clone()
+        } else if byok_empty {
+            DEFAULT_MANAGED_KEY_DIR.to_string()
+        } else {
+            String::new()
+        };
+
         let sources = KeySources {
+            key_dir,
             primary_path: desc.private_key_path.clone(),
-            dir: desc.private_key_dir.clone(),
+            byok_dir: desc.private_key_dir.clone(),
             extra_paths: desc.private_key_paths.clone(),
         };
+
+        // In managed mode, generate the initial key pair on first start.
+        if sources.managed() {
+            Self::ensure_key_dir(&sources.key_dir)?;
+            if Self::scan_managed_keys(&sources.key_dir)?.is_empty() {
+                Self::generate_managed_key(&sources.key_dir)?;
+            }
+        }
 
         let ring = Self::load_ring(&sources)?;
 
@@ -174,8 +266,9 @@ impl EncryptedLocalFs {
     }
 
     /// Build the key ring from the configured sources. The primary key is first
-    /// (so it is tried first and is the re-wrap target), followed by the keys
-    /// from `private_key_dir` and `private_key_paths`. Duplicate files are
+    /// (tried first and the re-wrap target): the newest managed key in managed
+    /// mode, otherwise the bring-your-own `private_key_path`. Remaining managed
+    /// and bring-your-own keys follow, for decryption only. Duplicate files are
     /// loaded once.
     fn load_ring(sources: &KeySources) -> Result<KeyRing> {
         let mut ordered_paths: Vec<String> = Vec::new();
@@ -190,9 +283,21 @@ impl EncryptedLocalFs {
             }
         };
 
+        // Managed keys first, newest (current primary) at the front.
+        let managed = if sources.managed() {
+            Self::scan_managed_keys(&sources.key_dir)?
+        } else {
+            Vec::new()
+        };
+        let has_managed = !managed.is_empty();
+        for path in &managed {
+            push(path, &mut ordered_paths);
+        }
+
+        // Bring-your-own keys (primary, then dir, then explicit paths).
         push(&sources.primary_path, &mut ordered_paths);
-        if !sources.dir.is_empty() {
-            for path in Self::scan_key_dir(&sources.dir)? {
+        if !sources.byok_dir.is_empty() {
+            for path in Self::scan_pem_dir(&sources.byok_dir)? {
                 push(&path, &mut ordered_paths);
             }
         }
@@ -202,7 +307,7 @@ impl EncryptedLocalFs {
 
         if ordered_paths.is_empty() {
             bail!(
-                "at least one of `private_key_path`, `private_key_dir`, or `private_key_paths` is required for encrypted local fs backend"
+                "no keys available: set `key_dir` for KBS-managed keys, or a `private_key_path` / `private_key_dir` / `private_key_paths`"
             );
         }
 
@@ -211,12 +316,13 @@ impl EncryptedLocalFs {
             .map(|p| Self::load_private_key(p))
             .collect::<Result<Vec<_>>>()?;
 
-        // The primary public key (re-wrap target) is the public part of the
-        // primary private key, which is `keys[0]` iff a primary path is set.
-        let primary_public = if sources.primary_path.is_empty() {
-            None
-        } else {
+        // The primary public key (re-wrap / rotate target) is the public part of
+        // `keys[0]`, which is the newest managed key, or the bring-your-own
+        // primary. It is `None` only when neither exists (decrypt-only keys).
+        let primary_public = if has_managed || !sources.primary_path.is_empty() {
             Some(keys[0].to_public_key())
+        } else {
+            None
         };
 
         Ok(KeyRing {
@@ -225,21 +331,96 @@ impl EncryptedLocalFs {
         })
     }
 
-    /// Return the `*.pem` files in a key directory, sorted for a deterministic
-    /// load order.
-    fn scan_key_dir(dir: &str) -> Result<Vec<String>> {
+    /// Return the `*.pem` files in a directory, name-sorted for determinism.
+    fn scan_pem_dir(dir: &str) -> Result<Vec<String>> {
         let mut paths = Vec::new();
         let entries = fs::read_dir(dir).with_context(|| format!("read private key dir `{dir}`"))?;
         for entry in entries {
             let path = entry
                 .with_context(|| format!("read entry in `{dir}`"))?
                 .path();
-            if path.extension().and_then(|e| e.to_str()) == Some("pem") && path.is_file() {
+            if path.extension().and_then(|e| e.to_str()) == Some(MANAGED_KEY_EXT) && path.is_file()
+            {
                 paths.push(path.to_string_lossy().into_owned());
             }
         }
         paths.sort();
         Ok(paths)
+    }
+
+    /// Managed key files (`mkey-<nanos>.pem`) in the store, sorted newest-first
+    /// by the embedded generation timestamp.
+    fn scan_managed_keys(dir: &str) -> Result<Vec<String>> {
+        let mut keys: Vec<(u128, String)> = Vec::new();
+        let entries = fs::read_dir(dir).with_context(|| format!("read managed key dir `{dir}`"))?;
+        for entry in entries {
+            let path = entry
+                .with_context(|| format!("read entry in `{dir}`"))?
+                .path();
+            if !path.is_file() {
+                continue;
+            }
+            if let Some(nanos) = Self::managed_key_generation(&path) {
+                keys.push((nanos, path.to_string_lossy().into_owned()));
+            }
+        }
+        // Newest first.
+        keys.sort_by(|a, b| b.0.cmp(&a.0));
+        Ok(keys.into_iter().map(|(_, p)| p).collect())
+    }
+
+    /// Parse the generation timestamp out of a managed key filename, or `None`
+    /// if the file is not a managed key.
+    fn managed_key_generation(path: &Path) -> Option<u128> {
+        let name = path.file_name()?.to_str()?;
+        let rest = name.strip_prefix(MANAGED_KEY_PREFIX)?;
+        let stem = rest.strip_suffix(&format!(".{MANAGED_KEY_EXT}"))?;
+        stem.parse::<u128>().ok()
+    }
+
+    /// Create the managed key directory (private, `0700`) if it does not exist.
+    fn ensure_key_dir(dir: &str) -> Result<()> {
+        if !Path::new(dir).exists() {
+            fs::create_dir_all(dir).with_context(|| format!("create managed key dir `{dir}`"))?;
+            fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
+                .with_context(|| format!("set permissions on `{dir}`"))?;
+        }
+        Ok(())
+    }
+
+    /// Generate a fresh RSA key pair and persist it (private, `0600`) into the
+    /// managed key directory. Returns the new key's path.
+    fn generate_managed_key(dir: &str) -> Result<PathBuf> {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("system clock before unix epoch")?
+            .as_nanos();
+        let path = Path::new(dir).join(format!("{MANAGED_KEY_PREFIX}{nanos}.{MANAGED_KEY_EXT}"));
+
+        // openssl generates RSA keys natively (fast); the PEM is then loadable by
+        // the `rsa` crate for decryption.
+        let rsa = openssl::rsa::Rsa::generate(RSA_KEY_BITS).context("generate RSA key pair")?;
+        let pem = rsa
+            .private_key_to_pem()
+            .context("encode RSA private key PEM")?;
+        fs::write(&path, pem).with_context(|| format!("write managed key `{path:?}`"))?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("set permissions on `{path:?}`"))?;
+        Ok(path)
+    }
+
+    /// Delete every managed key except `keep`. Returns the number removed.
+    fn retire_managed_keys_except(dir: &str, keep: &Path) -> Result<usize> {
+        let keep = fs::canonicalize(keep).unwrap_or_else(|_| keep.to_path_buf());
+        let mut removed = 0;
+        for path in Self::scan_managed_keys(dir)? {
+            let canonical = fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(&path));
+            if canonical != keep {
+                fs::remove_file(&path).with_context(|| format!("remove retired key `{path}`"))?;
+                removed += 1;
+            }
+        }
+        Ok(removed)
     }
 
     fn ring_snapshot(&self) -> Arc<KeyRing> {
@@ -441,6 +622,7 @@ mod tests {
     use base64::Engine;
     use openssl::rsa::Rsa;
     use rand::Rng;
+    use rsa::pkcs8::DecodePublicKey;
     use rsa::sha2::Sha256;
     use rsa::{BigUint, Oaep, Pkcs1v15Encrypt, RsaPublicKey};
     use tempfile::tempdir;
@@ -475,11 +657,7 @@ mod tests {
         .expect("create encrypted local fs backend")
     }
 
-    fn encrypt_envelope(
-        rsa: &Rsa<openssl::pkey::Private>,
-        alg: &str,
-        plaintext: &[u8],
-    ) -> Envelope {
+    fn encrypt_with_pub(rsa_pub: &RsaPublicKey, alg: &str, plaintext: &[u8]) -> Envelope {
         let mut rng = rand::thread_rng();
         let cek = Aes256Gcm::generate_key(&mut rng);
         let iv: [u8; 12] = rng.gen();
@@ -491,19 +669,13 @@ mod tests {
             .encrypt_in_place_detached(nonce, b"", &mut payload)
             .expect("encrypt");
 
-        let n = BigUint::from_bytes_be(rsa.n().to_vec().as_slice());
-        let e = BigUint::from_bytes_be(rsa.e().to_vec().as_slice());
-        let rsa_pub = RsaPublicKey::new(n, e).expect("build rsa public key");
         let encrypted_key = match alg {
             ALG_RSA1_5 => rsa_pub
                 .encrypt(&mut rng, Pkcs1v15Encrypt, cek.as_slice())
                 .expect("rsa1_5 encrypt cek"),
-            ALG_RSA_OAEP_256 => {
-                let padding = Oaep::new::<Sha256>();
-                rsa_pub
-                    .encrypt(&mut rng, padding, cek.as_slice())
-                    .expect("rsa-oaep encrypt cek")
-            }
+            ALG_RSA_OAEP_256 => rsa_pub
+                .encrypt(&mut rng, Oaep::new::<Sha256>(), cek.as_slice())
+                .expect("rsa-oaep encrypt cek"),
             _ => unreachable!(),
         };
 
@@ -514,6 +686,27 @@ mod tests {
             ciphertext: STANDARD.encode(payload),
             tag: STANDARD.encode(tag),
         }
+    }
+
+    fn encrypt_envelope(
+        rsa: &Rsa<openssl::pkey::Private>,
+        alg: &str,
+        plaintext: &[u8],
+    ) -> Envelope {
+        let n = BigUint::from_bytes_be(rsa.n().to_vec().as_slice());
+        let e = BigUint::from_bytes_be(rsa.e().to_vec().as_slice());
+        let rsa_pub = RsaPublicKey::new(n, e).expect("build rsa public key");
+        encrypt_with_pub(&rsa_pub, alg, plaintext)
+    }
+
+    /// Encrypt a resource for whatever public key the backend currently exposes.
+    async fn encrypt_for_backend(backend: &EncryptedLocalFs, plaintext: &[u8]) -> Envelope {
+        let pem = backend
+            .current_public_key_pem()
+            .await
+            .expect("backend public key");
+        let pubkey = RsaPublicKey::from_public_key_pem(&pem).expect("parse pubkey pem");
+        encrypt_with_pub(&pubkey, ALG_RSA_OAEP_256, plaintext)
     }
 
     #[tokio::test]
@@ -682,18 +875,105 @@ mod tests {
         assert_eq!(data, TEST_DATA);
     }
 
-    #[test]
-    fn rejects_empty_key_configuration() {
-        let tmp_dir = tempdir().unwrap();
-        let err = EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
+    fn build_managed_backend(tmp_dir: &tempfile::TempDir) -> EncryptedLocalFs {
+        EncryptedLocalFs::new(&EncryptedLocalFsRepoDesc {
             dir_path: tmp_dir.path().to_string_lossy().into(),
-            private_key_path: String::new(),
-            private_key_paths: vec![],
+            key_dir: tmp_dir.path().join("keys").to_string_lossy().into(),
             ..Default::default()
         })
-        .err()
-        .expect("a backend with no keys must fail to initialize");
-        assert!(err.to_string().contains("private_key"));
+        .expect("create managed backend")
+    }
+
+    fn managed_key_count(key_dir: &std::path::Path) -> usize {
+        std::fs::read_dir(key_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("pem"))
+            .count()
+    }
+
+    // With a managed key store and no operator-provided key, KBS generates its
+    // own key pair on start, exposes the public key, and round-trips resources.
+    #[tokio::test]
+    async fn managed_mode_auto_generates_key() {
+        let tmp_dir = tempdir().unwrap();
+        let backend = build_managed_backend(&tmp_dir);
+
+        let pem = backend.current_public_key_pem().await.expect("pubkey");
+        assert!(pem.contains("BEGIN PUBLIC KEY"));
+        assert_eq!(managed_key_count(&tmp_dir.path().join("keys")), 1);
+
+        let desc = resource_desc("managed");
+        let env = encrypt_for_backend(&backend, TEST_DATA).await;
+        backend
+            .write_secret_resource(desc.clone(), &serde_json::to_vec(&env).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.read_secret_resource(desc).await.expect("decrypt"),
+            TEST_DATA
+        );
+    }
+
+    // One-shot rotate: generate a new key, re-wrap resources onto it, retire the
+    // old key. The resource stays readable, the public key changes, and a freshly
+    // loaded backend (only the new key on disk) can still decrypt it.
+    #[tokio::test]
+    async fn rotate_generates_rewraps_and_retires() {
+        let tmp_dir = tempdir().unwrap();
+        let key_dir = tmp_dir.path().join("keys");
+        let backend = build_managed_backend(&tmp_dir);
+
+        let desc = resource_desc("secret");
+        let env = encrypt_for_backend(&backend, TEST_DATA).await;
+        backend
+            .write_secret_resource(desc.clone(), &serde_json::to_vec(&env).unwrap())
+            .await
+            .unwrap();
+        let pubkey_before = backend.current_public_key_pem().await.unwrap();
+
+        let report = backend.rotate_keys().await.expect("rotate");
+        assert_eq!(report.failed, 0);
+        assert_eq!(report.rewrapped, 1);
+        assert_eq!(report.retired_keys, 1, "the previous key is retired");
+        assert!(report.public_key.contains("BEGIN PUBLIC KEY"));
+
+        let pubkey_after = backend.current_public_key_pem().await.unwrap();
+        assert_ne!(pubkey_before, pubkey_after, "rotation changes the key");
+        assert_eq!(report.public_key, pubkey_after);
+        assert_eq!(managed_key_count(&key_dir), 1, "old key retired");
+
+        assert_eq!(
+            backend
+                .read_secret_resource(desc.clone())
+                .await
+                .expect("after rotate"),
+            TEST_DATA
+        );
+
+        let reopened = build_managed_backend(&tmp_dir);
+        assert_eq!(
+            reopened
+                .read_secret_resource(desc)
+                .await
+                .expect("reopened decrypt"),
+            TEST_DATA
+        );
+    }
+
+    // Rotation is only meaningful with a managed key store; bring-your-own mode
+    // must reject it.
+    #[tokio::test]
+    async fn rotate_requires_managed_mode() {
+        let tmp_dir = tempdir().unwrap();
+        let rsa = Rsa::generate(2048).unwrap();
+        let backend = build_backend(&tmp_dir, &rsa);
+
+        let err = backend
+            .rotate_keys()
+            .await
+            .expect_err("bring-your-own mode cannot rotate");
+        assert!(err.to_string().contains("managed"));
     }
 
     // A backend can pick up keys from `private_key_dir`, and `reload_keys`

--- a/kbs/src/plugins/implementations/resource/mod.rs
+++ b/kbs/src/plugins/implementations/resource/mod.rs
@@ -45,10 +45,22 @@ impl ClientPlugin for ResourceStorage {
                 let report = self.rewrap_resources().await?;
                 serde_json::to_vec(&report).context("serialize rewrap report")
             }
+            // One-shot key rotation: generate a new key, re-wrap all resources,
+            // retire the old keys, and return the new public key.
+            "POST" if resource_desc == "rotate" => {
+                let report = self.rotate_keys().await?;
+                serde_json::to_vec(&report).context("serialize rotate report")
+            }
             "POST" => {
                 let resource_description = ResourceDesc::try_from(resource_desc)?;
                 self.set_secret_resource(resource_description, body).await?;
                 Ok(vec![])
+            }
+            // Return the current primary public key (PEM) for clients to encrypt
+            // with. Admin authenticated (see `validate_auth`).
+            "GET" if resource_desc == "pubkey" => {
+                let pem = self.current_public_key_pem().await?;
+                Ok(pem.into_bytes())
             }
             "GET" => {
                 // Check if this is a list request based on path pattern
@@ -77,10 +89,15 @@ impl ClientPlugin for ResourceStorage {
         &self,
         _body: &[u8],
         _query: &str,
-        _path: &str,
+        path: &str,
         method: &Method,
     ) -> Result<bool> {
+        // Mutating operations and the admin-only public-key read require admin
+        // auth. Resource reads (other GETs) are gated by attestation instead.
         if method.as_str() == "POST" || method.as_str() == "DELETE" {
+            return Ok(true);
+        }
+        if method.as_str() == "GET" && path == "/pubkey" {
             return Ok(true);
         }
 


### PR DESCRIPTION
## Summary

Builds on the EncryptedLocalFs decryption key ring to let **KBS own the RSA keys
end-to-end**, so operators never have to generate keys or edit config to rotate.

- **Managed key store**: when `key_dir` is set (or no key is configured at all,
  using a default location), KBS generates an RSA key pair on first start and
  treats the newest key in the store as the primary. Bring-your-own keys still
  work and can coexist as decrypt-only sources.
- **One-shot rotate**: `POST /kbs/v0/resource/rotate` generates a new key pair,
  re-wraps every resource onto it, and retires the old key in a single call.
  Returns `{ public_key, rewrapped, skipped, failed, retired_keys }`. If any
  resource fails to re-wrap, the old key is kept so it stays decryptable.
- **Public key read**: `GET /kbs/v0/resource/pubkey` returns the current primary
  public key (PEM) for clients to encrypt with (admin authenticated).

Keys are generated with OpenSSL (fast, native) and stored `0600` in a `0700`
directory, named `mkey-<nanos>.pem` so the newest file is the current key.

Rotation workflow becomes a single call: `POST .../rotate` → then `GET .../pubkey`
to fetch the new key. No restart, no scripts, no config edits, client unaffected.

## Compatibility & safety

- Backward compatible: bring-your-own `private_key_path` / `private_key_dir` /
  `private_key_paths` and the `reload` / `rewrap` endpoints from the prior change
  still work; the envelope format is unchanged.
- Admin authenticated: `rotate` (POST), `pubkey` (GET) and the existing mutating
  endpoints all require admin auth.
- A wrong key is always rejected (RSA padding, CEK length, or AES-GCM tag).

## Test plan

- [x] `cargo test -p kbs --no-default-features --features encrypted-local-fs` — 12 tests pass, incl. managed-mode auto-generation, one-shot rotate (generate + rewrap + retire, reopened backend still decrypts), and rotate-requires-managed-mode
- [x] `cargo fmt -p kbs -- --check` clean; `cargo clippy` clean for the changed files
- [ ] CI (`rust-check.yml`)