### PR TITLE
Release v1.8.5 RPM

### DIFF
--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -212,6 +212,46 @@ This is also called "Repository" in old versions. The properties to be configure
 |----------|--------|-------------------------------------------------------------------------------|----------|-----------|
 | `type`   | String | The resource repository type. Valid values: `LocalFs`, `EncryptedLocalFs`, `Aliyun`, `ExternalKms` | Yes      | `LocalFs` |
 
+Resource plugin configuration can also be overridden with environment
+variables. Environment variables are applied after the configuration file is
+loaded, so they take precedence over the `[[plugins]]` section. If the config
+file does not contain a `resource` plugin, `KBS_RESOURCE_STORAGE_TYPE` must be
+set to create one from environment variables.
+
+| Environment Variable | Description |
+|----------------------|-------------|
+| `KBS_RESOURCE_STORAGE_TYPE` | Replaces or creates the resource backend type. Supported values: `LocalFs`, `EncryptedLocalFs`, `Aliyun`, `ExternalKms`. |
+| `KBS_RESOURCE_STORAGE_DIR_PATH` | Overrides `dir_path` for `LocalFs` and `EncryptedLocalFs`. |
+| `KBS_RESOURCE_STORAGE_PRIVATE_KEY_PATH` | Overrides `private_key_path` for `EncryptedLocalFs`. |
+| `KBS_RESOURCE_STORAGE_LIBRARY_PATH` | Overrides `library_path` for `ExternalKms`. |
+| `KBS_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE` | Overrides `initial_buffer_size` for `ExternalKms`. |
+| `KBS_RESOURCE_STORAGE_MAX_BUFFER_SIZE` | Overrides `max_buffer_size` for `ExternalKms`. |
+| `KBS_RESOURCE_STORAGE_ERROR_BUFFER_SIZE` | Overrides `error_buffer_size` for `ExternalKms`. |
+
+Aliyun backend fields can be overridden with the following variables:
+
+| Environment Variable | Description |
+|----------------------|-------------|
+| `KBS_RESOURCE_STORAGE_ALIYUN_CLIENT_KEY` | Overrides `client_key`. |
+| `KBS_RESOURCE_STORAGE_ALIYUN_KMS_INSTANCE_ID` | Overrides `kms_instance_id`. |
+| `KBS_RESOURCE_STORAGE_ALIYUN_PASSWORD` | Overrides `password`. |
+| `KBS_RESOURCE_STORAGE_ALIYUN_CERT_PEM` | Overrides `cert_pem`. |
+| `KBS_RESOURCE_STORAGE_ALIYUN_ACCESS_KEY_ID` | Overrides `access_key_id`. |
+| `KBS_RESOURCE_STORAGE_ALIYUN_ACCESS_KEY_SECRET` | Overrides `access_key_secret`. |
+| `KBS_RESOURCE_STORAGE_ALIYUN_REGION_ID` | Overrides `region_id`. |
+| `KBS_RESOURCE_STORAGE_ALIYUN_ENDPOINT` | Overrides `endpoint`. |
+| `KBS_RESOURCE_STORAGE_ALIYUN_INSECURE_SKIP_TLS_VERIFY` | Overrides `insecure_skip_tls_verify`; use `true` or `false`. |
+
+Example:
+
+```shell
+export KBS_RESOURCE_STORAGE_TYPE=ExternalKms
+export KBS_RESOURCE_STORAGE_LIBRARY_PATH=/opt/trustee/kbs/libkms_provider.so
+export KBS_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE=4096
+export KBS_RESOURCE_STORAGE_MAX_BUFFER_SIZE=1048576
+export KBS_RESOURCE_STORAGE_ERROR_BUFFER_SIZE=1024
+```
+
 **`LocalFs` Properties**
 
 | Property   | Type   | Description                     | Required | Default                                             |

--- a/kbs/docs/resource_storage_backend.md
+++ b/kbs/docs/resource_storage_backend.md
@@ -8,6 +8,36 @@ The [KBS config file](./config.md)
 defines which resource backend KBS will use. The default is the local
 file system (`LocalFs`).
 
