### PR TITLE
kbs: fix clippy lints in resource backend env-override path

### DIFF
--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -169,7 +169,7 @@ impl Default for RepositoryConfig {
 
 impl RepositoryConfig {
     pub(crate) fn env_overrides_present() -> bool {
-        let present = [
+        let core_present = [
             ENV_RESOURCE_STORAGE_TYPE,
             ENV_RESOURCE_STORAGE_DIR_PATH,
             ENV_RESOURCE_STORAGE_LIBRARY_PATH,
@@ -180,13 +180,21 @@ impl RepositoryConfig {
         .into_iter()
         .any(|name| env::var_os(name).is_some());
 
+        if core_present {
+            return true;
+        }
+
         #[cfg(feature = "encrypted-local-fs")]
-        let present = present || env::var_os(ENV_RESOURCE_STORAGE_PRIVATE_KEY_PATH).is_some();
+        if env::var_os(ENV_RESOURCE_STORAGE_PRIVATE_KEY_PATH).is_some() {
+            return true;
+        }
 
         #[cfg(feature = "aliyun")]
-        let present = present || super::aliyun_kms::AliyunKmsBackendConfig::env_overrides_present();
+        if super::aliyun_kms::AliyunKmsBackendConfig::env_overrides_present() {
+            return true;
+        }
 
-        present
+        false
     }
 
     pub(crate) fn from_env_overrides() -> Result<Self> {
@@ -213,8 +221,7 @@ impl RepositoryConfig {
         let normalized = backend_type
             .trim()
             .to_ascii_lowercase()
-            .replace('_', "")
-            .replace('-', "");
+            .replace(['_', '-'], "");
 
         match normalized.as_str() {
             "localfs" => Ok(Self::LocalFs(local_fs::LocalFsRepoDesc::default())),


### PR DESCRIPTION
## Summary

Fix two `clippy::let_and_return` / `clippy::collapsible_str_replace` errors that broke the KBS Lint CI job after #178 was merged. CI runs `make lint` with default features, where neither `encrypted-local-fs` nor `aliyun` is on, so the original `env_overrides_present` collapses to a let-then-return.

- `env_overrides_present`: rewrite as early-return so the body still type-checks under every feature combo and no longer trips `clippy::let_and_return`.
- `from_env_type`: combine two consecutive `str::replace` calls into one multi-pattern replace (`clippy::collapsible_str_replace`).

Failing CI run before fix: https://github.com/openanolis/trustee/actions/runs/26744534202/job/78816532964

## Test plan

- [x] `cd kbs && cargo clippy -p kbs --locked -- -D warnings` clean locally (default features)
- [ ] CI: KBS Lint / KBS Build / KBS Test all green