+The resource backend can also be overridden by environment variables. These
+variables are applied after the config file is loaded, so they take precedence
+over the `[[plugins]] name = "resource"` section. Set
+`KBS_RESOURCE_STORAGE_TYPE` to replace the backend type or to create the
+resource plugin when the config file does not define one.
+
+Common variables:
+
+| Environment Variable | Description |
+| -------------------- | ----------- |
+| `KBS_RESOURCE_STORAGE_TYPE` | Backend type: `LocalFs`, `EncryptedLocalFs`, `Aliyun`, or `ExternalKms`. |
+| `KBS_RESOURCE_STORAGE_DIR_PATH` | `dir_path` for `LocalFs` and `EncryptedLocalFs`. |
+| `KBS_RESOURCE_STORAGE_PRIVATE_KEY_PATH` | `private_key_path` for `EncryptedLocalFs`. |
+
+External KMS variables:
+
+| Environment Variable | Description |
+| -------------------- | ----------- |
+| `KBS_RESOURCE_STORAGE_LIBRARY_PATH` | Provider shared library path. |
+| `KBS_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE` | Initial secret buffer size in bytes. |
+| `KBS_RESOURCE_STORAGE_MAX_BUFFER_SIZE` | Maximum secret buffer size in bytes. |
+| `KBS_RESOURCE_STORAGE_ERROR_BUFFER_SIZE` | Error buffer size in bytes. |
+
+Aliyun variables use the `KBS_RESOURCE_STORAGE_ALIYUN_` prefix for backend
+fields such as `ENDPOINT`, `CERT_PEM`, `CLIENT_KEY`, `KMS_INSTANCE_ID`,
+`PASSWORD`, `ACCESS_KEY_ID`, `ACCESS_KEY_SECRET`, `REGION_ID`, and
+`INSECURE_SKIP_TLS_VERIFY`. The existing `ALIYUN_KMS_ACCESS_KEY_ID`,
+`ALIYUN_KMS_ACCESS_KEY_SECRET`, and `ALIYUN_KMS_REGION_ID` variables are still
+supported as AccessKey fallback credentials when those fields are omitted.
+
 ### Local File System Backend
 
 With the local file system backend default implementation, each resource

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::admin::config::{AdminConfig, DEFAULT_INSECURE_API};
-use crate::plugins::PluginsConfig;
+use crate::plugins::{PluginsConfig, RepositoryConfig};
 use crate::policy_engine::PolicyEngineConfig;
 use crate::token::AttestationTokenVerifierConfig;
 use anyhow::anyhow;
@@ -75,6 +75,30 @@ pub struct KbsConfig {
     pub plugins: Vec<PluginsConfig>,
 }
 
+impl KbsConfig {
+    fn apply_resource_plugin_env_overrides(&mut self) -> anyhow::Result<()> {
+        if !RepositoryConfig::env_overrides_present() {
+            return Ok(());
+        }
+
+        let mut found_resource_plugin = false;
+        for plugin in &mut self.plugins {
+            if let PluginsConfig::ResourceStorage(repository_config) = plugin {
+                repository_config.apply_env_overrides()?;
+                found_resource_plugin = true;
+            }
+        }
+
+        if !found_resource_plugin {
+            let repository_config = RepositoryConfig::from_env_overrides()?;
+            self.plugins
+                .push(PluginsConfig::ResourceStorage(repository_config));
+        }
+
+        Ok(())
+    }
+}
+
 impl TryFrom<&Path> for KbsConfig {
     type Error = anyhow::Error;
 
@@ -93,8 +117,11 @@ impl TryFrom<&Path> for KbsConfig {
             .add_source(File::with_name(config_path.to_str().unwrap()))
             .build()?;
 
-        c.try_deserialize()
-            .map_err(|e| anyhow!("invalid config: {}", e.to_string()))
+        let mut kbs_config: Self = c
+            .try_deserialize()
+            .map_err(|e| anyhow!("invalid config: {}", e.to_string()))?;
+        kbs_config.apply_resource_plugin_env_overrides()?;
+        Ok(kbs_config)
     }
 }
 
@@ -110,7 +137,11 @@ pub struct Cli {
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::{
+        env,
+        ffi::OsString,
+        path::{Path, PathBuf},
+    };
 
     use crate::{
         admin::config::AdminConfig,
@@ -120,7 +151,8 @@ mod tests {
         },
         plugins::{
             implementations::{
-                resource::local_fs::LocalFsRepoDesc, RepositoryConfig, SampleConfig,
+                resource::{external_kms::ExternalKmsBackendConfig, local_fs::LocalFsRepoDesc},
+                RepositoryConfig, SampleConfig,
             },
             PluginsConfig,
         },
@@ -139,6 +171,56 @@ mod tests {
     use reference_value_provider_service::storage::{local_fs, ReferenceValueStorageConfig};
 
     use rstest::rstest;
+    use serial_test::serial;
+
+    const RESOURCE_STORAGE_ENV_VARS: &[&str] = &[
+        "KBS_RESOURCE_STORAGE_TYPE",
+        "KBS_RESOURCE_STORAGE_DIR_PATH",
+        "KBS_RESOURCE_STORAGE_PRIVATE_KEY_PATH",
+        "KBS_RESOURCE_STORAGE_LIBRARY_PATH",
+        "KBS_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE",
+        "KBS_RESOURCE_STORAGE_MAX_BUFFER_SIZE",
+        "KBS_RESOURCE_STORAGE_ERROR_BUFFER_SIZE",
+        "KBS_RESOURCE_STORAGE_ALIYUN_CLIENT_KEY",
+        "KBS_RESOURCE_STORAGE_ALIYUN_KMS_INSTANCE_ID",
+        "KBS_RESOURCE_STORAGE_ALIYUN_PASSWORD",
+        "KBS_RESOURCE_STORAGE_ALIYUN_CERT_PEM",
+        "KBS_RESOURCE_STORAGE_ALIYUN_ACCESS_KEY_ID",
+        "KBS_RESOURCE_STORAGE_ALIYUN_ACCESS_KEY_SECRET",
+        "KBS_RESOURCE_STORAGE_ALIYUN_REGION_ID",
+        "KBS_RESOURCE_STORAGE_ALIYUN_ENDPOINT",
+        "KBS_RESOURCE_STORAGE_ALIYUN_INSECURE_SKIP_TLS_VERIFY",
+    ];
+
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl EnvGuard {
+        fn clear() -> Self {
+            let saved = RESOURCE_STORAGE_ENV_VARS
+                .iter()
+                .map(|name| {
+                    let value = env::var_os(name);
+                    env::remove_var(name);
+                    (*name, value)
+                })
+                .collect();
+
+            Self { saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in &self.saved {
+                match value {
+                    Some(value) => env::set_var(name, value),
+                    None => env::remove_var(name),
+                }
+            }
+        }
+    }
 
     #[rstest]
     #[case("test_data/configs/coco-as-grpc-1.toml",         KbsConfig {
@@ -360,8 +442,87 @@ mod tests {
             },
         ))],
     })]
+    #[serial]
     fn read_config(#[case] config_path: &str, #[case] expected: KbsConfig) {
+        let _env = EnvGuard::clear();
         let config = KbsConfig::try_from(Path::new(config_path)).unwrap();
         assert_eq!(config, expected, "case {config_path}");
+    }
+
+    #[test]
+    #[serial]
+    fn resource_storage_env_overrides_existing_local_fs() {
+        let _env = EnvGuard::clear();
+        env::set_var("KBS_RESOURCE_STORAGE_DIR_PATH", "/env/kbs-resource");
+
+        let config =
+            KbsConfig::try_from(Path::new("test_data/configs/coco-as-grpc-1.toml")).unwrap();
+
+        assert_eq!(
+            config.plugins[1],
+            PluginsConfig::ResourceStorage(RepositoryConfig::LocalFs(LocalFsRepoDesc {
+                dir_path: "/env/kbs-resource".into(),
+            }))
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn resource_storage_env_replaces_existing_backend_type() {
+        let _env = EnvGuard::clear();
+        env::set_var("KBS_RESOURCE_STORAGE_TYPE", "ExternalKms");
+        env::set_var("KBS_RESOURCE_STORAGE_LIBRARY_PATH", "/opt/kms/libcustom.so");
+        env::set_var("KBS_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE", "128");
+        env::set_var("KBS_RESOURCE_STORAGE_MAX_BUFFER_SIZE", "8192");
+        env::set_var("KBS_RESOURCE_STORAGE_ERROR_BUFFER_SIZE", "256");
+
+        let config =
+            KbsConfig::try_from(Path::new("test_data/configs/coco-as-grpc-1.toml")).unwrap();
+
+        assert_eq!(
+            config.plugins[1],
+            PluginsConfig::ResourceStorage(RepositoryConfig::ExternalKms(
+                ExternalKmsBackendConfig {
+                    library_path: "/opt/kms/libcustom.so".into(),
+                    initial_buffer_size: 128,
+                    max_buffer_size: 8192,
+                    error_buffer_size: 256,
+                }
+            ))
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn resource_storage_env_adds_resource_plugin() {
+        let _env = EnvGuard::clear();
+        env::set_var("KBS_RESOURCE_STORAGE_TYPE", "LocalFs");
+        env::set_var("KBS_RESOURCE_STORAGE_DIR_PATH", "/env/kbs-resource");
+
+        let config =
+            KbsConfig::try_from(Path::new("test_data/configs/coco-as-grpc-3.toml")).unwrap();
+
+        assert_eq!(
+            config.plugins,
+            vec![PluginsConfig::ResourceStorage(RepositoryConfig::LocalFs(
+                LocalFsRepoDesc {
+                    dir_path: "/env/kbs-resource".into(),
+                }
+            ))]
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn resource_storage_env_requires_type_when_adding_plugin() {
+        let _env = EnvGuard::clear();
+        env::set_var("KBS_RESOURCE_STORAGE_DIR_PATH", "/env/kbs-resource");
+
+        let err = KbsConfig::try_from(Path::new("test_data/configs/coco-as-grpc-3.toml"))
+            .expect_err("resource storage type should be required");
+
+        assert!(err
+            .to_string()
+            .contains("KBS_RESOURCE_STORAGE_TYPE is required"));
     }
 }

--- a/kbs/src/plugins/implementations/resource/aliyun_kms.rs
+++ b/kbs/src/plugins/implementations/resource/aliyun_kms.rs
@@ -8,7 +8,18 @@ use derivative::Derivative;
 use kms::{plugins::aliyun::AliyunKmsClient, Annotations, Getter};
 use log::info;
 use serde::Deserialize;
-use std::env;
+use std::{env, fmt::Display, str::FromStr};
+
+const ENV_ALIYUN_CLIENT_KEY: &str = "KBS_RESOURCE_STORAGE_ALIYUN_CLIENT_KEY";
+const ENV_ALIYUN_KMS_INSTANCE_ID: &str = "KBS_RESOURCE_STORAGE_ALIYUN_KMS_INSTANCE_ID";
+const ENV_ALIYUN_PASSWORD: &str = "KBS_RESOURCE_STORAGE_ALIYUN_PASSWORD";
+const ENV_ALIYUN_CERT_PEM: &str = "KBS_RESOURCE_STORAGE_ALIYUN_CERT_PEM";
+const ENV_ALIYUN_ACCESS_KEY_ID: &str = "KBS_RESOURCE_STORAGE_ALIYUN_ACCESS_KEY_ID";
+const ENV_ALIYUN_ACCESS_KEY_SECRET: &str = "KBS_RESOURCE_STORAGE_ALIYUN_ACCESS_KEY_SECRET";
+const ENV_ALIYUN_REGION_ID: &str = "KBS_RESOURCE_STORAGE_ALIYUN_REGION_ID";
+const ENV_ALIYUN_ENDPOINT: &str = "KBS_RESOURCE_STORAGE_ALIYUN_ENDPOINT";
+const ENV_ALIYUN_INSECURE_SKIP_TLS_VERIFY: &str =
+    "KBS_RESOURCE_STORAGE_ALIYUN_INSECURE_SKIP_TLS_VERIFY";
 
 #[derive(Derivative, Deserialize, Clone, PartialEq)]
 #[derivative(Debug)]
@@ -27,6 +38,87 @@ pub struct AliyunKmsBackendConfig {
     endpoint: Option<String>,
     #[serde(default)]
     insecure_skip_tls_verify: bool,
+}
+
+impl Default for AliyunKmsBackendConfig {
+    fn default() -> Self {
+        Self {
+            client_key: None,
+            kms_instance_id: None,
+            password: None,
+            cert_pem: None,
+            access_key_id: None,
+            access_key_secret: None,
+            region_id: None,
+            endpoint: None,
+            insecure_skip_tls_verify: false,
+        }
+    }
+}
+
+impl AliyunKmsBackendConfig {
+    pub(crate) fn env_overrides_present() -> bool {
+        [
+            ENV_ALIYUN_CLIENT_KEY,
+            ENV_ALIYUN_KMS_INSTANCE_ID,
+            ENV_ALIYUN_PASSWORD,
+            ENV_ALIYUN_CERT_PEM,
+            ENV_ALIYUN_ACCESS_KEY_ID,
+            ENV_ALIYUN_ACCESS_KEY_SECRET,
+            ENV_ALIYUN_REGION_ID,
+            ENV_ALIYUN_ENDPOINT,
+            ENV_ALIYUN_INSECURE_SKIP_TLS_VERIFY,
+        ]
+        .into_iter()
+        .any(|name| env::var_os(name).is_some())
+    }
+
+    pub(crate) fn apply_env_overrides(&mut self) -> Result<()> {
+        set_optional_string_from_env(&mut self.client_key, ENV_ALIYUN_CLIENT_KEY)?;
+        set_optional_string_from_env(&mut self.kms_instance_id, ENV_ALIYUN_KMS_INSTANCE_ID)?;
+        set_optional_string_from_env(&mut self.password, ENV_ALIYUN_PASSWORD)?;
+        set_optional_string_from_env(&mut self.cert_pem, ENV_ALIYUN_CERT_PEM)?;
+        set_optional_string_from_env(&mut self.access_key_id, ENV_ALIYUN_ACCESS_KEY_ID)?;
+        set_optional_string_from_env(&mut self.access_key_secret, ENV_ALIYUN_ACCESS_KEY_SECRET)?;
+        set_optional_string_from_env(&mut self.region_id, ENV_ALIYUN_REGION_ID)?;
+        set_optional_string_from_env(&mut self.endpoint, ENV_ALIYUN_ENDPOINT)?;
+
+        if let Some(insecure_skip_tls_verify) = env_parse(ENV_ALIYUN_INSECURE_SKIP_TLS_VERIFY)? {
+            self.insecure_skip_tls_verify = insecure_skip_tls_verify;
+        }
+
+        Ok(())
+    }
+}
+
+fn set_optional_string_from_env(target: &mut Option<String>, name: &str) -> Result<()> {
+    if let Some(value) = env_string(name)? {
+        *target = Some(value);
+    }
+
+    Ok(())
+}
+
+fn env_string(name: &str) -> Result<Option<String>> {
+    match env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(err) => Err(anyhow!("read environment variable {name}: {err}")),
+    }
+}
+
+fn env_parse<T>(name: &str) -> Result<Option<T>>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    env_string(name)?
+        .map(|value| {
+            value
+                .parse::<T>()
+                .map_err(|err| anyhow!("parse environment variable {name}: {err}"))
+        })
+        .transpose()
 }
 
 pub struct AliyunKmsBackend {

--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -2,18 +2,33 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, OnceLock};
+use std::{
+    env,
+    fmt::{self, Display},
+    str::FromStr,
+    sync::{Arc, OnceLock},
+};
 
-use anyhow::{bail, Context, Error, Result};
+use anyhow::{anyhow, bail, Context, Error, Result};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 #[cfg(feature = "encrypted-local-fs")]
 use super::encrypted_local_fs;
 use super::local_fs;
 
 type RepositoryInstance = Arc<dyn StorageBackend>;
+
+const ENV_RESOURCE_STORAGE_TYPE: &str = "KBS_RESOURCE_STORAGE_TYPE";
+const ENV_RESOURCE_STORAGE_DIR_PATH: &str = "KBS_RESOURCE_STORAGE_DIR_PATH";
+
+#[cfg(feature = "encrypted-local-fs")]
+const ENV_RESOURCE_STORAGE_PRIVATE_KEY_PATH: &str = "KBS_RESOURCE_STORAGE_PRIVATE_KEY_PATH";
+
+const ENV_RESOURCE_STORAGE_LIBRARY_PATH: &str = "KBS_RESOURCE_STORAGE_LIBRARY_PATH";
+const ENV_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE: &str = "KBS_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE";
+const ENV_RESOURCE_STORAGE_MAX_BUFFER_SIZE: &str = "KBS_RESOURCE_STORAGE_MAX_BUFFER_SIZE";
+const ENV_RESOURCE_STORAGE_ERROR_BUFFER_SIZE: &str = "KBS_RESOURCE_STORAGE_ERROR_BUFFER_SIZE";
 
 /// Interface of a `Repository`.
 #[async_trait::async_trait]
@@ -150,6 +165,157 @@ impl Default for RepositoryConfig {
     fn default() -> Self {
         Self::LocalFs(local_fs::LocalFsRepoDesc::default())
     }
+}
+
+impl RepositoryConfig {
+    pub(crate) fn env_overrides_present() -> bool {
+        let present = [
+            ENV_RESOURCE_STORAGE_TYPE,
+            ENV_RESOURCE_STORAGE_DIR_PATH,
+            ENV_RESOURCE_STORAGE_LIBRARY_PATH,
+            ENV_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE,
+            ENV_RESOURCE_STORAGE_MAX_BUFFER_SIZE,
+            ENV_RESOURCE_STORAGE_ERROR_BUFFER_SIZE,
+        ]
+        .into_iter()
+        .any(|name| env::var_os(name).is_some());
+
+        #[cfg(feature = "encrypted-local-fs")]
+        let present = present || env::var_os(ENV_RESOURCE_STORAGE_PRIVATE_KEY_PATH).is_some();
+
+        #[cfg(feature = "aliyun")]
+        let present = present || super::aliyun_kms::AliyunKmsBackendConfig::env_overrides_present();
+
+        present
+    }
+
+    pub(crate) fn from_env_overrides() -> Result<Self> {
+        let backend_type = env_string(ENV_RESOURCE_STORAGE_TYPE)?.ok_or_else(|| {
+            anyhow!(
+                "{ENV_RESOURCE_STORAGE_TYPE} is required when configuring the resource plugin only from environment variables"
+            )
+        })?;
+
+        let mut config = Self::from_env_type(&backend_type)?;
+        config.apply_field_env_overrides()?;
+        Ok(config)
+    }
+
+    pub(crate) fn apply_env_overrides(&mut self) -> Result<()> {
+        if let Some(backend_type) = env_string(ENV_RESOURCE_STORAGE_TYPE)? {
+            *self = Self::from_env_type(&backend_type)?;
+        }
+
+        self.apply_field_env_overrides()
+    }
+
+    fn from_env_type(backend_type: &str) -> Result<Self> {
+        let normalized = backend_type
+            .trim()
+            .to_ascii_lowercase()
+            .replace('_', "")
+            .replace('-', "");
+
+        match normalized.as_str() {
+            "localfs" => Ok(Self::LocalFs(local_fs::LocalFsRepoDesc::default())),
+            "encryptedlocalfs" => {
+                #[cfg(feature = "encrypted-local-fs")]
+                {
+                    Ok(Self::EncryptedLocalFs(
+                        encrypted_local_fs::EncryptedLocalFsRepoDesc::default(),
+                    ))
+                }
+
+                #[cfg(not(feature = "encrypted-local-fs"))]
+                {
+                    bail!(
+                        "{ENV_RESOURCE_STORAGE_TYPE}=EncryptedLocalFs requires the encrypted-local-fs feature"
+                    )
+                }
+            }
+            "aliyun" => {
+                #[cfg(feature = "aliyun")]
+                {
+                    Ok(Self::Aliyun(
+                        super::aliyun_kms::AliyunKmsBackendConfig::default(),
+                    ))
+                }
+
+                #[cfg(not(feature = "aliyun"))]
+                {
+                    bail!("{ENV_RESOURCE_STORAGE_TYPE}=Aliyun requires the aliyun feature")
+                }
+            }
+            "externalkms" => Ok(Self::ExternalKms(
+                super::external_kms::ExternalKmsBackendConfig::default(),
+            )),
+            _ => bail!("unsupported {ENV_RESOURCE_STORAGE_TYPE} value `{backend_type}`"),
+        }
+    }
+
+    fn apply_field_env_overrides(&mut self) -> Result<()> {
+        match self {
+            Self::LocalFs(desc) => {
+                if let Some(dir_path) = env_string(ENV_RESOURCE_STORAGE_DIR_PATH)? {
+                    desc.dir_path = dir_path;
+                }
+            }
+            #[cfg(feature = "encrypted-local-fs")]
+            Self::EncryptedLocalFs(desc) => {
+                if let Some(dir_path) = env_string(ENV_RESOURCE_STORAGE_DIR_PATH)? {
+                    desc.dir_path = dir_path;
+                }
+                if let Some(private_key_path) = env_string(ENV_RESOURCE_STORAGE_PRIVATE_KEY_PATH)? {
+                    desc.private_key_path = private_key_path;
+                }
+            }
+            #[cfg(feature = "aliyun")]
+            Self::Aliyun(config) => {
+                config.apply_env_overrides()?;
+            }
+            Self::ExternalKms(config) => {
+                if let Some(library_path) = env_string(ENV_RESOURCE_STORAGE_LIBRARY_PATH)? {
+                    config.library_path = library_path;
+                }
+                if let Some(initial_buffer_size) =
+                    env_parse(ENV_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE)?
+                {
+                    config.initial_buffer_size = initial_buffer_size;
+                }
+                if let Some(max_buffer_size) = env_parse(ENV_RESOURCE_STORAGE_MAX_BUFFER_SIZE)? {
+                    config.max_buffer_size = max_buffer_size;
+                }
+                if let Some(error_buffer_size) = env_parse(ENV_RESOURCE_STORAGE_ERROR_BUFFER_SIZE)?
+                {
+                    config.error_buffer_size = error_buffer_size;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn env_string(name: &str) -> Result<Option<String>> {
+    match env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(err) => Err(anyhow!("read environment variable {name}: {err}")),
+    }
+}
+
+fn env_parse<T>(name: &str) -> Result<Option<T>>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    env_string(name)?
+        .map(|value| {
+            value
+                .parse::<T>()
+                .map_err(|err| anyhow!("parse environment variable {name}: {err}"))
+        })
+        .transpose()
 }
 
 #[derive(Clone)]

--- a/kbs/src/plugins/implementations/resource/external_kms.rs
+++ b/kbs/src/plugins/implementations/resource/external_kms.rs
@@ -35,6 +35,17 @@ pub struct ExternalKmsBackendConfig {
     pub error_buffer_size: u32,
 }
 
+impl Default for ExternalKmsBackendConfig {
+    fn default() -> Self {
+        Self {
+            library_path: default_library_path(),
+            initial_buffer_size: default_initial_buffer_size(),
+            max_buffer_size: default_max_buffer_size(),
+            error_buffer_size: default_error_buffer_size(),
+        }
+    }
+}
+
 fn default_library_path() -> String {
     DEFAULT_LIBRARY_PATH.to_string()
 }

--- a/rpm/trustee.spec
+++ b/rpm/trustee.spec
@@ -4,7 +4,7 @@
 %global __brp_mangle_shebangs %{nil}
 
 Name:           trustee
-Version:        1.8.4
+Version:        1.8.5
 Release:	    %{alinux_release}%{?dist}
 Summary:        Daemon services for attestation and secret distribution
 Group:          Applications/System
@@ -148,6 +148,15 @@ fi
 /var/lib/attestation/token/ear/policies/opa/default.rego
 
 %changelog
+* Mon Jun 01 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> -1.8.5-1
+- KBS: allow resource plugin configuration override via environment variables
+- KBS: self-manage EncryptedLocalFs keys with one-shot rotation API
+- KBS: support key rotation for EncryptedLocalFs backend
+- KBS/SDK: add reencrypt_resource.py for out-of-band key rotation
+- Verifier: fix Hygon TPM SM2 quote signature verification
+- Gateway: use 191-char prefix index on aa_instance_heartbeats.instance_id
+- Docs: document EncryptedLocalFs key rotation and managed-key rotation
+
 * Mon May 18 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> -1.8.4-1
 - KBS: support private cloud Aliyun KMS endpoints
 - AS: add signer transparency support


### PR DESCRIPTION
## Summary

Bump RPM packaging to v1.8.5 and bundle the following changes since v1.8.4:

- KBS: allow resource plugin configuration override via environment variables
- KBS: self-manage EncryptedLocalFs keys with one-shot rotation API
- KBS: support key rotation for EncryptedLocalFs backend
- KBS/SDK: add `reencrypt_resource.py` for out-of-band key rotation
- Verifier: fix Hygon TPM SM2 quote signature verification
- Gateway: use 191-char prefix index on `aa_instance_heartbeats.instance_id`
- Docs: document EncryptedLocalFs key rotation and managed-key rotation

## Test plan

- [ ] `rpmbuild -bb rpm/trustee.spec` builds successfully
- [ ] Smoke test the resulting `trustee` RPM on a target host