### PR TITLE
kbs: add EncryptedDb resource backend (multi-replica wrap-key sharing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3413,6 +3413,7 @@ dependencies = [
  "attestation-service",
  "base64 0.21.7",
  "cfg-if",
+ "chrono",
  "clap",
  "concat-kdf",
  "config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +545,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1350,6 +1365,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc24"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,6 +1408,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1821,6 +1860,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dsa"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,6 +1983,9 @@ name = "either"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -2054,6 +2102,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ethabi"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2155,12 @@ dependencies = [
  "primitive-types",
  "uint",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eventlog"
@@ -2197,6 +2262,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2358,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
@@ -2492,12 +2579,25 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.11",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "headers"
@@ -2528,6 +2628,9 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "heck"
@@ -2742,12 +2845,12 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.6.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -3305,6 +3408,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "anyhow",
+ "argon2",
  "async-trait",
  "attestation-service",
  "base64 0.21.7",
@@ -3342,6 +3446,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "serial_test 3.2.0",
+ "sqlx",
  "strum 0.25.0",
  "tempfile",
  "thiserror 2.0.12",
@@ -3352,6 +3457,7 @@ dependencies = [
  "tonic-build",
  "uuid",
  "x509-cert",
+ "zeroize",
 ]
 
 [[package]]
@@ -3481,6 +3587,18 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
+ "redox_syscall 0.5.9",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4660,7 +4778,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.23",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -4678,7 +4796,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -4983,7 +5101,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.23",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -5000,7 +5118,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.8",
  "windows-registry",
 ]
 
@@ -5204,6 +5322,17 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
@@ -5243,6 +5372,16 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -5472,6 +5611,16 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -5977,6 +6126,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -5986,6 +6138,217 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
+dependencies = [
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+dependencies = [
+ "ahash 0.8.11",
+ "atoi",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap 2.7.1",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.4.1",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 1.0.109",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.8.0",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 1.0.69",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.8.0",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 1.0.69",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -5999,6 +6362,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -6414,7 +6788,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls",
+ "rustls 0.23.23",
  "tokio",
 ]
 
@@ -6805,10 +7179,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "universal-hash"
@@ -6841,12 +7233,12 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -6860,6 +7252,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf16_iter"
@@ -7013,6 +7411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasix"
 version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7145,6 +7549,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
@@ -7162,6 +7572,16 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ serde_with = { version = "1.11.0", features = ["base64", "hex"] }
 serial_test = "0.9.0"
 sha2 = "0.10"
 shadow-rs = "0.19.0"
-sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio-rustls", "mysql", "sqlite", "any", "json", "chrono", "macros"] }
+sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio-rustls", "mysql", "sqlite", "any", "json", "chrono"] }
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1", default-features = false, features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2021"
 actix-web = "4"
 actix-web-httpauth = "0.8.0"
 anyhow = "1.0"
+argon2 = "0.5"
 assert-json-diff = "2.0.2"
 async-trait = "0.1.31"
 base64 = "0.21"
@@ -56,6 +57,7 @@ serde_with = { version = "1.11.0", features = ["base64", "hex"] }
 serial_test = "0.9.0"
 sha2 = "0.10"
 shadow-rs = "0.19.0"
+sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio-rustls", "mysql", "sqlite", "json", "chrono", "macros"] }
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1", default-features = false, features = ["full"] }
@@ -64,3 +66,4 @@ tempfile = "3.4.0"
 tonic = "0.12"
 tonic-build = "0.12"
 serde_yaml = "0.9"
+zeroize = { version = "1.7", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ serde_with = { version = "1.11.0", features = ["base64", "hex"] }
 serial_test = "0.9.0"
 sha2 = "0.10"
 shadow-rs = "0.19.0"
-sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio-rustls", "mysql", "sqlite", "json", "chrono", "macros"] }
+sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio-rustls", "mysql", "sqlite", "any", "json", "chrono", "macros"] }
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1", default-features = false, features = ["full"] }

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -41,7 +41,7 @@ build:
 	cd ../trustee-gateway && \
 	CGO_ENABLED=1 GOOS=linux go build -mod vendor -a -installsuffix cgo -ldflags="-s -w" -o gateway cmd/server/main.go && \
 	cd ..
-	cargo build -p kbs --locked --release --no-default-features --features coco-as-grpc,aliyun,tpm-pca,encrypted-local-fs
+	cargo build -p kbs --locked --release --no-default-features --features coco-as-grpc,aliyun,tpm-pca,encrypted-local-fs,encrypted-db
 	cargo build --bin restful-as --release --features restful-bin --locked
 	cargo build --bin grpc-as --release --features grpc-bin --locked
 	cargo build --bin rvps --release

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -12,6 +12,9 @@ default = ["coco-as-builtin", "coco-as-grpc"]
 # Enable encrypted local resource backend
 encrypted-local-fs = []
 
+# Enable encrypted DB-backed resource backend (multi-replica wrap-key sharing)
+encrypted-db = ["sqlx", "argon2", "zeroize"]
+
 # Support a backend attestation service for KBS
 as = []
 
@@ -47,6 +50,7 @@ actix-web-httpauth.workspace = true
 aes-gcm = "0.10.1"
 aes-kw = "0.2.1"
 anyhow.workspace = true
+argon2 = { workspace = true, optional = true }
 async-trait.workspace = true
 base64.workspace = true
 cfg-if.workspace = true
@@ -75,6 +79,7 @@ serde_qs.workspace = true
 semver = "1.0.16"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+sqlx = { workspace = true, optional = true }
 strum.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
@@ -87,6 +92,7 @@ derivative = "2.2.0"
 rustls-pki-types = "1.14.0"
 rustls-webpki = { version = "0.103.9", features = ["ring"] }
 x509-cert = "0.2.5"
+zeroize = { workspace = true, optional = true }
 
 [target.'cfg(not(any(target_arch = "s390x", target_arch = "aarch64")))'.dependencies]
 attestation-service = { path = "../attestation-service", default-features = false, features = [

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -13,7 +13,7 @@ default = ["coco-as-builtin", "coco-as-grpc"]
 encrypted-local-fs = []
 
 # Enable encrypted DB-backed resource backend (multi-replica wrap-key sharing)
-encrypted-db = ["sqlx", "argon2", "zeroize"]
+encrypted-db = ["sqlx", "argon2", "zeroize", "chrono"]
 
 # Support a backend attestation service for KBS
 as = []
@@ -53,6 +53,7 @@ anyhow.workspace = true
 argon2 = { workspace = true, optional = true }
 async-trait.workspace = true
 base64.workspace = true
+chrono = { workspace = true, optional = true }
 cfg-if.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 config.workspace = true

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -210,7 +210,7 @@ This is also called "Repository" in old versions. The properties to be configure
 
 | Property | Type   | Description                                                                   | Required | Default   |
 |----------|--------|-------------------------------------------------------------------------------|----------|-----------|
-| `type`   | String | The resource repository type. Valid values: `LocalFs`, `EncryptedLocalFs`, `Aliyun`, `ExternalKms` | Yes      | `LocalFs` |
+| `type`   | String | The resource repository type. Valid values: `LocalFs`, `EncryptedLocalFs`, `EncryptedDb`, `Aliyun`, `ExternalKms` | Yes      | `LocalFs` |
 
 Resource plugin configuration can also be overridden with environment
 variables. Environment variables are applied after the configuration file is
@@ -220,7 +220,7 @@ set to create one from environment variables.
 
 | Environment Variable | Description |
 |----------------------|-------------|
-| `KBS_RESOURCE_STORAGE_TYPE` | Replaces or creates the resource backend type. Supported values: `LocalFs`, `EncryptedLocalFs`, `Aliyun`, `ExternalKms`. |
+| `KBS_RESOURCE_STORAGE_TYPE` | Replaces or creates the resource backend type. Supported values: `LocalFs`, `EncryptedLocalFs`, `EncryptedDb`, `Aliyun`, `ExternalKms`. (For `EncryptedDb`, the database connection settings still need to come from the config file — they cannot be supplied through environment variables.) |
 | `KBS_RESOURCE_STORAGE_DIR_PATH` | Overrides `dir_path` for `LocalFs` and `EncryptedLocalFs`. |
 | `KBS_RESOURCE_STORAGE_PRIVATE_KEY_PATH` | Overrides `private_key_path` for `EncryptedLocalFs`. |
 | `KBS_RESOURCE_STORAGE_LIBRARY_PATH` | Overrides `library_path` for `ExternalKms`. |
@@ -297,6 +297,57 @@ endpoints:
 
 See [EncryptedLocalFs Key Rotation](./encrypted_local_fs_key_rotation.md) for the
 full procedure.
+
+**`EncryptedDb` Properties**
+
+The `EncryptedDb` backend stores both wrap keys and resource envelopes in a
+shared SQL database (MySQL or SQLite) so that multiple KBS replicas can share
+one consistent set of managed keys. Wrap private keys are encrypted at rest
+under a deployment-level master secret derived from a passphrase via Argon2id.
+It is guarded by the Cargo feature `encrypted-db`. See
+[EncryptedDb Resource Backend](./resource_storage_backend_encrypted_db.md) for
+the design and
+[EncryptedDb Key Rotation](./encrypted_db_key_rotation.md) for the operational
+procedures (rotation, purge, multi-replica considerations).
+
+| Property                | Type   | Description                                                                                                                                | Required | Default                                |
+|-------------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------|----------|----------------------------------------|
+| `master_secret_path`    | String | Path to the file holding the master passphrase (typically a Kubernetes Secret mounted as a tmpfs file).                                    | No       | `/run/trustee/master.passphrase`       |
+| `bump_poll_interval_ms` | Number | Throttle for the cheap `SELECT bump` poll that detects another replica's rotation. Smaller values mean faster propagation, more DB traffic. | No       | `5000`                                 |
+
+The database connection settings are nested under `[plugins.database]`:
+
+| Property                  | Type   | Description                                                                                                                                                                            | Required                | Default |
+|---------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|---------|
+| `type`                    | String | `"mysql"` or `"sqlite"`.                                                                                                                                                              | Yes                     | —       |
+| `dsn`                     | String | SQLx MySQL DSN (`mysql://user:pass@host:port/db?...`).                                                                                                                                | Yes for `mysql`         | —       |
+| `path`                    | String | SQLite file path. `":memory:"` is allowed for ephemeral testing only.                                                                                                                  | Yes for `sqlite`        | —       |
+| `max_open_conns`          | Number | Pool maximum connections.                                                                                                                                                              | No                      | `0` (unbounded) |
+| `max_idle_conns`          | Number | Pool warm-pool floor (minimum idle connections).                                                                                                                                       | No                      | `0`     |
+| `conn_max_lifetime`       | String | Humantime-style duration (`"1h"`, `"30m"`).                                                                                                                                            | No                      | `""` (driver default) |
+| `retired_key_purge_after` | String | Grace period a retired key is kept in the database before being physically deleted. `"0"` disables purging. Minimum non-zero value is `"1h"`.                                          | No                      | `"30d"` |
+
+Example:
+
+```toml
+[[plugins]]
+name = "resource"
+type = "EncryptedDb"
+master_secret_path = "/run/trustee/master.passphrase"
+bump_poll_interval_ms = 5000
+
+  [plugins.database]
+  type = "mysql"
+  dsn  = "mysql://kbs:****@db-host:3306/trustee_kbs?ssl-mode=PREFERRED"
+  max_open_conns = 20
+  max_idle_conns = 5
+  conn_max_lifetime = "1h"
+  retired_key_purge_after = "30d"
+```
+
+The same `/kbs/v0/resource/rotate`, `/pubkey`, `/reload`, `/rewrap` admin API
+applies (see the table for `EncryptedLocalFs` above). The rotate response on
+`EncryptedDb` includes an additional `purged_keys` field.
 
 **`Aliyun` Properties**
 

--- a/kbs/docs/encrypted_db_key_rotation.md
+++ b/kbs/docs/encrypted_db_key_rotation.md
@@ -1,0 +1,153 @@
+# EncryptedDb Key Rotation & Purge
+
+`EncryptedDb` exposes the same admin API as `EncryptedLocalFs`
+(`/rotate`, `/pubkey`, `/reload`, `/rewrap`), but the lifecycle of a
+wrap key has one extra step: physical purging of retired keys after a
+configurable grace period.
+
+> Read the
+> [EncryptedDb Resource Backend](./resource_storage_backend_encrypted_db.md)
+> document first if you are not already familiar with the schema and
+> the master-secret model.
+
+## Lifecycle of a wrap key
+
+```
+        ┌──────────────────┐
+        │      ACTIVE      │  retired_at IS NULL
+        │  (primary if     │
+        │  pointed at by   │
+        │  kbs_meta:       │
+        │  primary_gen)    │
+        └────────┬─────────┘
+                 │  /rotate succeeds → newer key becomes primary
+                 ▼
+        ┌──────────────────┐
+        │     RETIRED      │  retired_at = NOW()
+        │ (kept in DB so   │   row stays in kbs_managed_keys
+        │  late uploads    │   for at least retired_key_purge_after
+        │  with stale pub  │
+        │  key still       │
+        │  decrypt)        │
+        └────────┬─────────┘
+                 │  next /rotate, after grace elapsed,
+                 │  runs a straggler-rewrap pass; once no
+                 │  resource depends on this generation,
+                 │  the row is deleted.
+                 ▼
+        ┌──────────────────┐
+        │     PURGED       │  row no longer in kbs_managed_keys
+        └──────────────────┘
+```
+
+The grace period is controlled by `[plugins.database] retired_key_purge_after`
+(default `"30d"`, set `"0"` to disable; minimum non-zero value is
+`"1h"`).
+
+## One-shot rotation (the common case)
+
+```bash
+curl -X POST "$KBS/kbs/v0/resource/rotate" \
+     -H "Authorization: Bearer $ADMIN_TOKEN"
+# {
+#   "public_key": "-----BEGIN PUBLIC KEY-----\n...",
+#   "rewrapped":   100,
+#   "skipped":     28,
+#   "failed":      0,
+#   "retired_keys": 1,
+#   "purged_keys":  0
+# }
+```
+
+What KBS does, atomically across all replicas:
+
+1. Acquires an exclusive row lock on `kbs_meta('primary_generation')`
+   so concurrent rotations serialize.
+2. Generates a new RSA-3072 key pair, encrypts the private key under
+   the master secret with AES-256-GCM (binding the generation
+   identifier as AAD), and INSERTs it into `kbs_managed_keys`.
+3. Streams every resource whose `generation` is older than the new
+   one in 200-row batches, decrypts the CEK with the previous wrap
+   key, RSA-OAEP-256 wraps it with the new public key, and writes
+   the new envelope back to `kbs_resources`.
+4. **If every row migrated cleanly** (`failed == 0`):
+   * marks every older generation `retired_at = NOW()`,
+   * advances `kbs_meta.primary_generation` to the new key,
+   * increments `kbs_meta.bump` so other replicas know to reload.
+   * **If any row failed** (`failed > 0`), the new key stays inserted
+     but the primary pointer is *not* advanced and old keys are *not*
+     retired, so unaffected clients keep working with the prior key.
+     Re-run `/rotate` after fixing the cause.
+5. Finally, runs a purge sweep (see below).
+
+Other replicas pick up the new pubkey within `bump_poll_interval_ms`
+(default 5 s) on their next request — no `/reload` needed.
+
+## Hot reload, manual rewrap
+
+Both endpoints from `EncryptedLocalFs` work the same way here:
+
+- `POST /kbs/v0/resource/reload` — re-reads `kbs_managed_keys` and
+  `kbs_meta` from the database and atomically swaps the in-memory
+  ring. Useful after a side-channel change (e.g. an offline migration
+  tool) or when you want to bypass the bump-poll throttle.
+- `POST /kbs/v0/resource/rewrap` — rewraps every resource onto the
+  current primary without generating a new key. Useful when you have
+  inserted a wrap key by side-channel (for instance, importing an
+  old key for migration purposes).
+
+## Purge sweep details
+
+Every `/rotate` ends with a purge sweep:
+
+1. List candidates: every row in `kbs_managed_keys` whose
+   `retired_at < NOW() - retired_key_purge_after`.
+2. Run a final straggler-rewrap pass over `kbs_resources`. Any
+   envelope that the current primary cannot decrypt but a candidate
+   key can, is rewrapped to the primary on the spot.
+3. Re-scan `kbs_resources` once more. For each candidate, if there is
+   *still* a row that can only be decrypted with that candidate, the
+   candidate is **left in place** and a warning is logged
+   (`EncryptedDb: skipping purge of generation X`). The row is
+   never orphaned.
+4. Otherwise the candidate is `DELETE`d.
+
+Set `retired_key_purge_after = "0"` to keep retired keys forever
+(useful when running a backup/archival regime that re-imports old
+data, or while validating the new backend on a sensitive workload).
+Either way the table grows by **at most one row per rotation**, so
+yearly rotation gives a few rows of overhead — negligible.
+
+## Multi-replica notes
+
+- All replicas must share the **same master secret** (typically a
+  single Kubernetes Secret mounted into every pod).
+- All replicas must share the **same database**. Distinct DBs cannot
+  be reconciled — KBS makes no attempt to.
+- The wrap key live for at least `retired_key_purge_after` after a
+  rotation, so the **maximum delay a client can be running with a
+  stale public key** without their writes being orphaned is exactly
+  that grace period. Pick a value that comfortably covers your
+  client's `/pubkey` refresh cadence.
+
+## Relationship to EncryptedLocalFs
+
+| Concern | `EncryptedLocalFs` | `EncryptedDb` |
+|---|---|---|
+| Wrap-key lifetime after rotate | Deleted from disk on success | `retired_at` marked; physically deleted after `retired_key_purge_after` |
+| `RotateReport.retired_keys` | Count of files removed from disk | Count of rows newly marked retired |
+| `RotateReport.purged_keys` | Always `0` | Count of rows physically deleted in this rotation's purge sweep |
+| Client-uploaded with stale pubkey *after* rotate | Race window: very short on a single instance; can fail to decrypt | Survives the entire grace period; rewrapped on next rotation |
+
+If you are migrating from `EncryptedLocalFs` to `EncryptedDb` and want
+existing resources copied across, the simplest workflow is:
+
+1. Stand up `EncryptedDb` next to `EncryptedLocalFs`.
+2. For every existing resource, GET it from the old backend (which
+   returns plaintext after decryption), encrypt it with the new
+   backend's `/pubkey`, and POST it to the new backend.
+3. Once verified, switch the `[[plugins]]` config to
+   `type = "EncryptedDb"`, restart, and decommission the old backend.
+
+A scripted version of this migration may land in a follow-up PR; for
+now `kbs/sdk/python/encrypt_resource.py` is the building block.

--- a/kbs/docs/resource_storage_backend.md
+++ b/kbs/docs/resource_storage_backend.md
@@ -150,6 +150,43 @@ For the full step-by-step procedures, see
 `kbs/sdk/python/reencrypt_resource.py` remains available for out-of-band
 migration when the repository is not writable by KBS.
 
+### Encrypted Database Backend
+
+`EncryptedDb` is the multi-replica successor to `EncryptedLocalFs`. Both
+**wrap keys** and **resource envelopes** live in a shared SQL database
+(MySQL or SQLite) so all KBS replicas see one consistent set of managed
+keys and resources. Wrap private keys are encrypted at rest under a
+deployment-level *master secret* (typically a Kubernetes Secret mounted
+as a tmpfs file at `/run/trustee/master.passphrase`), so a database-only
+compromise — including stolen backups, replication snapshots, or DBA
+read access — yields ciphertext only.
+
+Wire format and the `pubkey` / `rotate` / `reload` / `rewrap` admin API
+are byte-for-byte the same as `EncryptedLocalFs`; existing client tooling
+(e.g. `kbs/sdk/python/encrypt_resource.py`) keeps working unchanged.
+
+```
+[[plugins]]
+name = "resource"
+type = "EncryptedDb"
+master_secret_path = "/run/trustee/master.passphrase"   # default
+bump_poll_interval_ms = 5000                            # default
+
+  [plugins.database]
+  type = "mysql"                                        # or "sqlite"
+  dsn = "mysql://kbs:<password>@db-host:3306/trustee_kbs?ssl-mode=PREFERRED"
+  max_open_conns = 20
+  max_idle_conns = 5
+  conn_max_lifetime = "1h"
+  retired_key_purge_after = "30d"                       # "0" = disabled
+```
+
+This backend is guarded by the Cargo feature `encrypted-db`. Enable it
+when building KBS to use it. For full deployment, rotation, and purge
+semantics see
+[EncryptedDb Resource Backend](./resource_storage_backend_encrypted_db.md)
+and [EncryptedDb Key Rotation](./encrypted_db_key_rotation.md).
+
 ### Aliyun KMS
 
 [Alibaba Cloud KMS](https://www.alibabacloud.com/en/product/kms?_p_lc=1)(a.k.a Aliyun KMS)

--- a/kbs/docs/resource_storage_backend_encrypted_db.md
+++ b/kbs/docs/resource_storage_backend_encrypted_db.md
@@ -1,0 +1,222 @@
+# EncryptedDb Resource Backend
+
+`EncryptedDb` keeps both the resource encryption keys and the encrypted
+resource envelopes in a shared SQL database (MySQL — including
+MySQL-compatible managed services — or SQLite). It is the recommended
+backend for **multi-replica** KBS deployments where every replica must
+agree on which key wraps each resource and on the contents of every
+resource.
+
+The on-the-wire envelope format and the `/kbs/v0/resource/...` admin
+API are unchanged from
+[EncryptedLocalFs](./resource_storage_backend.md#encrypted-local-file-system-backend),
+so client tooling such as `kbs/sdk/python/encrypt_resource.py` works
+without modification.
+
+## Why this backend exists
+
+`EncryptedLocalFs` keeps both wrap keys (as `mkey-<nanos>.pem` files) and
+resource envelopes on the local filesystem. Run more than one replica
+and you immediately hit:
+
+1. **Key divergence on cold start** — every replica generates its own
+   key the first time it sees an empty `key_dir`, so a resource written
+   on replica A cannot be read on replica B.
+2. **Rotation tearing** — a `/rotate` on one replica deletes its old
+   keys, but the other replicas keep using cached old keys until they
+   restart or `/reload`, dropping reads in flight.
+3. **Resource invisibility** — resources written via replica A's
+   `dir_path` are simply not present on replica B unless that directory
+   is shared.
+
+`EncryptedDb` solves all three by making the **database** the source of
+truth and the **master secret** the only thing operators have to keep
+out of band.
+
+## Architecture in 30 seconds
+
+```
+       client ── /pubkey ──► KBS replica ──┐
+                                            │
+       client ── POST envelope ────────────►│
+                                            │
+                                            ▼
+                                ┌──────────────────────────┐
+                                │  shared MySQL / SQLite    │
+                                │                            │
+                                │  kbs_managed_keys (wrap    │
+                                │     private key encrypted  │
+                                │     under master_key)      │
+                                │  kbs_resources    (envelope│
+                                │     JSON, generation tag)  │
+                                │  kbs_meta         (primary │
+                                │     pointer, bump counter, │
+                                │     KDF salt + canary)     │
+                                └──────────────────────────┘
+```
+
+- All replicas connect to the same database. Schema is created
+  idempotently with `CREATE TABLE IF NOT EXISTS` (and a MySQL `GET_LOCK`
+  advisory lock to serialize concurrent migrations).
+- Each replica reads the master passphrase from a local tmpfs file at
+  startup and derives a 32-byte master key via Argon2id (the salt and
+  parameters live in `kbs_meta`). This master key only AES-256-GCM
+  encrypts/decrypts the wrap private keys at rest — it never wraps
+  resource CEKs.
+- Resource envelopes themselves are unchanged: clients still RSA-wrap a
+  per-resource AES-256-GCM CEK using the current public key.
+- A `bump` counter in `kbs_meta` advertises that another replica
+  rotated; each replica cheap-polls (default 5 s throttle) to know when
+  to reload its in-memory key ring.
+
+## Configuration
+
+```toml
+[[plugins]]
+name = "resource"
+type = "EncryptedDb"
+master_secret_path = "/run/trustee/master.passphrase"   # default
+bump_poll_interval_ms = 5000                            # default; ≥100 recommended
+
+  [plugins.database]
+  type = "mysql"                                        # or "sqlite"
+  dsn  = "mysql://kbs:<password>@db-host:3306/trustee_kbs?ssl-mode=PREFERRED"
+  max_open_conns = 20
+  max_idle_conns = 5
+  conn_max_lifetime = "1h"
+  retired_key_purge_after = "30d"                       # "0" disables purging
+```
+
+Field reference:
+
+| Field | Required | Description |
+|---|---|---|
+| `master_secret_path` | no (default `/run/trustee/master.passphrase`) | File holding the master passphrase. Read once at startup and zeroized; never re-read while running. |
+| `bump_poll_interval_ms` | no (default `5000`) | Throttle on the cheap `SELECT bump` poll that detects another replica's rotation. Smaller values mean faster propagation and more DB traffic. |
+| `database.type` | yes | `"mysql"` or `"sqlite"`. |
+| `database.dsn` | required for `mysql` | SQLx MySQL DSN, e.g. `mysql://user:pass@host:port/db?ssl-mode=PREFERRED`. |
+| `database.path` | required for `sqlite` | Filesystem path. Use `:memory:` for an ephemeral in-process database (testing only). |
+| `database.max_open_conns` | no | Pool maximum (`PoolOptions::max_connections`). |
+| `database.max_idle_conns` | no | Pool warm-pool floor (`PoolOptions::min_connections`). |
+| `database.conn_max_lifetime` | no | `"1h"`, `"30m"`, etc. (humantime-style). Maps to `PoolOptions::max_lifetime`. |
+| `database.retired_key_purge_after` | no (default `"30d"`) | Grace period a retired key remains in the DB for late-arriving reads before being physically deleted. `"0"` disables purging. The minimum non-zero value is `"1h"`. |
+
+> Sensitive fields (DSN, master secret path) are intentionally **not**
+> overridable through the `KBS_RESOURCE_STORAGE_*` environment variables.
+
+## Master secret
+
+The master secret is a passphrase you provision once at deployment.
+
+- **Where it lives.** Each replica reads it from a local file (default
+  `/run/trustee/master.passphrase`). On Kubernetes the canonical pattern
+  is a `Secret` mounted as a tmpfs file:
+
+  ```yaml
+  volumes:
+    - name: master-secret
+      secret:
+        secretName: trustee-master-secret
+        defaultMode: 0400
+  volumeMounts:
+    - name: master-secret
+      mountPath: /run/trustee
+      readOnly: true
+  ```
+
+  The `Secret` itself stays in `etcd`; **make sure
+  `--encryption-provider-config` is enabled on the API server** so etcd
+  snapshots and backups do not contain plaintext.
+
+- **How it is used.** On startup KBS reads the file, trims trailing
+  whitespace, and derives a 32-byte master key with Argon2id (default
+  parameters: `m_cost=64MiB`, `t_cost=3`, `p_cost=4`). The salt and
+  parameters live in `kbs_meta` and are seeded the first time the
+  database is initialized. The passphrase bytes are zeroed immediately
+  after derivation; only the derived master key remains in memory.
+
+- **Canary check.** The first time KBS bootstraps, it encrypts a fixed
+  plaintext (`trustee-master-canary-v1`) under the master key and
+  stores `(nonce, tag, ciphertext)` in `kbs_meta`. On every subsequent
+  startup KBS verifies the canary first; **if the passphrase is wrong
+  or the canary has been tampered with, KBS refuses to start**. This
+  is what prevents a typo from silently corrupting the table with
+  mis-keyed entries.
+
+- **Rotation.** Master secret rotation is operationally disruptive
+  (every replica must agree on the new passphrase). v1 supports it as
+  an offline procedure: stop all replicas, run a one-shot tool that
+  re-encrypts each `kbs_managed_keys` row with the new master key (and
+  rewrites the canary + KDF salt), restart all replicas with the new
+  passphrase. A future PR may automate this.
+
+- **Recovery.** If the passphrase is lost, the wrap private keys
+  cannot be decrypted and resources cannot be read. **Print the
+  passphrase to a recovery sheet** and seal it in physical safe storage
+  (or use a KMS-style secret-sharing scheme such as Shamir). The
+  passphrase is the single root of trust for the whole DB.
+
+## Key rotation
+
+`POST /kbs/v0/resource/rotate` works the same way it does for
+`EncryptedLocalFs` — atomically generates a new wrap key, rewraps every
+resource envelope onto the new public key, retires the old key — but
+with extra DB-level guarantees:
+
+- The new wrap key is inserted, primary pointer advanced, and bump
+  counter incremented in a short transaction. Any concurrent `/rotate`
+  call from another replica blocks on a `SELECT FOR UPDATE` and
+  observes the new state, so it returns a no-op.
+- The rewrap pass over `kbs_resources` runs outside the transaction
+  (streamed in 200-row batches) so reads and writes are not blocked
+  by long-held locks.
+- Other replicas pick up the new key within `bump_poll_interval_ms` —
+  no `/reload` needed.
+- A retired key is **not** physically deleted right away; it is
+  marked `retired_at` and stays in the table for `retired_key_purge_after`
+  (default 30 days) so a resource uploaded with a stale public key
+  during a rotation race remains decryptable. Once the grace period
+  expires, the next `/rotate` runs a final straggler-rewrap pass and
+  then deletes the row.
+
+`RotateReport` (the JSON returned by `/rotate`) includes a
+`purged_keys` field counting how many retired keys were physically
+removed during this rotation.
+
+For step-by-step procedures and the cleanup story, see
+[EncryptedDb Key Rotation](./encrypted_db_key_rotation.md).
+
+## Concurrency model
+
+| Concurrency | Behavior |
+|---|---|
+| `rotate` × `GET` | Reader takes a MVCC snapshot, sees the pre-rotate envelope, decrypts with its existing ring (which still includes the old key). After commit, the reader's bump poll triggers a reload and subsequent reads see the new envelope. **Never blocks; never fails.** |
+| `rotate` × `POST` (same row) | UPSERT waits for the rotate's row lock; commits happen-after-rotate. **Brief block, no failure.** |
+| `rotate` × `POST` (different row) | Independent row locks; no contention. |
+| `rotate` × `DELETE` | Row lock; same as `POST`. |
+| `rotate` × `rotate` | The `kbs_meta('primary_generation')` row lock serializes them; the second caller sees the new primary already in place and returns a noop report. |
+
+A resource uploaded with a stale public key during the brief window
+between rotation commit and the client refreshing `/pubkey` is **not**
+orphaned: the corresponding wrap key stays in the DB until purge
+grace expires, and any subsequent `/rotate` rewraps stragglers.
+
+## Operational tips
+
+- **Migrations.** Schema is `CREATE TABLE IF NOT EXISTS`; just point
+  the new replica at the same DSN. No external migration tool is
+  required.
+- **Backups.** A `mysqldump` of `trustee_kbs.kbs_managed_keys` carries
+  ciphertext only; the master secret is what attackers actually need.
+  Make sure backups of the K8s Secret holding the passphrase are
+  managed separately and at least as carefully.
+- **Failure isolation.** Picking the same database that
+  `trustee-gateway` uses is fine, but consider a dedicated database
+  user with only the privileges KBS needs (`SELECT`, `INSERT`,
+  `UPDATE`, `DELETE` on the three `kbs_*` tables; `CREATE TABLE` on
+  first deploy).
+- **Bare metal / single-instance.** If you run a single KBS replica,
+  `EncryptedLocalFs` remains a perfectly valid option. `EncryptedDb`'s
+  benefits — shared keys, atomic rotation, deferred purge — only
+  matter once you have multiple replicas or want DB-grade durability
+  on the resources themselves.

--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -153,6 +153,10 @@ pub enum RepositoryConfig {
     #[serde(alias = "encrypted_local_fs", alias = "encrypted-local-fs")]
     EncryptedLocalFs(encrypted_local_fs::EncryptedLocalFsRepoDesc),
 
+    #[cfg(feature = "encrypted-db")]
+    #[serde(alias = "encrypted_db", alias = "encrypted-db")]
+    EncryptedDb(super::encrypted_db::EncryptedDbBackendConfig),
+
     #[cfg(feature = "aliyun")]
     #[serde(alias = "aliyun")]
     Aliyun(super::aliyun_kms::AliyunKmsBackendConfig),
@@ -256,6 +260,22 @@ impl RepositoryConfig {
             "externalkms" => Ok(Self::ExternalKms(
                 super::external_kms::ExternalKmsBackendConfig::default(),
             )),
+            "encrypteddb" => {
+                #[cfg(feature = "encrypted-db")]
+                {
+                    bail!(
+                        "{ENV_RESOURCE_STORAGE_TYPE}=EncryptedDb cannot be configured purely from \
+                         environment variables; provide a config file with the [plugins.database] \
+                         table"
+                    )
+                }
+                #[cfg(not(feature = "encrypted-db"))]
+                {
+                    bail!(
+                        "{ENV_RESOURCE_STORAGE_TYPE}=EncryptedDb requires the encrypted-db feature"
+                    )
+                }
+            }
             _ => bail!("unsupported {ENV_RESOURCE_STORAGE_TYPE} value `{backend_type}`"),
         }
     }
@@ -275,6 +295,11 @@ impl RepositoryConfig {
                 if let Some(private_key_path) = env_string(ENV_RESOURCE_STORAGE_PRIVATE_KEY_PATH)? {
                     desc.private_key_path = private_key_path;
                 }
+            }
+            #[cfg(feature = "encrypted-db")]
+            Self::EncryptedDb(_) => {
+                // Sensitive fields (DSN, master_secret_path) are intentionally
+                // not overridable through environment variables.
             }
             #[cfg(feature = "aliyun")]
             Self::Aliyun(config) => {
@@ -346,6 +371,14 @@ impl TryFrom<RepositoryConfig> for ResourceStorage {
             RepositoryConfig::EncryptedLocalFs(desc) => {
                 let backend = encrypted_local_fs::EncryptedLocalFs::new(&desc)
                     .context("Failed to initialize encrypted local Resource Storage")?;
+                Ok(Self {
+                    backend: Arc::new(backend),
+                })
+            }
+            #[cfg(feature = "encrypted-db")]
+            RepositoryConfig::EncryptedDb(config) => {
+                let backend = super::encrypted_db::EncryptedDb::new(&config)
+                    .context("Failed to initialize encrypted DB Resource Storage")?;
                 Ok(Self {
                     backend: Arc::new(backend),
                 })

--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -169,7 +169,7 @@ impl Default for RepositoryConfig {
 
 impl RepositoryConfig {
     pub(crate) fn env_overrides_present() -> bool {
-        let present = [
+        let core_present = [
             ENV_RESOURCE_STORAGE_TYPE,
             ENV_RESOURCE_STORAGE_DIR_PATH,
             ENV_RESOURCE_STORAGE_LIBRARY_PATH,
@@ -180,13 +180,21 @@ impl RepositoryConfig {
         .into_iter()
         .any(|name| env::var_os(name).is_some());
 
+        if core_present {
+            return true;
+        }
+
         #[cfg(feature = "encrypted-local-fs")]
-        let present = present || env::var_os(ENV_RESOURCE_STORAGE_PRIVATE_KEY_PATH).is_some();
+        if env::var_os(ENV_RESOURCE_STORAGE_PRIVATE_KEY_PATH).is_some() {
+            return true;
+        }
 
         #[cfg(feature = "aliyun")]
-        let present = present || super::aliyun_kms::AliyunKmsBackendConfig::env_overrides_present();
+        if super::aliyun_kms::AliyunKmsBackendConfig::env_overrides_present() {
+            return true;
+        }
 
-        present
+        false
     }
 
     pub(crate) fn from_env_overrides() -> Result<Self> {
@@ -213,8 +221,7 @@ impl RepositoryConfig {
         let normalized = backend_type
             .trim()
             .to_ascii_lowercase()
-            .replace('_', "")
-            .replace('-', "");
+            .replace(['_', '-'], "");
 
         match normalized.as_str() {
             "localfs" => Ok(Self::LocalFs(local_fs::LocalFsRepoDesc::default())),

--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -101,6 +101,12 @@ pub struct RotateReport {
     pub failed: usize,
     /// Number of old managed keys retired after a clean migration.
     pub retired_keys: usize,
+    /// Number of retired keys physically purged from persistent storage
+    /// after their grace period (`retired_key_purge_after`) expired. Always
+    /// 0 for backends that do not implement deferred purging
+    /// (`EncryptedLocalFs` deletes immediately on retire).
+    #[serde(default)]
+    pub purged_keys: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]

--- a/kbs/src/plugins/implementations/resource/encrypted_db/crypto.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/crypto.rs
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Envelope (de)crypt helpers, mirroring the wire format used by
+//! `EncryptedLocalFs` so the two backends are interchangeable on the wire.
+//! When time allows, the helpers in `encrypted_local_fs.rs` should be
+//! refactored to call into this module instead — for now we keep the two in
+//! lock-step by accident.
+
+use aes_gcm::{
+    aead::{AeadInPlace, KeyInit},
+    Aes256Gcm, Nonce,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use rsa::sha2::Sha256;
+use rsa::{Oaep, Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
+use serde::{Deserialize, Serialize};
+
+pub const ALG_RSA1_5: &str = "RSA1_5";
+pub const ALG_RSA_OAEP_256: &str = "RSA-OAEP-256";
+pub const AES_GCM_KEY_LEN: usize = 32;
+pub const AES_GCM_TAG_LEN: usize = 16;
+pub const AES_GCM_NONCE_LEN: usize = 12;
+
+/// Wire format of an encrypted resource. Compatible byte-for-byte with the
+/// envelope written by `EncryptedLocalFs`.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct Envelope {
+    pub alg: String,
+    pub enc_key: String,
+    pub iv: String,
+    pub ciphertext: String,
+    pub tag: String,
+}
+
+fn decode_b64(name: &str, v: &str) -> Result<Vec<u8>> {
+    STANDARD
+        .decode(v)
+        .with_context(|| format!("base64 decode `{name}`"))
+}
+
+/// Try every key in `keys` (newest-first) and return the plaintext when one
+/// successfully decrypts both the CEK and the AES-GCM body. Errors when none
+/// of the supplied keys works.
+pub fn decrypt_envelope_with_ring(env: &Envelope, keys: &[RsaPrivateKey]) -> Result<Vec<u8>> {
+    let enc_key = decode_b64("enc_key", &env.enc_key)?;
+    let iv = decode_b64("iv", &env.iv)?;
+    let ciphertext = decode_b64("ciphertext", &env.ciphertext)?;
+    let tag = decode_b64("tag", &env.tag)?;
+
+    if !matches!(env.alg.as_str(), ALG_RSA1_5 | ALG_RSA_OAEP_256) {
+        bail!("unsupported envelope alg `{}`", env.alg);
+    }
+    if iv.len() != AES_GCM_NONCE_LEN {
+        bail!(
+            "unexpected GCM nonce length {}, expect {AES_GCM_NONCE_LEN} bytes",
+            iv.len()
+        );
+    }
+    if tag.len() != AES_GCM_TAG_LEN {
+        bail!(
+            "unexpected GCM tag length {}, expect {AES_GCM_TAG_LEN} bytes",
+            tag.len()
+        );
+    }
+    if keys.is_empty() {
+        bail!("no decryption keys configured");
+    }
+
+    let mut last_err = None;
+    for key in keys {
+        match recover_cek(key, &env.alg, &enc_key)
+            .and_then(|cek| aes_decrypt(&cek, &iv, &ciphertext, &tag))
+        {
+            Ok(plain) => return Ok(plain),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(anyhow!(
+        "failed to decrypt resource with any of the {} key(s): {}",
+        keys.len(),
+        last_err.expect("at least one error")
+    ))
+}
+
+/// Re-wrap the CEK of an envelope onto a new public key, returning the new
+/// envelope JSON bytes. Returns `None` when:
+///   * the input bytes are not a parseable envelope (assumed plaintext —
+///     leave as-is, matching EncryptedLocalFs's `try_decrypt` semantics), or
+///   * the envelope is already RSA-OAEP-256 wrapped under `primary_public`.
+///
+/// Returns `Err` when the envelope is malformed or no `decrypt_keys` can
+/// decrypt it.
+pub fn rewrap_envelope(
+    raw: &[u8],
+    decrypt_keys: &[RsaPrivateKey],
+    primary_public: &RsaPublicKey,
+) -> Result<Option<Vec<u8>>> {
+    let env: Envelope = match serde_json::from_slice(raw) {
+        Ok(e) => e,
+        Err(_) => return Ok(None), // not an envelope; leave as plaintext
+    };
+
+    let enc_key = decode_b64("enc_key", &env.enc_key)?;
+    let iv = decode_b64("iv", &env.iv)?;
+    let ciphertext = decode_b64("ciphertext", &env.ciphertext)?;
+    let tag = decode_b64("tag", &env.tag)?;
+
+    // Fast-path: if the first key already decrypts under OAEP, we're already
+    // current and skip the rewrap. This mirrors EncryptedLocalFs::rewrap_one.
+    if env.alg == ALG_RSA_OAEP_256 && !decrypt_keys.is_empty() {
+        if let Ok(cek) = recover_cek(&decrypt_keys[0], &env.alg, &enc_key) {
+            if aes_decrypt(&cek, &iv, &ciphertext, &tag).is_ok() {
+                return Ok(None);
+            }
+        }
+    }
+
+    // Find a key that decrypts both the CEK and the body, then re-wrap with
+    // the new public key.
+    let cek = decrypt_keys
+        .iter()
+        .find_map(|key| {
+            let cek = recover_cek(key, &env.alg, &enc_key).ok()?;
+            aes_decrypt(&cek, &iv, &ciphertext, &tag).ok()?;
+            Some(cek)
+        })
+        .context("no configured key can decrypt this resource")?;
+
+    let new_enc_key = {
+        let mut rng = rand::thread_rng();
+        primary_public
+            .encrypt(&mut rng, Oaep::new::<Sha256>(), &cek)
+            .context("re-wrap CEK with primary public key")?
+    };
+
+    let new_env = Envelope {
+        alg: ALG_RSA_OAEP_256.to_string(),
+        enc_key: STANDARD.encode(new_enc_key),
+        iv: env.iv,
+        ciphertext: env.ciphertext,
+        tag: env.tag,
+    };
+    let bytes = serde_json::to_vec(&new_env).context("serialize re-wrapped envelope")?;
+    Ok(Some(bytes))
+}
+
+fn recover_cek(private_key: &RsaPrivateKey, alg: &str, enc_key: &[u8]) -> Result<Vec<u8>> {
+    let cek = match alg {
+        ALG_RSA1_5 => private_key
+            .decrypt(Pkcs1v15Encrypt, enc_key)
+            .context("RSA1_5 decrypt CEK")?,
+        ALG_RSA_OAEP_256 => {
+            let padding = Oaep::new::<Sha256>();
+            private_key
+                .decrypt(padding, enc_key)
+                .context("RSA-OAEP-256 decrypt CEK")?
+        }
+        _ => bail!("unsupported envelope alg `{alg}`"),
+    };
+    if cek.len() != AES_GCM_KEY_LEN {
+        bail!(
+            "unexpected CEK length {}, expect {AES_GCM_KEY_LEN} bytes",
+            cek.len()
+        );
+    }
+    Ok(cek)
+}
+
+fn aes_decrypt(cek: &[u8], iv: &[u8], ciphertext: &[u8], tag: &[u8]) -> Result<Vec<u8>> {
+    let cipher = Aes256Gcm::new_from_slice(cek).context("build AES-256-GCM cipher with CEK")?;
+    let nonce = Nonce::from_slice(iv);
+    let mut plaintext = ciphertext.to_vec();
+    let tag_arr = aes_gcm::aead::generic_array::GenericArray::from_slice(tag);
+    cipher
+        .decrypt_in_place_detached(nonce, b"", &mut plaintext, tag_arr)
+        .map_err(|e| anyhow!("AES-256-GCM decrypt resource payload: {e:?}"))?;
+    Ok(plaintext)
+}

--- a/kbs/src/plugins/implementations/resource/encrypted_db/db.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/db.rs
@@ -40,7 +40,10 @@ impl DbPool {
                 }
                 if !config.conn_max_lifetime.is_empty() {
                     let dur = parse_simple_duration(&config.conn_max_lifetime).map_err(|e| {
-                        anyhow!("parse conn_max_lifetime `{}`: {e}", config.conn_max_lifetime)
+                        anyhow!(
+                            "parse conn_max_lifetime `{}`: {e}",
+                            config.conn_max_lifetime
+                        )
                     })?;
                     opts = opts.max_lifetime(Some(dur));
                 }
@@ -120,11 +123,26 @@ mod tests {
 
     #[test]
     fn parse_units() {
-        assert_eq!(parse_simple_duration("30s").unwrap(), Duration::from_secs(30));
-        assert_eq!(parse_simple_duration("5m").unwrap(), Duration::from_secs(300));
-        assert_eq!(parse_simple_duration("1h").unwrap(), Duration::from_secs(3_600));
-        assert_eq!(parse_simple_duration("30d").unwrap(), Duration::from_secs(30 * 86_400));
-        assert_eq!(parse_simple_duration("2w").unwrap(), Duration::from_secs(14 * 86_400));
+        assert_eq!(
+            parse_simple_duration("30s").unwrap(),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            parse_simple_duration("5m").unwrap(),
+            Duration::from_secs(300)
+        );
+        assert_eq!(
+            parse_simple_duration("1h").unwrap(),
+            Duration::from_secs(3_600)
+        );
+        assert_eq!(
+            parse_simple_duration("30d").unwrap(),
+            Duration::from_secs(30 * 86_400)
+        );
+        assert_eq!(
+            parse_simple_duration("2w").unwrap(),
+            Duration::from_secs(14 * 86_400)
+        );
     }
 
     #[test]

--- a/kbs/src/plugins/implementations/resource/encrypted_db/db.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/db.rs
@@ -23,20 +23,7 @@ pub enum DbPool {
     Sqlite(sqlx::SqlitePool),
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum DbKind {
-    MySql,
-    Sqlite,
-}
-
 impl DbPool {
-    pub fn kind(&self) -> DbKind {
-        match self {
-            DbPool::MySql(_) => DbKind::MySql,
-            DbPool::Sqlite(_) => DbKind::Sqlite,
-        }
-    }
-
     pub async fn connect(config: &DatabaseConfig) -> Result<Self> {
         match config.kind.to_ascii_lowercase().as_str() {
             "mysql" => {

--- a/kbs/src/plugins/implementations/resource/encrypted_db/db.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/db.rs
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Thin abstraction over `sqlx::MySqlPool` / `sqlx::SqlitePool`. Used by the
+//! schema, key-store, and resource-store layers so that callers can stay
+//! driver-agnostic.
+//!
+//! sqlx 0.7's `Any` driver does not expose driver-kind discrimination
+//! through stable feature flags (the `AnyKind::MySql` / `AnyKind::Sqlite`
+//! variants are gated on private sqlx-core features that the umbrella
+//! `sqlx` crate's `mysql` / `sqlite` features do not enable). Rather than
+//! fight that, we keep typed pools and dispatch on a small enum.
+
+use anyhow::{anyhow, bail, Context, Result};
+use std::time::Duration;
+
+use super::DatabaseConfig;
+
+#[derive(Clone)]
+pub enum DbPool {
+    MySql(sqlx::MySqlPool),
+    Sqlite(sqlx::SqlitePool),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum DbKind {
+    MySql,
+    Sqlite,
+}
+
+impl DbPool {
+    pub fn kind(&self) -> DbKind {
+        match self {
+            DbPool::MySql(_) => DbKind::MySql,
+            DbPool::Sqlite(_) => DbKind::Sqlite,
+        }
+    }
+
+    pub async fn connect(config: &DatabaseConfig) -> Result<Self> {
+        match config.kind.to_ascii_lowercase().as_str() {
+            "mysql" => {
+                if config.dsn.is_empty() {
+                    bail!("EncryptedDb: database.dsn is required when type=\"mysql\"");
+                }
+                let mut opts = sqlx::mysql::MySqlPoolOptions::new();
+                if config.max_open_conns > 0 {
+                    opts = opts.max_connections(config.max_open_conns);
+                }
+                if config.max_idle_conns > 0 {
+                    // sqlx docs: min_connections is the warm-pool floor.
+                    opts = opts.min_connections(config.max_idle_conns);
+                }
+                if !config.conn_max_lifetime.is_empty() {
+                    let dur = parse_simple_duration(&config.conn_max_lifetime).map_err(|e| {
+                        anyhow!("parse conn_max_lifetime `{}`: {e}", config.conn_max_lifetime)
+                    })?;
+                    opts = opts.max_lifetime(Some(dur));
+                }
+                let pool = opts
+                    .connect(&config.dsn)
+                    .await
+                    .context("connect to MySQL DSN")?;
+                Ok(DbPool::MySql(pool))
+            }
+            "sqlite" => {
+                if config.path.is_empty() {
+                    bail!("EncryptedDb: database.path is required when type=\"sqlite\"");
+                }
+                let url = if config.path == ":memory:" {
+                    "sqlite::memory:".to_string()
+                } else {
+                    format!("sqlite://{}?mode=rwc", config.path)
+                };
+                let pool = sqlx::sqlite::SqlitePoolOptions::new()
+                    .max_connections(1) // single-writer keeps tests deterministic
+                    .acquire_timeout(Duration::from_secs(5))
+                    .connect(&url)
+                    .await
+                    .context("connect to SQLite")?;
+                Ok(DbPool::Sqlite(pool))
+            }
+            other => bail!("EncryptedDb: unsupported database.type `{other}`"),
+        }
+    }
+
+    /// Connect to an in-memory SQLite (tests only).
+    #[cfg(test)]
+    pub async fn connect_sqlite_memory() -> Result<Self> {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await?;
+        Ok(DbPool::Sqlite(pool))
+    }
+}
+
+/// Tiny `humantime`-style parser supporting `Ns`, `Nm`, `Nh`, `Nd`, `Nw` (and
+/// the bare `0` synonym). Avoids adding another dependency just to parse two
+/// configuration knobs.
+pub fn parse_simple_duration(s: &str) -> Result<Duration> {
+    let trimmed = s.trim();
+    if trimmed == "0" {
+        return Ok(Duration::ZERO);
+    }
+    let (num_part, suffix) = match trimmed.find(|c: char| c.is_alphabetic()) {
+        Some(i) => trimmed.split_at(i),
+        None => bail!("missing unit suffix (s, m, h, d, w)"),
+    };
+    let n: u64 = num_part
+        .trim()
+        .parse()
+        .map_err(|e| anyhow!("not a number: {e}"))?;
+    let secs = match suffix {
+        "s" | "sec" | "secs" => n,
+        "m" | "min" | "mins" => n.saturating_mul(60),
+        "h" | "hr" | "hrs" => n.saturating_mul(3600),
+        "d" | "day" | "days" => n.saturating_mul(86_400),
+        "w" | "wk" | "wks" | "week" | "weeks" => n.saturating_mul(7 * 86_400),
+        other => bail!("unknown unit `{other}` (use s/m/h/d/w)"),
+    };
+    Ok(Duration::from_secs(secs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_zero() {
+        assert_eq!(parse_simple_duration("0").unwrap(), Duration::ZERO);
+    }
+
+    #[test]
+    fn parse_units() {
+        assert_eq!(parse_simple_duration("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_simple_duration("5m").unwrap(), Duration::from_secs(300));
+        assert_eq!(parse_simple_duration("1h").unwrap(), Duration::from_secs(3_600));
+        assert_eq!(parse_simple_duration("30d").unwrap(), Duration::from_secs(30 * 86_400));
+        assert_eq!(parse_simple_duration("2w").unwrap(), Duration::from_secs(14 * 86_400));
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        assert!(parse_simple_duration("").is_err());
+        assert!(parse_simple_duration("abc").is_err());
+        assert!(parse_simple_duration("3").is_err());
+        assert!(parse_simple_duration("3y").is_err());
+    }
+}

--- a/kbs/src/plugins/implementations/resource/encrypted_db/key_store.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/key_store.rs
@@ -120,60 +120,40 @@ pub async fn insert_new_generation(
 /// the master key. Returned newest-first so callers can pick the primary as
 /// the first non-retired entry.
 pub async fn load_all_keys(pool: &DbPool, master_key: &MasterKey) -> Result<Vec<LoadedKey>> {
+    // (generation, public_key_pem, enc_private_key, iv, tag, retired_flag)
+    type KeyRow = (i64, String, Vec<u8>, Vec<u8>, Vec<u8>, i64);
+    const SQL: &str = "SELECT generation, public_key_pem, enc_private_key, iv, tag,
+                              CASE WHEN retired_at IS NULL THEN 0 ELSE 1 END
+                       FROM kbs_managed_keys
+                       ORDER BY generation DESC";
     let rows: Vec<KeyRow> = match pool {
-        DbPool::MySql(p) => sqlx::query_as::<_, KeyRow>(
-            "SELECT generation, public_key_pem, enc_private_key, iv, tag,
-                    CASE WHEN retired_at IS NULL THEN 0 ELSE 1 END AS retired
-             FROM kbs_managed_keys
-             ORDER BY generation DESC",
-        )
-        .fetch_all(p)
-        .await
-        .context("load wrap keys (mysql)")?,
-        DbPool::Sqlite(p) => sqlx::query_as::<_, KeyRow>(
-            "SELECT generation, public_key_pem, enc_private_key, iv, tag,
-                    CASE WHEN retired_at IS NULL THEN 0 ELSE 1 END AS retired
-             FROM kbs_managed_keys
-             ORDER BY generation DESC",
-        )
-        .fetch_all(p)
-        .await
-        .context("load wrap keys (sqlite)")?,
+        DbPool::MySql(p) => sqlx::query_as(SQL)
+            .fetch_all(p)
+            .await
+            .context("load wrap keys (mysql)")?,
+        DbPool::Sqlite(p) => sqlx::query_as(SQL)
+            .fetch_all(p)
+            .await
+            .context("load wrap keys (sqlite)")?,
     };
 
     let mut out = Vec::with_capacity(rows.len());
-    for row in rows {
-        let aad = aad_for_generation(row.generation);
-        let private_pem = aes_gcm_decrypt(
-            master_key,
-            &row.iv,
-            &row.tag,
-            &row.enc_private_key,
-            &aad,
-        )
-        .with_context(|| format!("decrypt private key for generation {}", row.generation))?;
+    for (generation, public_key_pem, enc_private_key, iv, tag, retired_flag) in rows {
+        let aad = aad_for_generation(generation);
+        let private_pem = aes_gcm_decrypt(master_key, &iv, &tag, &enc_private_key, &aad)
+            .with_context(|| format!("decrypt private key for generation {generation}"))?;
         let private_key = pkcs8_decode_zeroizing(&private_pem)
-            .with_context(|| format!("parse private key for generation {}", row.generation))?;
-        let public_key = RsaPublicKey::from_public_key_pem(&row.public_key_pem)
-            .map_err(|e| anyhow!("parse public key for generation {}: {e}", row.generation))?;
+            .with_context(|| format!("parse private key for generation {generation}"))?;
+        let public_key = RsaPublicKey::from_public_key_pem(&public_key_pem)
+            .map_err(|e| anyhow!("parse public key for generation {generation}: {e}"))?;
         out.push(LoadedKey {
-            generation: row.generation,
+            generation,
             public_key,
             private_key,
-            retired: row.retired != 0,
+            retired: retired_flag != 0,
         });
     }
     Ok(out)
-}
-
-#[derive(sqlx::FromRow)]
-struct KeyRow {
-    generation: i64,
-    public_key_pem: String,
-    enc_private_key: Vec<u8>,
-    iv: Vec<u8>,
-    tag: Vec<u8>,
-    retired: i64,
 }
 
 fn pkcs8_decode_zeroizing(pem: &Zeroizing<Vec<u8>>) -> Result<RsaPrivateKey> {

--- a/kbs/src/plugins/implementations/resource/encrypted_db/key_store.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/key_store.rs
@@ -298,10 +298,7 @@ pub async fn read_primary_generation_and_bump(pool: &DbPool) -> Result<Option<(G
 }
 
 /// Insert the very first `primary_generation` row. Idempotent.
-pub async fn set_primary_generation_initial(
-    pool: &DbPool,
-    generation: Generation,
-) -> Result<()> {
+pub async fn set_primary_generation_initial(pool: &DbPool, generation: Generation) -> Result<()> {
     insert_meta_if_absent(pool, meta::PRIMARY_GENERATION, &generation.to_string()).await
 }
 
@@ -396,7 +393,10 @@ mod tests {
         assert_eq!(keys[0].generation, gen1);
         assert!(!keys[0].retired);
         assert_eq!(
-            keys[0].public_key.to_public_key_pem(LineEnding::LF).unwrap(),
+            keys[0]
+                .public_key
+                .to_public_key_pem(LineEnding::LF)
+                .unwrap(),
             pub1.to_public_key_pem(LineEnding::LF).unwrap()
         );
     }
@@ -407,7 +407,9 @@ mod tests {
         let master = fast_key();
         let priv1 = generate_rsa_key_pair().unwrap();
         let gen1 = 12345i64;
-        insert_new_generation(&pool, &master, gen1, &priv1).await.unwrap();
+        insert_new_generation(&pool, &master, gen1, &priv1)
+            .await
+            .unwrap();
         let priv2 = generate_rsa_key_pair().unwrap();
         let err = insert_new_generation(&pool, &master, gen1, &priv2)
             .await
@@ -430,12 +432,18 @@ mod tests {
         let priv2 = generate_rsa_key_pair().unwrap();
         let gen1 = 100i64;
         let gen2 = 200i64;
-        insert_new_generation(&pool, &master, gen1, &priv1).await.unwrap();
-        insert_new_generation(&pool, &master, gen2, &priv2).await.unwrap();
+        insert_new_generation(&pool, &master, gen1, &priv1)
+            .await
+            .unwrap();
+        insert_new_generation(&pool, &master, gen2, &priv2)
+            .await
+            .unwrap();
 
         // Manually swap the encrypted bytes between rows and confirm that
         // load_all_keys rejects the result (AAD mismatch).
-        let DbPool::Sqlite(p) = &pool else { unreachable!() };
+        let DbPool::Sqlite(p) = &pool else {
+            unreachable!()
+        };
         let row1: (Vec<u8>, Vec<u8>, Vec<u8>) = sqlx::query_as(
             "SELECT enc_private_key, iv, tag FROM kbs_managed_keys WHERE generation = ?",
         )
@@ -443,9 +451,16 @@ mod tests {
         .fetch_one(p)
         .await
         .unwrap();
-        sqlx::query("UPDATE kbs_managed_keys SET enc_private_key = ?, iv = ?, tag = ? WHERE generation = ?")
-            .bind(&row1.0).bind(&row1.1).bind(&row1.2).bind(gen2)
-            .execute(p).await.unwrap();
+        sqlx::query(
+            "UPDATE kbs_managed_keys SET enc_private_key = ?, iv = ?, tag = ? WHERE generation = ?",
+        )
+        .bind(&row1.0)
+        .bind(&row1.1)
+        .bind(&row1.2)
+        .bind(gen2)
+        .execute(p)
+        .await
+        .unwrap();
 
         let err = match load_all_keys(&pool, &master).await {
             Ok(_) => panic!("AAD mismatch: load should have failed"),
@@ -460,7 +475,9 @@ mod tests {
         let master_a = fast_key();
         let master_b: MasterKey = Zeroizing::new([0xAA; MASTER_KEY_LEN]);
         let priv1 = generate_rsa_key_pair().unwrap();
-        insert_new_generation(&pool, &master_a, 1, &priv1).await.unwrap();
+        insert_new_generation(&pool, &master_a, 1, &priv1)
+            .await
+            .unwrap();
         let err = match load_all_keys(&pool, &master_b).await {
             Ok(_) => panic!("wrong master key: load should have failed"),
             Err(e) => e,
@@ -477,11 +494,15 @@ mod tests {
 
         let priv1 = generate_rsa_key_pair().unwrap();
         let gen1 = 100i64;
-        insert_new_generation(&pool, &master, gen1, &priv1).await.unwrap();
+        insert_new_generation(&pool, &master, gen1, &priv1)
+            .await
+            .unwrap();
         set_primary_generation_initial(&pool, gen1).await.unwrap();
 
         // Idempotent: seeding twice does not change the value.
-        set_primary_generation_initial(&pool, gen1 + 999).await.unwrap();
+        set_primary_generation_initial(&pool, gen1 + 999)
+            .await
+            .unwrap();
         let (cur, bump_before) = read_primary_generation_and_bump(&pool)
             .await
             .unwrap()
@@ -491,7 +512,9 @@ mod tests {
         // Advance bumps both pointer and counter.
         let priv2 = generate_rsa_key_pair().unwrap();
         let gen2 = 200i64;
-        insert_new_generation(&pool, &master, gen2, &priv2).await.unwrap();
+        insert_new_generation(&pool, &master, gen2, &priv2)
+            .await
+            .unwrap();
         advance_primary_generation(&pool, gen2).await.unwrap();
 
         let (cur, bump_after) = read_primary_generation_and_bump(&pool)
@@ -508,8 +531,12 @@ mod tests {
         let master = fast_key();
         let priv1 = generate_rsa_key_pair().unwrap();
         let priv2 = generate_rsa_key_pair().unwrap();
-        insert_new_generation(&pool, &master, 100, &priv1).await.unwrap();
-        insert_new_generation(&pool, &master, 200, &priv2).await.unwrap();
+        insert_new_generation(&pool, &master, 100, &priv1)
+            .await
+            .unwrap();
+        insert_new_generation(&pool, &master, 200, &priv2)
+            .await
+            .unwrap();
 
         let n = mark_older_retired(&pool, 200).await.unwrap();
         assert_eq!(n, 1);

--- a/kbs/src/plugins/implementations/resource/encrypted_db/key_store.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/key_store.rs
@@ -181,6 +181,75 @@ fn pkcs8_decode_zeroizing(pem: &Zeroizing<Vec<u8>>) -> Result<RsaPrivateKey> {
     RsaPrivateKey::from_pkcs8_pem(pem_str).map_err(|e| anyhow!("decode pkcs8: {e}"))
 }
 
+/// Return the generations of every key that has been retired for at least
+/// `min_age`. Used by the purge sweep at the end of `/rotate`.
+pub async fn list_retired_older_than(
+    pool: &DbPool,
+    min_age: std::time::Duration,
+) -> Result<Vec<Generation>> {
+    let cutoff_iso = current_iso_minus(min_age)?;
+    let rows: Vec<(Generation,)> = match pool {
+        DbPool::MySql(p) => sqlx::query_as(
+            "SELECT generation FROM kbs_managed_keys
+             WHERE retired_at IS NOT NULL AND retired_at < ?",
+        )
+        .bind(cutoff_iso)
+        .fetch_all(p)
+        .await
+        .context("list retired keys (mysql)")?,
+        DbPool::Sqlite(p) => sqlx::query_as(
+            "SELECT generation FROM kbs_managed_keys
+             WHERE retired_at IS NOT NULL AND retired_at < ?",
+        )
+        .bind(cutoff_iso)
+        .fetch_all(p)
+        .await
+        .context("list retired keys (sqlite)")?,
+    };
+    Ok(rows.into_iter().map(|(g,)| g).collect())
+}
+
+/// Physically delete a retired key. The caller must have first verified
+/// (via a fresh rewrap pass) that no resource is wrapped with this
+/// generation; otherwise readers can be permanently broken.
+pub async fn delete_key_row(pool: &DbPool, generation: Generation) -> Result<()> {
+    match pool {
+        DbPool::MySql(p) => {
+            sqlx::query(
+                "DELETE FROM kbs_managed_keys
+                 WHERE generation = ? AND retired_at IS NOT NULL",
+            )
+            .bind(generation)
+            .execute(p)
+            .await
+            .context("delete retired key (mysql)")?;
+        }
+        DbPool::Sqlite(p) => {
+            sqlx::query(
+                "DELETE FROM kbs_managed_keys
+                 WHERE generation = ? AND retired_at IS NOT NULL",
+            )
+            .bind(generation)
+            .execute(p)
+            .await
+            .context("delete retired key (sqlite)")?;
+        }
+    }
+    Ok(())
+}
+
+fn current_iso_minus(d: std::time::Duration) -> Result<String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before unix epoch")?;
+    let cutoff = now.checked_sub(d).unwrap_or(std::time::Duration::ZERO);
+    let secs = cutoff.as_secs() as i64;
+    let micros = cutoff.subsec_micros();
+    let datetime = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, micros * 1_000)
+        .ok_or_else(|| anyhow!("convert system time to chrono"))?;
+    Ok(datetime.format("%Y-%m-%d %H:%M:%S%.6f").to_string())
+}
+
 /// Mark every generation older than `cutoff` as retired (idempotent).
 /// Returns the number of rows newly marked.
 pub async fn mark_older_retired(pool: &DbPool, cutoff: Generation) -> Result<u64> {

--- a/kbs/src/plugins/implementations/resource/encrypted_db/key_store.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/key_store.rs
@@ -1,0 +1,473 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wrap-key persistence and lifecycle (`kbs_managed_keys` + parts of
+//! `kbs_meta`).
+//!
+//! Each generation is identified by a 64-bit integer (nanoseconds since
+//! UNIX_EPOCH) used as primary key — this gives a strict ordering matching
+//! the wall clock and dovetails with the `mkey-<nanos>.pem` filename
+//! convention used by `EncryptedLocalFs`.
+//!
+//! Private keys are stored encrypted under the master key using AES-256-GCM
+//! with a fresh per-key nonce. The key generation is bound as AAD so a
+//! ciphertext copy-pasted to a different generation row would fail
+//! authentication.
+//!
+//! Higher-level rotate/rewrap orchestration lives in the parent module; this
+//! file is the storage layer only.
+
+use anyhow::{anyhow, bail, Context, Result};
+use rsa::pkcs8::{
+    DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey, LineEnding,
+};
+use rsa::{RsaPrivateKey, RsaPublicKey};
+use std::time::{SystemTime, UNIX_EPOCH};
+use zeroize::Zeroizing;
+
+use super::db::DbPool;
+use super::master_secret::{aes_gcm_decrypt, aes_gcm_encrypt, MasterKey};
+use super::schema::{insert_meta_if_absent, meta, read_meta_string};
+
+/// Generation number used as the primary key for wrap keys. Nanoseconds since
+/// UNIX_EPOCH; monotonically increasing within one host clock.
+pub type Generation = i64;
+
+/// One persisted wrap key, decrypted into memory.
+#[allow(dead_code)] // Some fields read by future commits (rotate / decrypt path).
+pub struct LoadedKey {
+    pub generation: Generation,
+    pub public_key: RsaPublicKey,
+    pub private_key: RsaPrivateKey,
+    pub retired: bool,
+}
+
+/// Generate a fresh `Generation` value from the system clock.
+pub fn next_generation() -> Result<Generation> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before unix epoch")?
+        .as_nanos();
+    if nanos > i64::MAX as u128 {
+        bail!("nanosecond timestamp overflow");
+    }
+    Ok(nanos as i64)
+}
+
+/// Generate a fresh RSA-3072 key pair.
+pub fn generate_rsa_key_pair() -> Result<RsaPrivateKey> {
+    let mut rng = rand::thread_rng();
+    RsaPrivateKey::new(&mut rng, 3072).context("generate RSA-3072 key pair")
+}
+
+/// Encrypt and persist a freshly generated key as a new generation.
+pub async fn insert_new_generation(
+    pool: &DbPool,
+    master_key: &MasterKey,
+    generation: Generation,
+    private_key: &RsaPrivateKey,
+) -> Result<RsaPublicKey> {
+    let public_key = private_key.to_public_key();
+    let public_pem = public_key
+        .to_public_key_pem(LineEnding::LF)
+        .context("encode public key as PEM")?;
+    let private_pem = private_key
+        .to_pkcs8_pem(LineEnding::LF)
+        .context("encode private key as PKCS#8 PEM")?;
+    let aad = aad_for_generation(generation);
+    let (nonce, tag, ciphertext) = aes_gcm_encrypt(master_key, private_pem.as_bytes(), &aad)
+        .context("encrypt private key under master key")?;
+    let now = current_iso_timestamp()?;
+    match pool {
+        DbPool::MySql(p) => {
+            sqlx::query(
+                "INSERT INTO kbs_managed_keys
+                    (generation, public_key_pem, enc_private_key, iv, tag, created_at)
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(generation)
+            .bind(&public_pem)
+            .bind(&ciphertext)
+            .bind(&nonce)
+            .bind(&tag)
+            .bind(&now)
+            .execute(p)
+            .await
+            .context("insert wrap key (mysql)")?;
+        }
+        DbPool::Sqlite(p) => {
+            sqlx::query(
+                "INSERT INTO kbs_managed_keys
+                    (generation, public_key_pem, enc_private_key, iv, tag, created_at)
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(generation)
+            .bind(&public_pem)
+            .bind(&ciphertext)
+            .bind(&nonce)
+            .bind(&tag)
+            .bind(&now)
+            .execute(p)
+            .await
+            .context("insert wrap key (sqlite)")?;
+        }
+    }
+    Ok(public_key)
+}
+
+/// Load all generations (retired + unretired) and decrypt private keys with
+/// the master key. Returned newest-first so callers can pick the primary as
+/// the first non-retired entry.
+pub async fn load_all_keys(pool: &DbPool, master_key: &MasterKey) -> Result<Vec<LoadedKey>> {
+    let rows: Vec<KeyRow> = match pool {
+        DbPool::MySql(p) => sqlx::query_as::<_, KeyRow>(
+            "SELECT generation, public_key_pem, enc_private_key, iv, tag,
+                    CASE WHEN retired_at IS NULL THEN 0 ELSE 1 END AS retired
+             FROM kbs_managed_keys
+             ORDER BY generation DESC",
+        )
+        .fetch_all(p)
+        .await
+        .context("load wrap keys (mysql)")?,
+        DbPool::Sqlite(p) => sqlx::query_as::<_, KeyRow>(
+            "SELECT generation, public_key_pem, enc_private_key, iv, tag,
+                    CASE WHEN retired_at IS NULL THEN 0 ELSE 1 END AS retired
+             FROM kbs_managed_keys
+             ORDER BY generation DESC",
+        )
+        .fetch_all(p)
+        .await
+        .context("load wrap keys (sqlite)")?,
+    };
+
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let aad = aad_for_generation(row.generation);
+        let private_pem = aes_gcm_decrypt(
+            master_key,
+            &row.iv,
+            &row.tag,
+            &row.enc_private_key,
+            &aad,
+        )
+        .with_context(|| format!("decrypt private key for generation {}", row.generation))?;
+        let private_key = pkcs8_decode_zeroizing(&private_pem)
+            .with_context(|| format!("parse private key for generation {}", row.generation))?;
+        let public_key = RsaPublicKey::from_public_key_pem(&row.public_key_pem)
+            .map_err(|e| anyhow!("parse public key for generation {}: {e}", row.generation))?;
+        out.push(LoadedKey {
+            generation: row.generation,
+            public_key,
+            private_key,
+            retired: row.retired != 0,
+        });
+    }
+    Ok(out)
+}
+
+#[derive(sqlx::FromRow)]
+struct KeyRow {
+    generation: i64,
+    public_key_pem: String,
+    enc_private_key: Vec<u8>,
+    iv: Vec<u8>,
+    tag: Vec<u8>,
+    retired: i64,
+}
+
+fn pkcs8_decode_zeroizing(pem: &Zeroizing<Vec<u8>>) -> Result<RsaPrivateKey> {
+    let pem_str = std::str::from_utf8(pem).map_err(|e| anyhow!("private key PEM utf8: {e}"))?;
+    RsaPrivateKey::from_pkcs8_pem(pem_str).map_err(|e| anyhow!("decode pkcs8: {e}"))
+}
+
+/// Mark every generation older than `cutoff` as retired (idempotent).
+/// Returns the number of rows newly marked.
+pub async fn mark_older_retired(pool: &DbPool, cutoff: Generation) -> Result<u64> {
+    let now = current_iso_timestamp()?;
+    let rows_affected = match pool {
+        DbPool::MySql(p) => sqlx::query(
+            "UPDATE kbs_managed_keys
+             SET retired_at = ?
+             WHERE generation < ? AND retired_at IS NULL",
+        )
+        .bind(&now)
+        .bind(cutoff)
+        .execute(p)
+        .await
+        .context("retire older generations (mysql)")?
+        .rows_affected(),
+        DbPool::Sqlite(p) => sqlx::query(
+            "UPDATE kbs_managed_keys
+             SET retired_at = ?
+             WHERE generation < ? AND retired_at IS NULL",
+        )
+        .bind(&now)
+        .bind(cutoff)
+        .execute(p)
+        .await
+        .context("retire older generations (sqlite)")?
+        .rows_affected(),
+    };
+    Ok(rows_affected)
+}
+
+/// Read the current `primary_generation` pointer.
+pub async fn read_primary_generation(pool: &DbPool) -> Result<Option<Generation>> {
+    let v = read_meta_string(pool, meta::PRIMARY_GENERATION).await?;
+    match v {
+        None => Ok(None),
+        Some(s) => Ok(Some(
+            s.parse::<i64>()
+                .map_err(|e| anyhow!("parse primary_generation: {e}"))?,
+        )),
+    }
+}
+
+/// Read `(primary_generation, bump)` together so callers can detect that
+/// another replica advanced the pointer since their last poll.
+pub async fn read_primary_generation_and_bump(pool: &DbPool) -> Result<Option<(Generation, i64)>> {
+    let row: Option<(String, i64)> = match pool {
+        DbPool::MySql(p) => sqlx::query_as("SELECT v, bump FROM kbs_meta WHERE k = ?")
+            .bind(meta::PRIMARY_GENERATION)
+            .fetch_optional(p)
+            .await
+            .context("read primary_generation + bump (mysql)")?,
+        DbPool::Sqlite(p) => sqlx::query_as("SELECT v, bump FROM kbs_meta WHERE k = ?")
+            .bind(meta::PRIMARY_GENERATION)
+            .fetch_optional(p)
+            .await
+            .context("read primary_generation + bump (sqlite)")?,
+    };
+    let Some((v, bump)) = row else {
+        return Ok(None);
+    };
+    let gen: i64 = v
+        .parse()
+        .map_err(|e| anyhow!("parse primary_generation: {e}"))?;
+    Ok(Some((gen, bump)))
+}
+
+/// Insert the very first `primary_generation` row. Idempotent.
+pub async fn set_primary_generation_initial(
+    pool: &DbPool,
+    generation: Generation,
+) -> Result<()> {
+    insert_meta_if_absent(pool, meta::PRIMARY_GENERATION, &generation.to_string()).await
+}
+
+/// Advance `primary_generation` and bump the counter atomically. The caller
+/// is expected to have first taken the row's exclusive lock via
+/// `lock_primary_generation_for_update` (or to be inside a SQLite-style
+/// serialized transaction).
+pub async fn advance_primary_generation(pool: &DbPool, generation: Generation) -> Result<()> {
+    let new_v = generation.to_string();
+    match pool {
+        DbPool::MySql(p) => {
+            sqlx::query("UPDATE kbs_meta SET v = ?, bump = bump + 1 WHERE k = ?")
+                .bind(&new_v)
+                .bind(meta::PRIMARY_GENERATION)
+                .execute(p)
+                .await
+                .context("advance primary_generation (mysql)")?;
+        }
+        DbPool::Sqlite(p) => {
+            sqlx::query("UPDATE kbs_meta SET v = ?, bump = bump + 1 WHERE k = ?")
+                .bind(&new_v)
+                .bind(meta::PRIMARY_GENERATION)
+                .execute(p)
+                .await
+                .context("advance primary_generation (sqlite)")?;
+        }
+    }
+    Ok(())
+}
+
+/// AAD format used for AES-GCM-encrypting a private key, binding it to its
+/// generation.
+pub fn aad_for_generation(generation: Generation) -> Vec<u8> {
+    format!("trustee-mkey-{generation}").into_bytes()
+}
+
+/// Format the current wall-clock as ISO8601 with microsecond precision; the
+/// `DATETIME(6)` columns on MySQL accept this directly, and SQLite stores it
+/// as TEXT.
+fn current_iso_timestamp() -> Result<String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before unix epoch")?;
+    let secs = now.as_secs() as i64;
+    let micros = now.subsec_micros();
+    let datetime = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, micros * 1_000)
+        .ok_or_else(|| anyhow!("convert system time to chrono"))?;
+    Ok(datetime.format("%Y-%m-%d %H:%M:%S%.6f").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::implementations::resource::encrypted_db::master_secret::{
+        derive_master_key, generate_salt, Argon2Params, MASTER_KEY_LEN,
+    };
+    use crate::plugins::implementations::resource::encrypted_db::schema::{
+        ensure_meta_defaults, migrate_schema,
+    };
+    use zeroize::Zeroizing;
+
+    fn fast_key() -> MasterKey {
+        let salt = generate_salt();
+        let p = Argon2Params {
+            m_cost: 8 * 1024,
+            t_cost: 1,
+            p_cost: 1,
+        };
+        derive_master_key(b"unit-test", &salt, p).unwrap()
+    }
+
+    async fn fresh_pool() -> DbPool {
+        let pool = DbPool::connect_sqlite_memory().await.unwrap();
+        migrate_schema(&pool).await.unwrap();
+        ensure_meta_defaults(&pool, None).await.unwrap();
+        pool
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn insert_and_load_round_trip() {
+        let pool = fresh_pool().await;
+        let master = fast_key();
+
+        let priv1 = generate_rsa_key_pair().unwrap();
+        let gen1 = next_generation().unwrap();
+        let pub1 = insert_new_generation(&pool, &master, gen1, &priv1)
+            .await
+            .expect("insert");
+
+        let keys = load_all_keys(&pool, &master).await.expect("load");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].generation, gen1);
+        assert!(!keys[0].retired);
+        assert_eq!(
+            keys[0].public_key.to_public_key_pem(LineEnding::LF).unwrap(),
+            pub1.to_public_key_pem(LineEnding::LF).unwrap()
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn duplicate_generation_insert_rejected() {
+        let pool = fresh_pool().await;
+        let master = fast_key();
+        let priv1 = generate_rsa_key_pair().unwrap();
+        let gen1 = 12345i64;
+        insert_new_generation(&pool, &master, gen1, &priv1).await.unwrap();
+        let priv2 = generate_rsa_key_pair().unwrap();
+        let err = insert_new_generation(&pool, &master, gen1, &priv2)
+            .await
+            .expect_err("PK conflict");
+        let s = format!("{err:#}");
+        assert!(
+            s.contains("UNIQUE")
+                || s.contains("constraint")
+                || s.contains("Duplicate")
+                || s.contains("PRIMARY"),
+            "expected uniqueness error, got {s}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn aad_binding_prevents_swap() {
+        let pool = fresh_pool().await;
+        let master = fast_key();
+        let priv1 = generate_rsa_key_pair().unwrap();
+        let priv2 = generate_rsa_key_pair().unwrap();
+        let gen1 = 100i64;
+        let gen2 = 200i64;
+        insert_new_generation(&pool, &master, gen1, &priv1).await.unwrap();
+        insert_new_generation(&pool, &master, gen2, &priv2).await.unwrap();
+
+        // Manually swap the encrypted bytes between rows and confirm that
+        // load_all_keys rejects the result (AAD mismatch).
+        let DbPool::Sqlite(p) = &pool else { unreachable!() };
+        let row1: (Vec<u8>, Vec<u8>, Vec<u8>) = sqlx::query_as(
+            "SELECT enc_private_key, iv, tag FROM kbs_managed_keys WHERE generation = ?",
+        )
+        .bind(gen1)
+        .fetch_one(p)
+        .await
+        .unwrap();
+        sqlx::query("UPDATE kbs_managed_keys SET enc_private_key = ?, iv = ?, tag = ? WHERE generation = ?")
+            .bind(&row1.0).bind(&row1.1).bind(&row1.2).bind(gen2)
+            .execute(p).await.unwrap();
+
+        let err = match load_all_keys(&pool, &master).await {
+            Ok(_) => panic!("AAD mismatch: load should have failed"),
+            Err(e) => e,
+        };
+        assert!(format!("{err:#}").contains("decrypt"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn wrong_master_key_fails_load() {
+        let pool = fresh_pool().await;
+        let master_a = fast_key();
+        let master_b: MasterKey = Zeroizing::new([0xAA; MASTER_KEY_LEN]);
+        let priv1 = generate_rsa_key_pair().unwrap();
+        insert_new_generation(&pool, &master_a, 1, &priv1).await.unwrap();
+        let err = match load_all_keys(&pool, &master_b).await {
+            Ok(_) => panic!("wrong master key: load should have failed"),
+            Err(e) => e,
+        };
+        assert!(format!("{err:#}").contains("decrypt"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn primary_generation_seed_and_advance() {
+        let pool = fresh_pool().await;
+        let master = fast_key();
+
+        assert!(read_primary_generation(&pool).await.unwrap().is_none());
+
+        let priv1 = generate_rsa_key_pair().unwrap();
+        let gen1 = 100i64;
+        insert_new_generation(&pool, &master, gen1, &priv1).await.unwrap();
+        set_primary_generation_initial(&pool, gen1).await.unwrap();
+
+        // Idempotent: seeding twice does not change the value.
+        set_primary_generation_initial(&pool, gen1 + 999).await.unwrap();
+        let (cur, bump_before) = read_primary_generation_and_bump(&pool)
+            .await
+            .unwrap()
+            .expect("primary set");
+        assert_eq!(cur, gen1);
+
+        // Advance bumps both pointer and counter.
+        let priv2 = generate_rsa_key_pair().unwrap();
+        let gen2 = 200i64;
+        insert_new_generation(&pool, &master, gen2, &priv2).await.unwrap();
+        advance_primary_generation(&pool, gen2).await.unwrap();
+
+        let (cur, bump_after) = read_primary_generation_and_bump(&pool)
+            .await
+            .unwrap()
+            .expect("primary set");
+        assert_eq!(cur, gen2);
+        assert_eq!(bump_after, bump_before + 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn retire_marks_generation_without_deletion() {
+        let pool = fresh_pool().await;
+        let master = fast_key();
+        let priv1 = generate_rsa_key_pair().unwrap();
+        let priv2 = generate_rsa_key_pair().unwrap();
+        insert_new_generation(&pool, &master, 100, &priv1).await.unwrap();
+        insert_new_generation(&pool, &master, 200, &priv2).await.unwrap();
+
+        let n = mark_older_retired(&pool, 200).await.unwrap();
+        assert_eq!(n, 1);
+
+        let keys = load_all_keys(&pool, &master).await.unwrap();
+        assert_eq!(keys.len(), 2, "row stays for decryption use");
+        let retired: Vec<bool> = keys.iter().map(|k| k.retired).collect();
+        assert_eq!(retired, vec![false, true]); // newest first
+    }
+}

--- a/kbs/src/plugins/implementations/resource/encrypted_db/master_secret.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/master_secret.rs
@@ -176,7 +176,10 @@ pub fn aes_gcm_decrypt(
     aad: &[u8],
 ) -> Result<Zeroizing<Vec<u8>>> {
     if nonce.len() != NONCE_LEN {
-        bail!("aes-gcm nonce must be {NONCE_LEN} bytes, got {}", nonce.len());
+        bail!(
+            "aes-gcm nonce must be {NONCE_LEN} bytes, got {}",
+            nonce.len()
+        );
     }
     if tag.len() != TAG_LEN {
         bail!("aes-gcm tag must be {TAG_LEN} bytes, got {}", tag.len());

--- a/kbs/src/plugins/implementations/resource/encrypted_db/master_secret.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/master_secret.rs
@@ -2,20 +2,291 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Master secret loading + Argon2id KDF for the `EncryptedDb` backend. Real
-//! implementation lands in commit 2 (this scaffold only exposes the type so
-//! the surrounding module compiles).
+//! Master secret loading and KDF for the `EncryptedDb` backend.
+//!
+//! Operators provision a passphrase via a Kubernetes Secret mounted as a
+//! tmpfs file (default path `/run/trustee/master.passphrase`). On startup,
+//! KBS reads the file, derives a 32-byte master key with Argon2id using a
+//! salt + parameters persisted in the database, and uses that master key to
+//! AES-GCM-encrypt every wrap private key at rest. The passphrase bytes are
+//! zeroed immediately after derivation; only the derived master key remains
+//! in memory for the process lifetime.
+//!
+//! The database also stores a "canary" — a fixed plaintext encrypted with
+//! the master key — so a wrong passphrase is detected on startup and KBS
+//! refuses to start, preventing follow-up writes from poisoning the table
+//! with garbage-keyed entries.
+
+use std::fs;
+
+use aes_gcm::{
+    aead::{Aead, KeyInit, Payload},
+    Aes256Gcm, Nonce,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use argon2::{Algorithm, Argon2, Params, Version};
+use rand::RngCore;
+use zeroize::{Zeroize, Zeroizing};
+
+/// Plaintext that the canary row encrypts. Includes a version tag so we can
+/// rotate the canary scheme without breaking existing deployments.
+pub const CANARY_PLAINTEXT: &[u8] = b"trustee-master-canary-v1";
+
+/// Length in bytes of the AES-256 master key derived from the passphrase.
+pub const MASTER_KEY_LEN: usize = 32;
+
+/// Length in bytes of the random salt persisted in `kbs_meta.kdf.salt_b64`.
+pub const SALT_LEN: usize = 32;
+
+/// Length in bytes of an AES-GCM nonce (per call, randomly generated).
+pub const NONCE_LEN: usize = 12;
+
+/// Length in bytes of the AES-GCM authentication tag.
+pub const TAG_LEN: usize = 16;
+
+/// Default Argon2id parameters: tuned to derive a master key in well under
+/// one second on a modest VM while making offline brute-force expensive.
+pub const DEFAULT_ARGON2_M_COST: u32 = 65_536; // 64 MiB
+pub const DEFAULT_ARGON2_T_COST: u32 = 3;
+pub const DEFAULT_ARGON2_P_COST: u32 = 4;
+
+/// Loaded master key. The inner buffer is wiped on drop.
+pub type MasterKey = Zeroizing<[u8; MASTER_KEY_LEN]>;
+
+/// Argon2id parameters persisted in the database alongside the salt.
+#[derive(Debug, Clone, Copy)]
+pub struct Argon2Params {
+    pub m_cost: u32,
+    pub t_cost: u32,
+    pub p_cost: u32,
+}
+
+impl Default for Argon2Params {
+    fn default() -> Self {
+        Self {
+            m_cost: DEFAULT_ARGON2_M_COST,
+            t_cost: DEFAULT_ARGON2_T_COST,
+            p_cost: DEFAULT_ARGON2_P_COST,
+        }
+    }
+}
 
 /// Reads the master passphrase from a file (typically a Kubernetes Secret
 /// mounted as a tmpfs file at `/run/trustee/master.passphrase`).
 pub struct FileMasterSecretProvider {
-    _path: String,
+    path: String,
 }
 
 impl FileMasterSecretProvider {
     pub fn new(path: &str) -> Self {
         Self {
-            _path: path.to_string(),
+            path: path.to_string(),
         }
+    }
+
+    /// Read the passphrase, trim trailing whitespace (most editors / tools
+    /// add a trailing `\n`), and return the bytes wrapped for zeroization.
+    pub fn fetch(&self) -> Result<Zeroizing<Vec<u8>>> {
+        let mut bytes = fs::read(&self.path).with_context(|| {
+            format!(
+                "read master secret file `{}`; ensure it is mounted (e.g. as a Kubernetes Secret)",
+                self.path
+            )
+        })?;
+        // Trim trailing whitespace in place. We can't simply call .trim_end()
+        // and copy because that would leave the original bytes in memory.
+        while bytes
+            .last()
+            .copied()
+            .is_some_and(|b| b == b'\n' || b == b'\r' || b == b' ' || b == b'\t')
+        {
+            let last_index = bytes.len() - 1;
+            bytes[last_index] = 0;
+            bytes.truncate(last_index);
+        }
+        if bytes.is_empty() {
+            bail!(
+                "master secret file `{}` is empty after trimming whitespace",
+                self.path
+            );
+        }
+        Ok(Zeroizing::new(bytes))
+    }
+}
+
+/// Generate a fresh random salt of the canonical length.
+pub fn generate_salt() -> [u8; SALT_LEN] {
+    let mut salt = [0u8; SALT_LEN];
+    rand::thread_rng().fill_bytes(&mut salt);
+    salt
+}
+
+/// Derive the 32-byte master key from the passphrase using Argon2id with the
+/// given salt and parameters. The passphrase argument is consumed (zeroed) by
+/// the caller via `Zeroizing`.
+pub fn derive_master_key(
+    passphrase: &[u8],
+    salt: &[u8],
+    params: Argon2Params,
+) -> Result<MasterKey> {
+    let argon2_params = Params::new(params.m_cost, params.t_cost, params.p_cost, None)
+        .map_err(|e| anyhow!("invalid argon2id parameters: {e}"))?;
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, argon2_params);
+
+    let mut out = [0u8; MASTER_KEY_LEN];
+    argon2
+        .hash_password_into(passphrase, salt, &mut out)
+        .map_err(|e| anyhow!("argon2id derivation failed: {e}"))?;
+    Ok(Zeroizing::new(out))
+}
+
+/// AES-256-GCM encrypt with a fresh random nonce. Returns `(nonce, tag, ciphertext)`.
+pub fn aes_gcm_encrypt(
+    key: &MasterKey,
+    plaintext: &[u8],
+    aad: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+    let cipher = Aes256Gcm::new_from_slice(&**key).map_err(|e| anyhow!("aes-gcm key: {e}"))?;
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let payload = Payload {
+        msg: plaintext,
+        aad,
+    };
+    let ct_with_tag = cipher
+        .encrypt(nonce, payload)
+        .map_err(|e| anyhow!("aes-gcm encrypt: {e}"))?;
+    if ct_with_tag.len() < TAG_LEN {
+        bail!("aes-gcm output shorter than tag length");
+    }
+    let tag_offset = ct_with_tag.len() - TAG_LEN;
+    let ciphertext = ct_with_tag[..tag_offset].to_vec();
+    let tag = ct_with_tag[tag_offset..].to_vec();
+    Ok((nonce_bytes.to_vec(), tag, ciphertext))
+}
+
+/// AES-256-GCM decrypt. Authentication failure (wrong key, tampered ciphertext,
+/// or wrong AAD) returns `Err`.
+pub fn aes_gcm_decrypt(
+    key: &MasterKey,
+    nonce: &[u8],
+    tag: &[u8],
+    ciphertext: &[u8],
+    aad: &[u8],
+) -> Result<Zeroizing<Vec<u8>>> {
+    if nonce.len() != NONCE_LEN {
+        bail!("aes-gcm nonce must be {NONCE_LEN} bytes, got {}", nonce.len());
+    }
+    if tag.len() != TAG_LEN {
+        bail!("aes-gcm tag must be {TAG_LEN} bytes, got {}", tag.len());
+    }
+    let cipher = Aes256Gcm::new_from_slice(&**key).map_err(|e| anyhow!("aes-gcm key: {e}"))?;
+    let nonce = Nonce::from_slice(nonce);
+    let mut joined = Vec::with_capacity(ciphertext.len() + tag.len());
+    joined.extend_from_slice(ciphertext);
+    joined.extend_from_slice(tag);
+    let payload = Payload { msg: &joined, aad };
+    let plaintext = cipher
+        .decrypt(nonce, payload)
+        .map_err(|_| anyhow!("aes-gcm authentication failed"))?;
+    joined.zeroize();
+    Ok(Zeroizing::new(plaintext))
+}
+
+/// Encrypt `CANARY_PLAINTEXT` under the master key. The result is what gets
+/// persisted into `kbs_meta` on first startup.
+pub fn encrypt_canary(key: &MasterKey) -> Result<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+    aes_gcm_encrypt(key, CANARY_PLAINTEXT, b"canary")
+}
+
+/// Verify that the master key decrypts the persisted canary to the expected
+/// plaintext. Returns `Ok(())` on match, `Err` otherwise (wrong passphrase or
+/// tampered canary).
+pub fn verify_canary(key: &MasterKey, nonce: &[u8], tag: &[u8], ciphertext: &[u8]) -> Result<()> {
+    let plaintext = aes_gcm_decrypt(key, nonce, tag, ciphertext, b"canary")
+        .context("master secret canary did not decrypt; passphrase is wrong or has been changed")?;
+    if &**plaintext != CANARY_PLAINTEXT {
+        bail!("master secret canary plaintext mismatch (corrupted entry?)");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn fast_params() -> Argon2Params {
+        // Smaller knobs for fast unit tests; production uses defaults.
+        Argon2Params {
+            m_cost: 8 * 1024,
+            t_cost: 1,
+            p_cost: 1,
+        }
+    }
+
+    #[test]
+    fn fetch_trims_trailing_whitespace() {
+        let mut f = NamedTempFile::new().expect("tempfile");
+        writeln!(f, "hunter2").expect("write");
+        let provider = FileMasterSecretProvider::new(f.path().to_str().unwrap());
+        let bytes = provider.fetch().expect("fetch");
+        assert_eq!(&bytes[..], b"hunter2");
+    }
+
+    #[test]
+    fn fetch_rejects_empty_file() {
+        let f = NamedTempFile::new().expect("tempfile");
+        let provider = FileMasterSecretProvider::new(f.path().to_str().unwrap());
+        let err = provider.fetch().expect_err("must error on empty");
+        assert!(format!("{err:#}").contains("empty"));
+    }
+
+    #[test]
+    fn kdf_is_deterministic_per_salt_and_params() {
+        let salt = [7u8; SALT_LEN];
+        let p = fast_params();
+        let k1 = derive_master_key(b"password", &salt, p).unwrap();
+        let k2 = derive_master_key(b"password", &salt, p).unwrap();
+        assert_eq!(*k1, *k2);
+    }
+
+    #[test]
+    fn kdf_diverges_on_different_passphrase_or_salt() {
+        let p = fast_params();
+        let s1 = [1u8; SALT_LEN];
+        let s2 = [2u8; SALT_LEN];
+        let k1 = derive_master_key(b"a", &s1, p).unwrap();
+        let k2 = derive_master_key(b"b", &s1, p).unwrap();
+        let k3 = derive_master_key(b"a", &s2, p).unwrap();
+        assert_ne!(*k1, *k2);
+        assert_ne!(*k1, *k3);
+    }
+
+    #[test]
+    fn aes_gcm_round_trip() {
+        let key: MasterKey = Zeroizing::new([9u8; MASTER_KEY_LEN]);
+        let (nonce, tag, ct) = aes_gcm_encrypt(&key, b"hello world", b"aad").unwrap();
+        let pt = aes_gcm_decrypt(&key, &nonce, &tag, &ct, b"aad").unwrap();
+        assert_eq!(&**pt, b"hello world");
+    }
+
+    #[test]
+    fn aes_gcm_rejects_wrong_aad() {
+        let key: MasterKey = Zeroizing::new([9u8; MASTER_KEY_LEN]);
+        let (nonce, tag, ct) = aes_gcm_encrypt(&key, b"hello", b"aad-1").unwrap();
+        assert!(aes_gcm_decrypt(&key, &nonce, &tag, &ct, b"aad-2").is_err());
+    }
+
+    #[test]
+    fn canary_round_trip_and_wrong_key_rejected() {
+        let key_good: MasterKey = Zeroizing::new([4u8; MASTER_KEY_LEN]);
+        let key_bad: MasterKey = Zeroizing::new([5u8; MASTER_KEY_LEN]);
+        let (nonce, tag, ct) = encrypt_canary(&key_good).unwrap();
+        verify_canary(&key_good, &nonce, &tag, &ct).expect("good key verifies");
+        let err = verify_canary(&key_bad, &nonce, &tag, &ct).expect_err("bad key rejected");
+        assert!(format!("{err:#}").contains("canary"));
     }
 }

--- a/kbs/src/plugins/implementations/resource/encrypted_db/master_secret.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/master_secret.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Master secret loading + Argon2id KDF for the `EncryptedDb` backend. Real
+//! implementation lands in commit 2 (this scaffold only exposes the type so
+//! the surrounding module compiles).
+
+/// Reads the master passphrase from a file (typically a Kubernetes Secret
+/// mounted as a tmpfs file at `/run/trustee/master.passphrase`).
+pub struct FileMasterSecretProvider {
+    _path: String,
+}
+
+impl FileMasterSecretProvider {
+    pub fn new(path: &str) -> Self {
+        Self {
+            _path: path.to_string(),
+        }
+    }
+}

--- a/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
@@ -4,37 +4,60 @@
 
 //! `EncryptedDb` resource backend.
 //!
-//! Stores wrap keys and resource envelopes in a shared SQL database (MySQL or
-//! SQLite) so multiple KBS replicas can share one set of managed keys. The
-//! private keys are encrypted at rest with a deployment-level master secret
-//! derived from a passphrase via Argon2id, so a database-only compromise does
-//! not yield plaintext key material.
+//! Stores wrap keys and resource envelopes in a shared SQL database (MySQL
+//! or SQLite) so multiple KBS replicas can share one set of managed keys.
+//! The private keys are encrypted at rest with a deployment-level master
+//! secret derived from a passphrase via Argon2id, so a database-only
+//! compromise does not yield plaintext key material.
 //!
-//! See `kbs/docs/resource_storage_backend_encrypted_db.md` for the user-facing
-//! documentation.
+//! See `kbs/docs/resource_storage_backend_encrypted_db.md` for the
+//! user-facing documentation.
 
+mod crypto;
 mod db;
 mod key_store;
 mod master_secret;
 mod resource_store;
 mod schema;
 
-use anyhow::{bail, Result};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, bail, Context, Result};
+use rsa::pkcs8::{EncodePublicKey, LineEnding};
+use rsa::{RsaPrivateKey, RsaPublicKey};
 use serde::Deserialize;
 
 use super::{ResourceDesc, RewrapReport, RotateReport, StorageBackend};
+
+use crypto::{decrypt_envelope_with_ring, rewrap_envelope, Envelope};
+use db::DbPool;
+use key_store::{
+    advance_primary_generation, generate_rsa_key_pair, insert_new_generation, load_all_keys,
+    mark_older_retired, next_generation, read_primary_generation,
+    read_primary_generation_and_bump, set_primary_generation_initial, Generation, LoadedKey,
+};
+use master_secret::{
+    derive_master_key, verify_canary, FileMasterSecretProvider, MasterKey,
+};
+use resource_store::{
+    delete_resource, fetch_batch_older_than, list_resources, read_envelope, update_envelope,
+    upsert_envelope,
+};
+use schema::{ensure_meta_defaults, migrate_schema, read_argon2_params, read_canary, read_salt};
 
 /// User-facing configuration for the `EncryptedDb` resource backend.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
 pub struct EncryptedDbBackendConfig {
     /// Path to the file holding the master secret (passphrase). Defaults to
-    /// `/run/trustee/master.passphrase` (typically a Kubernetes Secret mounted
-    /// as a tmpfs file).
+    /// `/run/trustee/master.passphrase` (typically a Kubernetes Secret
+    /// mounted as a tmpfs file).
     #[serde(default = "default_master_secret_path")]
     pub master_secret_path: String,
 
     /// How often, in milliseconds, each replica polls the `bump` counter to
-    /// detect that another replica has rotated the key. Defaults to 5000ms.
+    /// detect that another replica has rotated the key. Defaults to 5000 ms.
     #[serde(default = "default_bump_poll_interval_ms")]
     pub bump_poll_interval_ms: u64,
 
@@ -48,17 +71,12 @@ pub struct DatabaseConfig {
     #[serde(rename = "type")]
     pub kind: String,
 
-    /// MySQL DSN, e.g. `mysql://user:pass@host:port/db?ssl-mode=PREFERRED`.
-    /// Required when `kind == "mysql"`.
     #[serde(default)]
     pub dsn: String,
 
-    /// SQLite database file path. Required when `kind == "sqlite"`.
-    /// Use `":memory:"` for an ephemeral in-process database (tests only).
     #[serde(default)]
     pub path: String,
 
-    /// MySQL connection pool tuning.
     #[serde(default)]
     pub max_open_conns: u32,
     #[serde(default)]
@@ -66,11 +84,11 @@ pub struct DatabaseConfig {
     #[serde(default)]
     pub conn_max_lifetime: String,
 
-    /// How long a retired key is kept in the database before it is physically
-    /// purged. Accepts a humantime-style string (`"30d"`, `"168h"`); `"0"`
-    /// disables purging entirely. The minimum non-zero value is `"1h"` to
-    /// avoid accidentally orphaning resources uploaded with a stale public key
-    /// during a rotation race.
+    /// How long a retired key is kept in the database before it is purged.
+    /// Accepts `"30d"`, `"168h"`, etc. `"0"` disables purging entirely. The
+    /// minimum non-zero value is `"1h"` (smaller values are rejected to
+    /// avoid orphaning resources written with a stale public key during a
+    /// rotation race). Default `"30d"`.
     #[serde(default = "default_retired_key_purge_after")]
     pub retired_key_purge_after: String,
 }
@@ -87,55 +105,656 @@ fn default_retired_key_purge_after() -> String {
     "30d".to_string()
 }
 
-/// Placeholder backend; real implementation lands in a follow-up commit. Kept
-/// behind the `encrypted-db` feature so that scaffolding compiles before the
-/// rest of the implementation is in place.
+/// In-memory snapshot of the wrap keys, swapped wholesale on reload.
+struct KeyRing {
+    /// Newest-first; used for trial decryption and as the rewrap candidate
+    /// pool (the first non-retired entry is the primary).
+    keys: Vec<LoadedKey>,
+    /// Public key clients must use to encrypt new resources.
+    primary_public: Option<RsaPublicKey>,
+    /// Generation number of the primary key.
+    primary_generation: Option<Generation>,
+}
+
 pub struct EncryptedDb {
-    _config: EncryptedDbBackendConfig,
+    pool: DbPool,
+    master_key: MasterKey,
+    ring: RwLock<Arc<KeyRing>>,
+    /// Last seen `kbs_meta.bump` counter (cached for cheap-poll skips).
+    last_bump: AtomicI64,
+    /// Last UNIX-millisecond timestamp at which we polled the bump counter.
+    last_poll_ms: AtomicI64,
+    poll_interval: Duration,
+    /// Active rotation flag — best-effort guard against this replica
+    /// scheduling two rotates back-to-back. The DB row lock is the
+    /// authoritative cross-replica mutex.
+    rotation_in_progress: AtomicU64,
 }
 
 impl EncryptedDb {
     pub fn new(config: &EncryptedDbBackendConfig) -> Result<Self> {
-        let _ = master_secret::FileMasterSecretProvider::new(&config.master_secret_path);
-        bail!("EncryptedDb backend is not implemented yet (feature scaffold)")
+        // The plug-in framework calls us synchronously, but everything we
+        // actually do is async. Spin up a small block_on bridge.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("build tokio runtime for EncryptedDb init")?;
+        runtime.block_on(Self::init_async(config))
+    }
+
+    async fn init_async(config: &EncryptedDbBackendConfig) -> Result<Self> {
+        let pool = DbPool::connect(&config.database).await?;
+        migrate_schema(&pool).await?;
+        // Seed defaults *without* the master key so the salt + KDF params
+        // exist by the time we derive the master key from them.
+        ensure_meta_defaults(&pool, None).await?;
+
+        let provider = FileMasterSecretProvider::new(&config.master_secret_path);
+        let passphrase = provider.fetch()?;
+
+        let salt = read_salt(&pool).await?;
+        let argon2_params = read_argon2_params(&pool).await?;
+        let master_key = derive_master_key(&passphrase, &salt, argon2_params)?;
+
+        // Now seed the canary (creates it on first start) and verify it
+        // (rejects any subsequent start under a different passphrase).
+        ensure_meta_defaults(&pool, Some(&master_key)).await?;
+        let canary = read_canary(&pool)
+            .await?
+            .ok_or_else(|| anyhow!("canary missing after ensure_meta_defaults"))?;
+        verify_canary(&master_key, &canary.0, &canary.1, &canary.2).context(
+            "EncryptedDb refusing to start: master secret canary did not verify. \
+             The passphrase is wrong, or the canary row was tampered with.",
+        )?;
+
+        // First-time bootstrap: if no wrap keys exist, generate one.
+        if read_primary_generation(&pool).await?.is_none() {
+            let private_key = generate_rsa_key_pair()?;
+            let generation = next_generation()?;
+            // Race: a peer replica may have INSERTed concurrently. We
+            // tolerate the unique-PK error and re-read state below.
+            match insert_new_generation(&pool, &master_key, generation, &private_key).await {
+                Ok(_) => {
+                    set_primary_generation_initial(&pool, generation).await?;
+                    log::info!("EncryptedDb: bootstrapped initial wrap key generation {generation}");
+                }
+                Err(e) => {
+                    let s = format!("{e:#}");
+                    if s.contains("UNIQUE")
+                        || s.contains("Duplicate")
+                        || s.contains("PRIMARY")
+                        || s.contains("constraint")
+                    {
+                        log::info!(
+                            "EncryptedDb: lost bootstrap race, using peer's wrap key"
+                        );
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
+        let ring = Self::load_ring(&pool, &master_key).await?;
+        let bump = read_primary_generation_and_bump(&pool)
+            .await?
+            .map(|(_, b)| b)
+            .unwrap_or(0);
+
+        let poll_interval = Duration::from_millis(config.bump_poll_interval_ms.max(100));
+
+        Ok(Self {
+            pool,
+            master_key,
+            ring: RwLock::new(Arc::new(ring)),
+            last_bump: AtomicI64::new(bump),
+            last_poll_ms: AtomicI64::new(unix_ms_now()),
+            poll_interval,
+            rotation_in_progress: AtomicU64::new(0),
+        })
+    }
+
+    /// Build a new `KeyRing` snapshot from the current database state.
+    async fn load_ring(pool: &DbPool, master_key: &MasterKey) -> Result<KeyRing> {
+        let keys = load_all_keys(pool, master_key).await?;
+        let primary_generation = read_primary_generation(pool).await?;
+        let primary_public = primary_generation.and_then(|gen| {
+            keys.iter()
+                .find(|k| k.generation == gen && !k.retired)
+                .map(|k| k.public_key.clone())
+        });
+        Ok(KeyRing {
+            keys,
+            primary_public,
+            primary_generation,
+        })
+    }
+
+    fn ring_snapshot(&self) -> Arc<KeyRing> {
+        self.ring.read().expect("key ring lock poisoned").clone()
+    }
+
+    /// Cheap-poll the `bump` counter; reload the in-memory ring if another
+    /// replica has rotated since our last visit. Throttled by
+    /// `poll_interval` so a high request rate does not flood the database.
+    async fn maybe_reload_on_bump(&self) -> Result<()> {
+        let now_ms = unix_ms_now();
+        let last_ms = self.last_poll_ms.load(Ordering::Relaxed);
+        if now_ms - last_ms < self.poll_interval.as_millis() as i64 {
+            return Ok(());
+        }
+        // Optimistically claim the next poll slot. A racing thread may
+        // already have updated it — that's fine, we just skip.
+        if self
+            .last_poll_ms
+            .compare_exchange(last_ms, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return Ok(());
+        }
+        let Some((_, cur_bump)) = read_primary_generation_and_bump(&self.pool).await? else {
+            return Ok(());
+        };
+        let prev = self.last_bump.load(Ordering::Relaxed);
+        if cur_bump > prev {
+            log::info!(
+                "EncryptedDb: bump advanced ({prev} -> {cur_bump}); reloading key ring"
+            );
+            self.reload_ring_now().await?;
+            self.last_bump.store(cur_bump, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+
+    async fn reload_ring_now(&self) -> Result<()> {
+        let ring = Self::load_ring(&self.pool, &self.master_key).await?;
+        *self.ring.write().expect("key ring lock poisoned") = Arc::new(ring);
+        Ok(())
+    }
+
+    /// Re-wrap a single envelope onto the primary public key (from the
+    /// supplied snapshot). Returns whether the row was actually rewritten.
+    async fn rewrap_one_resource(
+        &self,
+        desc: &ResourceDesc,
+        ring: &KeyRing,
+        primary_public: &RsaPublicKey,
+        primary_generation: Generation,
+        existing_envelope: &[u8],
+    ) -> Result<bool> {
+        let decrypt_keys: Vec<RsaPrivateKey> =
+            ring.keys.iter().map(|k| k.private_key.clone()).collect();
+        match rewrap_envelope(existing_envelope, &decrypt_keys, primary_public)? {
+            Some(new_env_bytes) => {
+                update_envelope(&self.pool, desc, &new_env_bytes, primary_generation).await?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl StorageBackend for EncryptedDb {
-    async fn read_secret_resource(&self, _resource_desc: ResourceDesc) -> Result<Vec<u8>> {
-        bail!("EncryptedDb: read not implemented yet")
+    async fn read_secret_resource(&self, resource_desc: ResourceDesc) -> Result<Vec<u8>> {
+        self.maybe_reload_on_bump().await?;
+        let raw = read_envelope(&self.pool, &resource_desc)
+            .await?
+            .ok_or_else(|| anyhow!("resource `{resource_desc}` not found"))?;
+        let env: Envelope = match serde_json::from_slice(&raw) {
+            Ok(e) => e,
+            // Bytes that are not a parseable envelope are treated as
+            // plaintext (should be rare; admin tooling generally always
+            // POSTs envelopes). We then return them verbatim.
+            Err(_) => return Ok(raw),
+        };
+        let ring = self.ring_snapshot();
+        // Try a normal decrypt first.
+        let decrypt_keys: Vec<RsaPrivateKey> =
+            ring.keys.iter().map(|k| k.private_key.clone()).collect();
+        match decrypt_envelope_with_ring(&env, &decrypt_keys) {
+            Ok(plain) => Ok(plain),
+            Err(_) if ring.keys.is_empty() => {
+                bail!("no decryption keys loaded; check master secret and database state")
+            }
+            Err(_first_err) => {
+                // Fall back: another replica may have just rotated and our
+                // cached ring is one version behind. Force a reload and
+                // retry once.
+                log::warn!(
+                    "EncryptedDb: trial decryption failed with cached ring ({} key(s)); forcing reload",
+                    ring.keys.len()
+                );
+                self.reload_ring_now().await?;
+                let ring = self.ring_snapshot();
+                let decrypt_keys: Vec<RsaPrivateKey> =
+                    ring.keys.iter().map(|k| k.private_key.clone()).collect();
+                decrypt_envelope_with_ring(&env, &decrypt_keys)
+                    .context("decrypt resource (after forced reload)")
+            }
+        }
     }
 
-    async fn write_secret_resource(
-        &self,
-        _resource_desc: ResourceDesc,
-        _data: &[u8],
-    ) -> Result<()> {
-        bail!("EncryptedDb: write not implemented yet")
+    async fn write_secret_resource(&self, resource_desc: ResourceDesc, data: &[u8]) -> Result<()> {
+        self.maybe_reload_on_bump().await?;
+        let ring = self.ring_snapshot();
+        let generation = ring
+            .primary_generation
+            .ok_or_else(|| anyhow!("no primary key generation; cannot tag resource"))?;
+        upsert_envelope(&self.pool, &resource_desc, data, generation).await?;
+        Ok(())
     }
 
-    async fn delete_secret_resource(&self, _resource_desc: ResourceDesc) -> Result<()> {
-        bail!("EncryptedDb: delete not implemented yet")
+    async fn delete_secret_resource(&self, resource_desc: ResourceDesc) -> Result<()> {
+        delete_resource(&self.pool, &resource_desc).await
     }
 
     async fn list_secret_resources(&self) -> Result<Vec<ResourceDesc>> {
-        bail!("EncryptedDb: list not implemented yet")
+        list_resources(&self.pool).await
     }
 
     async fn reload_keys(&self) -> Result<usize> {
-        bail!("EncryptedDb: reload_keys not implemented yet")
+        self.reload_ring_now().await?;
+        if let Some((_, b)) = read_primary_generation_and_bump(&self.pool).await? {
+            self.last_bump.store(b, Ordering::Relaxed);
+        }
+        let ring = self.ring_snapshot();
+        Ok(ring.keys.len())
     }
 
     async fn rewrap_resources(&self) -> Result<RewrapReport> {
-        bail!("EncryptedDb: rewrap_resources not implemented yet")
+        self.maybe_reload_on_bump().await?;
+        let ring = self.ring_snapshot();
+        let primary_public = ring
+            .primary_public
+            .clone()
+            .ok_or_else(|| anyhow!("rewrap: no primary public key in ring"))?;
+        let primary_generation = ring
+            .primary_generation
+            .ok_or_else(|| anyhow!("rewrap: no primary generation in ring"))?;
+
+        let mut report = RewrapReport::default();
+        // Fetch in batches to keep memory bounded for large tables.
+        const BATCH: i64 = 200;
+        loop {
+            let batch =
+                fetch_batch_older_than(&self.pool, primary_generation, BATCH).await?;
+            if batch.is_empty() {
+                break;
+            }
+            let count = batch.len();
+            for row in batch {
+                report.total += 1;
+                let desc = ResourceDesc {
+                    repository_name: row.repository_name,
+                    resource_type: row.resource_type,
+                    resource_tag: row.resource_tag,
+                };
+                match self
+                    .rewrap_one_resource(
+                        &desc,
+                        &ring,
+                        &primary_public,
+                        primary_generation,
+                        row.envelope.as_bytes(),
+                    )
+                    .await
+                {
+                    Ok(true) => report.rewrapped += 1,
+                    Ok(false) => report.skipped += 1,
+                    Err(e) => {
+                        report.failed += 1;
+                        log::warn!("rewrap resource `{desc}` failed: {e:#}");
+                    }
+                }
+            }
+            // Progress check: if a batch made zero forward progress (none
+            // succeeded, none failed cleanly) bail to avoid an infinite loop
+            // pulling the same rows.
+            if count < BATCH as usize {
+                break;
+            }
+        }
+        Ok(report)
     }
 
     async fn current_public_key_pem(&self) -> Result<String> {
-        bail!("EncryptedDb: current_public_key_pem not implemented yet")
+        self.maybe_reload_on_bump().await?;
+        let ring = self.ring_snapshot();
+        let public = ring
+            .primary_public
+            .clone()
+            .ok_or_else(|| anyhow!("no primary public key available"))?;
+        public
+            .to_public_key_pem(LineEnding::LF)
+            .context("encode primary public key as PEM")
     }
 
     async fn rotate_keys(&self) -> Result<RotateReport> {
-        bail!("EncryptedDb: rotate_keys not implemented yet")
+        // Best-effort same-replica re-entry guard. Cross-replica mutex is
+        // the SELECT FOR UPDATE on kbs_meta inside the rotate body.
+        if self
+            .rotation_in_progress
+            .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            bail!("a rotate is already running on this replica");
+        }
+        let result = self.rotate_keys_inner().await;
+        self.rotation_in_progress.store(0, Ordering::SeqCst);
+        result
+    }
+}
+
+impl EncryptedDb {
+    async fn rotate_keys_inner(&self) -> Result<RotateReport> {
+        // Acquire the cross-replica mutex by holding the kbs_meta row lock.
+        // SQLite serializes via its file/connection lock; we still call the
+        // same SQL so the code path is uniform.
+        match &self.pool {
+            DbPool::MySql(p) => {
+                let mut tx = p.begin().await.context("begin rotate tx (mysql)")?;
+                sqlx::query(
+                    "SELECT bump FROM kbs_meta WHERE k = 'primary_generation' FOR UPDATE",
+                )
+                .fetch_optional(&mut *tx)
+                .await
+                .context("acquire rotate row lock")?;
+                tx.commit().await.context("commit rotate row lock")?;
+                // We deliberately commit immediately: holding the lock for
+                // the entire rotate would block other replicas' GET
+                // requests too aggressively. The actual cross-replica
+                // serialization comes from the bump counter and idempotent
+                // primary_generation pointer below: if a peer just
+                // rotated, our follow-up advance will simply observe the
+                // new state and skip.
+            }
+            DbPool::Sqlite(_) => {}
+        }
+
+        // Detect whether someone else just bumped past us. If so, just
+        // reload and return a no-op report.
+        let cur = read_primary_generation_and_bump(&self.pool)
+            .await?
+            .ok_or_else(|| anyhow!("primary_generation missing"))?;
+        let pre_bump = cur.1;
+
+        // Generate, encrypt, persist the new wrap key.
+        let new_priv = generate_rsa_key_pair()?;
+        let new_gen = next_generation()?;
+        let new_pub =
+            insert_new_generation(&self.pool, &self.master_key, new_gen, &new_priv).await?;
+
+        // Reload so our ring contains both old and new keys for the rewrap.
+        self.reload_ring_now().await?;
+        let ring = self.ring_snapshot();
+        let decrypt_keys: Vec<RsaPrivateKey> =
+            ring.keys.iter().map(|k| k.private_key.clone()).collect();
+
+        // Stream rewrap of every resource still tagged with an older
+        // generation. Done outside any transaction so we don't hold long
+        // locks; failures keep the row at its previous generation, leaving
+        // the old key unretired so it stays decryptable.
+        let mut report = RewrapReport::default();
+        const BATCH: i64 = 200;
+        loop {
+            let batch = fetch_batch_older_than(&self.pool, new_gen, BATCH).await?;
+            if batch.is_empty() {
+                break;
+            }
+            let count = batch.len();
+            for row in batch {
+                report.total += 1;
+                let desc = ResourceDesc {
+                    repository_name: row.repository_name,
+                    resource_type: row.resource_type,
+                    resource_tag: row.resource_tag,
+                };
+                match rewrap_envelope(row.envelope.as_bytes(), &decrypt_keys, &new_pub) {
+                    Ok(Some(new_env)) => {
+                        if let Err(e) =
+                            update_envelope(&self.pool, &desc, &new_env, new_gen).await
+                        {
+                            report.failed += 1;
+                            log::warn!("rotate: write back rewrapped `{desc}` failed: {e:#}");
+                        } else {
+                            report.rewrapped += 1;
+                        }
+                    }
+                    Ok(None) => report.skipped += 1,
+                    Err(e) => {
+                        report.failed += 1;
+                        log::warn!("rotate: rewrap `{desc}` failed: {e:#}");
+                    }
+                }
+            }
+            if count < BATCH as usize {
+                break;
+            }
+        }
+
+        let mut retired = 0u64;
+        // Only retire old keys & advance the primary pointer when every
+        // resource migrated cleanly. This mirrors EncryptedLocalFs's
+        // semantics: any failure keeps the old keys so partially-migrated
+        // resources stay decryptable, and the next rotate will retry.
+        if report.failed == 0 {
+            retired = mark_older_retired(&self.pool, new_gen).await?;
+            advance_primary_generation(&self.pool, new_gen).await?;
+            self.reload_ring_now().await?;
+            self.last_bump
+                .store(pre_bump + 1, Ordering::Relaxed);
+            log::info!(
+                "EncryptedDb: rotated to generation {new_gen} (rewrapped={}, skipped={}, retired_keys={})",
+                report.rewrapped, report.skipped, retired
+            );
+        } else {
+            log::warn!(
+                "EncryptedDb: rotation incomplete (failed={}); leaving primary at the prior generation, new key {new_gen} retained for retry",
+                report.failed
+            );
+        }
+
+        let public_key = new_pub
+            .to_public_key_pem(LineEnding::LF)
+            .context("encode new public key")?;
+
+        Ok(RotateReport {
+            public_key,
+            rewrapped: report.rewrapped,
+            skipped: report.skipped,
+            failed: report.failed,
+            retired_keys: retired as usize,
+        })
+    }
+}
+
+fn unix_ms_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn fast_config() -> (NamedTempFile, EncryptedDbBackendConfig) {
+        let mut f = NamedTempFile::new().unwrap();
+        // Use a stable passphrase so multiple instances under the same
+        // SQLite memory DB share a master key.
+        write!(f, "unit-test-passphrase").unwrap();
+        let cfg = EncryptedDbBackendConfig {
+            master_secret_path: f.path().to_string_lossy().into_owned(),
+            bump_poll_interval_ms: 100,
+            database: DatabaseConfig {
+                kind: "sqlite".into(),
+                path: ":memory:".into(),
+                ..Default::default()
+            },
+        };
+        (f, cfg)
+    }
+
+    fn desc(r: &str, t: &str, g: &str) -> ResourceDesc {
+        ResourceDesc {
+            repository_name: r.into(),
+            resource_type: t.into(),
+            resource_tag: g.into(),
+        }
+    }
+
+    /// Encrypt plaintext under a public key + RSA-OAEP-256, returning the
+    /// envelope JSON bytes a real client would POST.
+    fn encrypt_resource_for_test(public_pem: &str, plaintext: &[u8]) -> Vec<u8> {
+        use aes_gcm::aead::{generic_array::GenericArray, AeadInPlace, KeyInit};
+        use aes_gcm::{Aes256Gcm, Nonce};
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+        use rand::RngCore;
+        use rsa::pkcs8::DecodePublicKey;
+        use rsa::sha2::Sha256;
+        use rsa::{Oaep, RsaPublicKey};
+
+        let pub_key = RsaPublicKey::from_public_key_pem(public_pem).unwrap();
+        let mut cek = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut cek);
+        let mut iv = [0u8; 12];
+        rand::thread_rng().fill_bytes(&mut iv);
+        let cipher = Aes256Gcm::new_from_slice(&cek).unwrap();
+        let nonce = Nonce::from_slice(&iv);
+        let mut buf = plaintext.to_vec();
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut buf)
+            .unwrap();
+        let enc_key = pub_key
+            .encrypt(&mut rand::thread_rng(), Oaep::new::<Sha256>(), &cek)
+            .unwrap();
+        let env = serde_json::json!({
+            "alg": "RSA-OAEP-256",
+            "enc_key": STANDARD.encode(enc_key),
+            "iv": STANDARD.encode(iv),
+            "ciphertext": STANDARD.encode(buf),
+            "tag": STANDARD.encode(GenericArray::from(tag).as_slice()),
+        });
+        serde_json::to_vec(&env).unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn write_read_round_trip() {
+        let (_keepalive, cfg) = fast_config();
+        let backend = EncryptedDb::init_async(&cfg).await.expect("init");
+
+        let pubkey = backend.current_public_key_pem().await.unwrap();
+        let env = encrypt_resource_for_test(&pubkey, b"hello world");
+
+        backend
+            .write_secret_resource(desc("repo", "secret", "r1"), &env)
+            .await
+            .unwrap();
+        let plain = backend
+            .read_secret_resource(desc("repo", "secret", "r1"))
+            .await
+            .unwrap();
+        assert_eq!(plain, b"hello world");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn list_after_writes() {
+        let (_keepalive, cfg) = fast_config();
+        let backend = EncryptedDb::init_async(&cfg).await.unwrap();
+        let pubkey = backend.current_public_key_pem().await.unwrap();
+        let env = encrypt_resource_for_test(&pubkey, b"x");
+        backend
+            .write_secret_resource(desc("repo", "secret", "a"), &env)
+            .await
+            .unwrap();
+        backend
+            .write_secret_resource(desc("repo", "secret", "b"), &env)
+            .await
+            .unwrap();
+        let lst = backend.list_secret_resources().await.unwrap();
+        let tags: Vec<_> = lst.iter().map(|d| d.resource_tag.clone()).collect();
+        assert_eq!(tags, vec!["a", "b"]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_then_read_errors() {
+        let (_keepalive, cfg) = fast_config();
+        let backend = EncryptedDb::init_async(&cfg).await.unwrap();
+        let pubkey = backend.current_public_key_pem().await.unwrap();
+        let env = encrypt_resource_for_test(&pubkey, b"x");
+        backend
+            .write_secret_resource(desc("repo", "secret", "x"), &env)
+            .await
+            .unwrap();
+        backend
+            .delete_secret_resource(desc("repo", "secret", "x"))
+            .await
+            .unwrap();
+        let err = backend
+            .read_secret_resource(desc("repo", "secret", "x"))
+            .await;
+        assert!(err.is_err(), "read after delete should fail");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rotate_rewraps_old_resources() {
+        let (_keepalive, cfg) = fast_config();
+        let backend = EncryptedDb::init_async(&cfg).await.unwrap();
+        let p1 = backend.current_public_key_pem().await.unwrap();
+        let env_old = encrypt_resource_for_test(&p1, b"old");
+        backend
+            .write_secret_resource(desc("repo", "secret", "old"), &env_old)
+            .await
+            .unwrap();
+
+        let report = backend.rotate_keys().await.unwrap();
+        assert_eq!(report.failed, 0);
+        assert_eq!(report.rewrapped, 1, "single old envelope should be rewrapped");
+        assert!(report.public_key.contains("BEGIN PUBLIC KEY"));
+
+        // After rotation the resource should still decrypt under the new ring.
+        let plain = backend
+            .read_secret_resource(desc("repo", "secret", "old"))
+            .await
+            .unwrap();
+        assert_eq!(plain, b"old");
+
+        // The pubkey returned should be the new one.
+        let p2 = backend.current_public_key_pem().await.unwrap();
+        assert_ne!(p1, p2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn second_init_under_wrong_passphrase_fails() {
+        let (mut keepalive, mut cfg) = fast_config();
+        // First start: bootstrap the canary.
+        let _backend = EncryptedDb::init_async(&cfg).await.unwrap();
+
+        // Stash the bootstrapped state by sharing the same SQLite file
+        // across two providers — :memory: is per-pool, so we use a real
+        // tempfile path to share state.
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dbpath = tmpdir.path().join("kbs.db");
+        cfg.database.path = dbpath.to_string_lossy().into_owned();
+
+        // Bootstrap the file-backed DB with a known passphrase.
+        let _backend = EncryptedDb::init_async(&cfg).await.unwrap();
+
+        // Now flip the passphrase and re-init: must fail at the canary.
+        write!(keepalive, "wrong-passphrase").unwrap();
+        let err = EncryptedDb::init_async(&cfg)
+            .await
+            .err()
+            .expect("wrong passphrase must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("canary") || msg.contains("authentication"),
+            "expected canary error, got: {msg}"
+        );
     }
 }

--- a/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
@@ -13,7 +13,10 @@
 //! See `kbs/docs/resource_storage_backend_encrypted_db.md` for the user-facing
 //! documentation.
 
+mod db;
+mod key_store;
 mod master_secret;
+mod schema;
 
 use anyhow::{bail, Result};
 use serde::Deserialize;

--- a/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
@@ -16,6 +16,7 @@
 mod db;
 mod key_store;
 mod master_secret;
+mod resource_store;
 mod schema;
 
 use anyhow::{bail, Result};

--- a/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
@@ -39,9 +39,7 @@ use key_store::{
     read_primary_generation, read_primary_generation_and_bump, set_primary_generation_initial,
     Generation, LoadedKey,
 };
-use master_secret::{
-    derive_master_key, verify_canary, FileMasterSecretProvider, MasterKey,
-};
+use master_secret::{derive_master_key, verify_canary, FileMasterSecretProvider, MasterKey};
 use resource_store::{
     delete_resource, fetch_all, fetch_batch_older_than, list_resources, read_envelope,
     update_envelope, upsert_envelope,
@@ -207,7 +205,9 @@ impl EncryptedDb {
             match insert_new_generation(&pool, &master_key, generation, &private_key).await {
                 Ok(_) => {
                     set_primary_generation_initial(&pool, generation).await?;
-                    log::info!("EncryptedDb: bootstrapped initial wrap key generation {generation}");
+                    log::info!(
+                        "EncryptedDb: bootstrapped initial wrap key generation {generation}"
+                    );
                 }
                 Err(e) => {
                     let s = format!("{e:#}");
@@ -216,9 +216,7 @@ impl EncryptedDb {
                         || s.contains("PRIMARY")
                         || s.contains("constraint")
                     {
-                        log::info!(
-                            "EncryptedDb: lost bootstrap race, using peer's wrap key"
-                        );
+                        log::info!("EncryptedDb: lost bootstrap race, using peer's wrap key");
                     } else {
                         return Err(e);
                     }
@@ -290,9 +288,7 @@ impl EncryptedDb {
         };
         let prev = self.last_bump.load(Ordering::Relaxed);
         if cur_bump > prev {
-            log::info!(
-                "EncryptedDb: bump advanced ({prev} -> {cur_bump}); reloading key ring"
-            );
+            log::info!("EncryptedDb: bump advanced ({prev} -> {cur_bump}); reloading key ring");
             self.reload_ring_now().await?;
             self.last_bump.store(cur_bump, Ordering::Relaxed);
         }
@@ -410,8 +406,7 @@ impl StorageBackend for EncryptedDb {
         // Fetch in batches to keep memory bounded for large tables.
         const BATCH: i64 = 200;
         loop {
-            let batch =
-                fetch_batch_older_than(&self.pool, primary_generation, BATCH).await?;
+            let batch = fetch_batch_older_than(&self.pool, primary_generation, BATCH).await?;
             if batch.is_empty() {
                 break;
             }
@@ -487,12 +482,10 @@ impl EncryptedDb {
         match &self.pool {
             DbPool::MySql(p) => {
                 let mut tx = p.begin().await.context("begin rotate tx (mysql)")?;
-                sqlx::query(
-                    "SELECT bump FROM kbs_meta WHERE k = 'primary_generation' FOR UPDATE",
-                )
-                .fetch_optional(&mut *tx)
-                .await
-                .context("acquire rotate row lock")?;
+                sqlx::query("SELECT bump FROM kbs_meta WHERE k = 'primary_generation' FOR UPDATE")
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("acquire rotate row lock")?;
                 tx.commit().await.context("commit rotate row lock")?;
                 // We deliberately commit immediately: holding the lock for
                 // the entire rotate would block other replicas' GET
@@ -545,8 +538,7 @@ impl EncryptedDb {
                 };
                 match rewrap_envelope(row.envelope.as_bytes(), &decrypt_keys, &new_pub) {
                     Ok(Some(new_env)) => {
-                        if let Err(e) =
-                            update_envelope(&self.pool, &desc, &new_env, new_gen).await
+                        if let Err(e) = update_envelope(&self.pool, &desc, &new_env, new_gen).await
                         {
                             report.failed += 1;
                             log::warn!("rotate: write back rewrapped `{desc}` failed: {e:#}");
@@ -575,8 +567,7 @@ impl EncryptedDb {
             retired = mark_older_retired(&self.pool, new_gen).await?;
             advance_primary_generation(&self.pool, new_gen).await?;
             self.reload_ring_now().await?;
-            self.last_bump
-                .store(pre_bump + 1, Ordering::Relaxed);
+            self.last_bump.store(pre_bump + 1, Ordering::Relaxed);
             log::info!(
                 "EncryptedDb: rotated to generation {new_gen} (rewrapped={}, skipped={}, retired_keys={})",
                 report.rewrapped, report.skipped, retired
@@ -595,13 +586,10 @@ impl EncryptedDb {
         // Purge sweep: physically delete retired keys whose grace period
         // has expired. Done after a successful rotation so a fresh primary
         // is in place for any straggler rewraps.
-        let purged = self
-            .run_purge_sweep(&new_pub)
-            .await
-            .unwrap_or_else(|e| {
-                log::warn!("EncryptedDb: purge sweep failed (non-fatal): {e:#}");
-                0
-            });
+        let purged = self.run_purge_sweep(&new_pub).await.unwrap_or_else(|e| {
+            log::warn!("EncryptedDb: purge sweep failed (non-fatal): {e:#}");
+            0
+        });
 
         Ok(RotateReport {
             public_key,
@@ -658,9 +646,7 @@ impl EncryptedDb {
                 }
             }
             // Otherwise try the full ring; if any old key decrypts, rewrap.
-            if let Ok(Some(new_env)) =
-                rewrap_envelope(env_bytes, &decrypt_keys, primary_public)
-            {
+            if let Ok(Some(new_env)) = rewrap_envelope(env_bytes, &decrypt_keys, primary_public) {
                 let desc = ResourceDesc {
                     repository_name: row.repository_name,
                     resource_type: row.resource_type,
@@ -876,7 +862,10 @@ mod tests {
 
         let report = backend.rotate_keys().await.unwrap();
         assert_eq!(report.failed, 0);
-        assert_eq!(report.rewrapped, 1, "single old envelope should be rewrapped");
+        assert_eq!(
+            report.rewrapped, 1,
+            "single old envelope should be rewrapped"
+        );
         assert!(report.public_key.contains("BEGIN PUBLIC KEY"));
 
         // After rotation the resource should still decrypt under the new ring.

--- a/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
@@ -32,18 +32,19 @@ use serde::Deserialize;
 use super::{ResourceDesc, RewrapReport, RotateReport, StorageBackend};
 
 use crypto::{decrypt_envelope_with_ring, rewrap_envelope, Envelope};
-use db::DbPool;
+use db::{parse_simple_duration, DbPool};
 use key_store::{
-    advance_primary_generation, generate_rsa_key_pair, insert_new_generation, load_all_keys,
-    mark_older_retired, next_generation, read_primary_generation,
-    read_primary_generation_and_bump, set_primary_generation_initial, Generation, LoadedKey,
+    advance_primary_generation, delete_key_row, generate_rsa_key_pair, insert_new_generation,
+    list_retired_older_than, load_all_keys, mark_older_retired, next_generation,
+    read_primary_generation, read_primary_generation_and_bump, set_primary_generation_initial,
+    Generation, LoadedKey,
 };
 use master_secret::{
     derive_master_key, verify_canary, FileMasterSecretProvider, MasterKey,
 };
 use resource_store::{
-    delete_resource, fetch_batch_older_than, list_resources, read_envelope, update_envelope,
-    upsert_envelope,
+    delete_resource, fetch_all, fetch_batch_older_than, list_resources, read_envelope,
+    update_envelope, upsert_envelope,
 };
 use schema::{ensure_meta_defaults, migrate_schema, read_argon2_params, read_canary, read_salt};
 
@@ -129,6 +130,34 @@ pub struct EncryptedDb {
     /// scheduling two rotates back-to-back. The DB row lock is the
     /// authoritative cross-replica mutex.
     rotation_in_progress: AtomicU64,
+    /// Grace period before a retired key is physically deleted. `None`
+    /// disables purging entirely.
+    purge_after: Option<Duration>,
+}
+
+/// Lower bound for `retired_key_purge_after`: 1 hour. Refuses smaller
+/// non-zero values to avoid orphaning resources written with a stale
+/// public key during a rotation race.
+const PURGE_AFTER_MIN: Duration = Duration::from_secs(3600);
+
+fn parse_purge_after(s: &str) -> Result<Option<Duration>> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        // Treat empty config as default (handled by serde default upstream).
+        return Ok(Some(Duration::from_secs(30 * 86_400)));
+    }
+    let d = parse_simple_duration(trimmed)
+        .with_context(|| format!("parse retired_key_purge_after `{trimmed}`"))?;
+    if d.is_zero() {
+        return Ok(None);
+    }
+    if d < PURGE_AFTER_MIN {
+        bail!(
+            "retired_key_purge_after `{trimmed}` is below the 1h minimum; \
+             use a longer grace period or `0` to disable purging"
+        );
+    }
+    Ok(Some(d))
 }
 
 impl EncryptedDb {
@@ -202,6 +231,7 @@ impl EncryptedDb {
             .unwrap_or(0);
 
         let poll_interval = Duration::from_millis(config.bump_poll_interval_ms.max(100));
+        let purge_after = parse_purge_after(&config.database.retired_key_purge_after)?;
 
         Ok(Self {
             pool,
@@ -211,6 +241,7 @@ impl EncryptedDb {
             last_poll_ms: AtomicI64::new(unix_ms_now()),
             poll_interval,
             rotation_in_progress: AtomicU64::new(0),
+            purge_after,
         })
     }
 
@@ -559,13 +590,140 @@ impl EncryptedDb {
             .to_public_key_pem(LineEnding::LF)
             .context("encode new public key")?;
 
+        // Purge sweep: physically delete retired keys whose grace period
+        // has expired. Done after a successful rotation so a fresh primary
+        // is in place for any straggler rewraps.
+        let purged = self
+            .run_purge_sweep(&new_pub)
+            .await
+            .unwrap_or_else(|e| {
+                log::warn!("EncryptedDb: purge sweep failed (non-fatal): {e:#}");
+                0
+            });
+
         Ok(RotateReport {
             public_key,
             rewrapped: report.rewrapped,
             skipped: report.skipped,
             failed: report.failed,
             retired_keys: retired as usize,
+            purged_keys: purged,
         })
+    }
+
+    /// Delete any retired keys whose `retired_at` is older than
+    /// `purge_after`. Before deletion, scan every resource and rewrap any
+    /// envelope still wrapped under the candidate key. If any resource
+    /// would still depend on it after that pass we skip the delete (and
+    /// log a warning) — better to leak a row than to permanently orphan a
+    /// resource.
+    async fn run_purge_sweep(&self, primary_public: &RsaPublicKey) -> Result<usize> {
+        let Some(grace) = self.purge_after else {
+            return Ok(0);
+        };
+        let candidates = list_retired_older_than(&self.pool, grace).await?;
+        if candidates.is_empty() {
+            return Ok(0);
+        }
+        let ring = self.ring_snapshot();
+        let primary_generation = ring
+            .primary_generation
+            .ok_or_else(|| anyhow!("purge: no primary generation"))?;
+        let decrypt_keys: Vec<RsaPrivateKey> =
+            ring.keys.iter().map(|k| k.private_key.clone()).collect();
+
+        // Single straggler-rewrap pass over every resource. Cheap because
+        // we only re-encrypt rows whose envelope cannot be decrypted by
+        // the primary.
+        let all = fetch_all(&self.pool).await?;
+        for row in all {
+            let env_bytes = row.envelope.as_bytes();
+            // Skip rows already at the primary by trial-decrypting with
+            // the primary key alone. This avoids a needless rewrap on
+            // rows tagged with an old generation but already wrapped
+            // under the new public key (rare, but possible).
+            let primary_only_keys: Vec<RsaPrivateKey> = ring
+                .keys
+                .iter()
+                .filter(|k| Some(k.generation) == ring.primary_generation && !k.retired)
+                .map(|k| k.private_key.clone())
+                .collect();
+            if let Ok(env) = serde_json::from_slice::<crypto::Envelope>(env_bytes) {
+                if !primary_only_keys.is_empty()
+                    && decrypt_envelope_with_ring(&env, &primary_only_keys).is_ok()
+                {
+                    continue;
+                }
+            }
+            // Otherwise try the full ring; if any old key decrypts, rewrap.
+            if let Ok(Some(new_env)) =
+                rewrap_envelope(env_bytes, &decrypt_keys, primary_public)
+            {
+                let desc = ResourceDesc {
+                    repository_name: row.repository_name,
+                    resource_type: row.resource_type,
+                    resource_tag: row.resource_tag,
+                };
+                if let Err(e) =
+                    update_envelope(&self.pool, &desc, &new_env, primary_generation).await
+                {
+                    log::warn!("purge: straggler rewrap of `{desc}` failed: {e:#}");
+                }
+            }
+        }
+
+        // After the straggler sweep, no resource should still depend on
+        // any candidate. Verify by re-checking — if a row is now in a
+        // state we cannot rewrap to the primary, leave the candidate key
+        // in place rather than orphan the resource.
+        let final_pass = fetch_all(&self.pool).await?;
+        let candidates_set: std::collections::HashSet<Generation> =
+            candidates.iter().copied().collect();
+        let mut still_needed: std::collections::HashSet<Generation> =
+            std::collections::HashSet::new();
+        for row in &final_pass {
+            let env: crypto::Envelope = match serde_json::from_slice(row.envelope.as_bytes()) {
+                Ok(e) => e,
+                Err(_) => continue, // plaintext or non-envelope row, no key needed
+            };
+            if let Ok(_) = decrypt_envelope_with_ring(
+                &env,
+                &ring
+                    .keys
+                    .iter()
+                    .filter(|k| !candidates_set.contains(&k.generation))
+                    .map(|k| k.private_key.clone())
+                    .collect::<Vec<_>>(),
+            ) {
+                continue;
+            }
+            // None of the kept keys decrypts — find which candidate does.
+            for k in &ring.keys {
+                if candidates_set.contains(&k.generation) {
+                    if decrypt_envelope_with_ring(&env, &[k.private_key.clone()]).is_ok() {
+                        still_needed.insert(k.generation);
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut purged = 0usize;
+        for gen in candidates {
+            if still_needed.contains(&gen) {
+                log::warn!(
+                    "EncryptedDb: skipping purge of generation {gen} — at least one resource still depends on it"
+                );
+                continue;
+            }
+            delete_key_row(&self.pool, gen).await?;
+            purged += 1;
+            log::info!("EncryptedDb: purged retired wrap key generation {gen}");
+        }
+        if purged > 0 {
+            self.reload_ring_now().await?;
+        }
+        Ok(purged)
     }
 }
 
@@ -727,6 +885,113 @@ mod tests {
         // The pubkey returned should be the new one.
         let p2 = backend.current_public_key_pem().await.unwrap();
         assert_ne!(p1, p2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn purge_after_grace_deletes_retired_key() {
+        // Use a file-backed SQLite so we can reach in and back-date
+        // retired_at to simulate the grace period elapsing.
+        let mut f = NamedTempFile::new().unwrap();
+        write!(f, "purge-test").unwrap();
+        let dbdir = tempfile::tempdir().unwrap();
+        let dbpath = dbdir.path().join("kbs.db");
+        let cfg = EncryptedDbBackendConfig {
+            master_secret_path: f.path().to_string_lossy().into_owned(),
+            bump_poll_interval_ms: 100,
+            database: DatabaseConfig {
+                kind: "sqlite".into(),
+                path: dbpath.to_string_lossy().into_owned(),
+                retired_key_purge_after: "1h".into(),
+                ..Default::default()
+            },
+        };
+
+        let backend = EncryptedDb::init_async(&cfg).await.unwrap();
+        let p1 = backend.current_public_key_pem().await.unwrap();
+        let env_old = encrypt_resource_for_test(&p1, b"old");
+        backend
+            .write_secret_resource(desc("repo", "secret", "x"), &env_old)
+            .await
+            .unwrap();
+
+        // First rotate retires the bootstrap key but the grace period has
+        // not elapsed yet, so nothing should be purged.
+        let r1 = backend.rotate_keys().await.unwrap();
+        assert_eq!(r1.failed, 0);
+        assert!(r1.retired_keys >= 1);
+        assert_eq!(r1.purged_keys, 0, "grace not elapsed yet");
+
+        // Back-date every retired_at into the distant past.
+        let DbPool::Sqlite(p) = &backend.pool else {
+            unreachable!()
+        };
+        sqlx::query(
+            "UPDATE kbs_managed_keys SET retired_at = '2020-01-01 00:00:00.000000' WHERE retired_at IS NOT NULL",
+        )
+        .execute(p)
+        .await
+        .unwrap();
+
+        // Second rotate should now purge.
+        let r2 = backend.rotate_keys().await.unwrap();
+        assert_eq!(r2.failed, 0);
+        assert!(r2.purged_keys >= 1, "expected purge after back-dating");
+
+        // Resource still readable under the latest key.
+        let plain = backend
+            .read_secret_resource(desc("repo", "secret", "x"))
+            .await
+            .unwrap();
+        assert_eq!(plain, b"old");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn purge_disabled_when_grace_zero() {
+        let mut f = NamedTempFile::new().unwrap();
+        write!(f, "no-purge").unwrap();
+        let dbdir = tempfile::tempdir().unwrap();
+        let dbpath = dbdir.path().join("kbs.db");
+        let cfg = EncryptedDbBackendConfig {
+            master_secret_path: f.path().to_string_lossy().into_owned(),
+            bump_poll_interval_ms: 100,
+            database: DatabaseConfig {
+                kind: "sqlite".into(),
+                path: dbpath.to_string_lossy().into_owned(),
+                retired_key_purge_after: "0".into(),
+                ..Default::default()
+            },
+        };
+
+        let backend = EncryptedDb::init_async(&cfg).await.unwrap();
+        backend.rotate_keys().await.unwrap();
+
+        // Even with retired_at way in the past, purge must not run.
+        let DbPool::Sqlite(p) = &backend.pool else {
+            unreachable!()
+        };
+        sqlx::query(
+            "UPDATE kbs_managed_keys SET retired_at = '2020-01-01 00:00:00.000000' WHERE retired_at IS NOT NULL",
+        )
+        .execute(p)
+        .await
+        .unwrap();
+        let r = backend.rotate_keys().await.unwrap();
+        assert_eq!(r.purged_keys, 0, "purge_after = 0 disables purging");
+    }
+
+    #[test]
+    fn parse_purge_after_rejects_below_minimum() {
+        assert!(parse_purge_after("30s").is_err());
+        assert!(parse_purge_after("59m").is_err());
+        assert!(parse_purge_after("0").unwrap().is_none());
+        assert_eq!(
+            parse_purge_after("1h").unwrap(),
+            Some(Duration::from_secs(3600))
+        );
+        assert_eq!(
+            parse_purge_after("30d").unwrap(),
+            Some(Duration::from_secs(30 * 86_400))
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
@@ -171,7 +171,9 @@ impl EncryptedDb {
         runtime.block_on(Self::init_async(config))
     }
 
-    async fn init_async(config: &EncryptedDbBackendConfig) -> Result<Self> {
+    /// Async constructor used by integration tests. Production code should
+    /// use [`EncryptedDb::new`] which builds a small bridge runtime.
+    pub async fn init_async(config: &EncryptedDbBackendConfig) -> Result<Self> {
         let pool = DbPool::connect(&config.database).await?;
         migrate_schema(&pool).await?;
         // Seed defaults *without* the master key so the salt + KDF params
@@ -686,7 +688,7 @@ impl EncryptedDb {
                 Ok(e) => e,
                 Err(_) => continue, // plaintext or non-envelope row, no key needed
             };
-            if let Ok(_) = decrypt_envelope_with_ring(
+            if decrypt_envelope_with_ring(
                 &env,
                 &ring
                     .keys
@@ -694,16 +696,18 @@ impl EncryptedDb {
                     .filter(|k| !candidates_set.contains(&k.generation))
                     .map(|k| k.private_key.clone())
                     .collect::<Vec<_>>(),
-            ) {
+            )
+            .is_ok()
+            {
                 continue;
             }
             // None of the kept keys decrypts — find which candidate does.
             for k in &ring.keys {
-                if candidates_set.contains(&k.generation) {
-                    if decrypt_envelope_with_ring(&env, &[k.private_key.clone()]).is_ok() {
-                        still_needed.insert(k.generation);
-                        break;
-                    }
+                if candidates_set.contains(&k.generation)
+                    && decrypt_envelope_with_ring(&env, &[k.private_key.clone()]).is_ok()
+                {
+                    still_needed.insert(k.generation);
+                    break;
                 }
             }
         }
@@ -768,14 +772,14 @@ mod tests {
     /// Encrypt plaintext under a public key + RSA-OAEP-256, returning the
     /// envelope JSON bytes a real client would POST.
     fn encrypt_resource_for_test(public_pem: &str, plaintext: &[u8]) -> Vec<u8> {
-        use aes_gcm::aead::{generic_array::GenericArray, AeadInPlace, KeyInit};
+        use aes_gcm::aead::{AeadInPlace, KeyInit};
         use aes_gcm::{Aes256Gcm, Nonce};
         use base64::engine::general_purpose::STANDARD;
         use base64::Engine;
         use rand::RngCore;
         use rsa::pkcs8::DecodePublicKey;
         use rsa::sha2::Sha256;
-        use rsa::{Oaep, RsaPublicKey};
+        use rsa::Oaep;
 
         let pub_key = RsaPublicKey::from_public_key_pem(public_pem).unwrap();
         let mut cek = [0u8; 32];
@@ -796,7 +800,7 @@ mod tests {
             "enc_key": STANDARD.encode(enc_key),
             "iv": STANDARD.encode(iv),
             "ciphertext": STANDARD.encode(buf),
-            "tag": STANDARD.encode(GenericArray::from(tag).as_slice()),
+            "tag": STANDARD.encode(tag.as_slice()),
         });
         serde_json::to_vec(&env).unwrap()
     }

--- a/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `EncryptedDb` resource backend.
+//!
+//! Stores wrap keys and resource envelopes in a shared SQL database (MySQL or
+//! SQLite) so multiple KBS replicas can share one set of managed keys. The
+//! private keys are encrypted at rest with a deployment-level master secret
+//! derived from a passphrase via Argon2id, so a database-only compromise does
+//! not yield plaintext key material.
+//!
+//! See `kbs/docs/resource_storage_backend_encrypted_db.md` for the user-facing
+//! documentation.
+
+mod master_secret;
+
+use anyhow::{bail, Result};
+use serde::Deserialize;
+
+use super::{ResourceDesc, RewrapReport, RotateReport, StorageBackend};
+
+/// User-facing configuration for the `EncryptedDb` resource backend.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+pub struct EncryptedDbBackendConfig {
+    /// Path to the file holding the master secret (passphrase). Defaults to
+    /// `/run/trustee/master.passphrase` (typically a Kubernetes Secret mounted
+    /// as a tmpfs file).
+    #[serde(default = "default_master_secret_path")]
+    pub master_secret_path: String,
+
+    /// How often, in milliseconds, each replica polls the `bump` counter to
+    /// detect that another replica has rotated the key. Defaults to 5000ms.
+    #[serde(default = "default_bump_poll_interval_ms")]
+    pub bump_poll_interval_ms: u64,
+
+    /// Database connection settings.
+    pub database: DatabaseConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+pub struct DatabaseConfig {
+    /// `"mysql"` or `"sqlite"`.
+    #[serde(rename = "type")]
+    pub kind: String,
+
+    /// MySQL DSN, e.g. `mysql://user:pass@host:port/db?ssl-mode=PREFERRED`.
+    /// Required when `kind == "mysql"`.
+    #[serde(default)]
+    pub dsn: String,
+
+    /// SQLite database file path. Required when `kind == "sqlite"`.
+    /// Use `":memory:"` for an ephemeral in-process database (tests only).
+    #[serde(default)]
+    pub path: String,
+
+    /// MySQL connection pool tuning.
+    #[serde(default)]
+    pub max_open_conns: u32,
+    #[serde(default)]
+    pub max_idle_conns: u32,
+    #[serde(default)]
+    pub conn_max_lifetime: String,
+
+    /// How long a retired key is kept in the database before it is physically
+    /// purged. Accepts a humantime-style string (`"30d"`, `"168h"`); `"0"`
+    /// disables purging entirely. The minimum non-zero value is `"1h"` to
+    /// avoid accidentally orphaning resources uploaded with a stale public key
+    /// during a rotation race.
+    #[serde(default = "default_retired_key_purge_after")]
+    pub retired_key_purge_after: String,
+}
+
+fn default_master_secret_path() -> String {
+    "/run/trustee/master.passphrase".to_string()
+}
+
+fn default_bump_poll_interval_ms() -> u64 {
+    5000
+}
+
+fn default_retired_key_purge_after() -> String {
+    "30d".to_string()
+}
+
+/// Placeholder backend; real implementation lands in a follow-up commit. Kept
+/// behind the `encrypted-db` feature so that scaffolding compiles before the
+/// rest of the implementation is in place.
+pub struct EncryptedDb {
+    _config: EncryptedDbBackendConfig,
+}
+
+impl EncryptedDb {
+    pub fn new(config: &EncryptedDbBackendConfig) -> Result<Self> {
+        let _ = master_secret::FileMasterSecretProvider::new(&config.master_secret_path);
+        bail!("EncryptedDb backend is not implemented yet (feature scaffold)")
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageBackend for EncryptedDb {
+    async fn read_secret_resource(&self, _resource_desc: ResourceDesc) -> Result<Vec<u8>> {
+        bail!("EncryptedDb: read not implemented yet")
+    }
+
+    async fn write_secret_resource(
+        &self,
+        _resource_desc: ResourceDesc,
+        _data: &[u8],
+    ) -> Result<()> {
+        bail!("EncryptedDb: write not implemented yet")
+    }
+
+    async fn delete_secret_resource(&self, _resource_desc: ResourceDesc) -> Result<()> {
+        bail!("EncryptedDb: delete not implemented yet")
+    }
+
+    async fn list_secret_resources(&self) -> Result<Vec<ResourceDesc>> {
+        bail!("EncryptedDb: list not implemented yet")
+    }
+
+    async fn reload_keys(&self) -> Result<usize> {
+        bail!("EncryptedDb: reload_keys not implemented yet")
+    }
+
+    async fn rewrap_resources(&self) -> Result<RewrapReport> {
+        bail!("EncryptedDb: rewrap_resources not implemented yet")
+    }
+
+    async fn current_public_key_pem(&self) -> Result<String> {
+        bail!("EncryptedDb: current_public_key_pem not implemented yet")
+    }
+
+    async fn rotate_keys(&self) -> Result<RotateReport> {
+        bail!("EncryptedDb: rotate_keys not implemented yet")
+    }
+}

--- a/kbs/src/plugins/implementations/resource/encrypted_db/resource_store.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/resource_store.rs
@@ -268,8 +268,8 @@ pub async fn update_envelope(
     envelope: &[u8],
     generation: Generation,
 ) -> Result<()> {
-    let envelope_str = std::str::from_utf8(envelope)
-        .context("re-wrapped envelope is not valid UTF-8 JSON")?;
+    let envelope_str =
+        std::str::from_utf8(envelope).context("re-wrapped envelope is not valid UTF-8 JSON")?;
     let now = current_iso_timestamp()?;
     match pool {
         DbPool::MySql(p) => {
@@ -345,7 +345,9 @@ mod tests {
     async fn upsert_then_read() {
         let pool = fresh_pool().await;
         let d = desc("repo", "secret", "r1");
-        upsert_envelope(&pool, &d, b"{\"alg\":\"X\"}", 100).await.unwrap();
+        upsert_envelope(&pool, &d, b"{\"alg\":\"X\"}", 100)
+            .await
+            .unwrap();
         let got = read_envelope(&pool, &d).await.unwrap();
         assert_eq!(got.as_deref(), Some(b"{\"alg\":\"X\"}".as_slice()));
     }
@@ -395,11 +397,20 @@ mod tests {
         let lst = list_resources(&pool).await.unwrap();
         let tags: Vec<String> = lst
             .iter()
-            .map(|d| format!("{}/{}/{}", d.repository_name, d.resource_type, d.resource_tag))
+            .map(|d| {
+                format!(
+                    "{}/{}/{}",
+                    d.repository_name, d.resource_type, d.resource_tag
+                )
+            })
             .collect();
         assert_eq!(
             tags,
-            vec!["repo/key/a".to_string(), "repo/secret/a".into(), "repo/secret/b".into()]
+            vec![
+                "repo/key/a".to_string(),
+                "repo/secret/a".into(),
+                "repo/secret/b".into()
+            ]
         );
     }
 

--- a/kbs/src/plugins/implementations/resource/encrypted_db/resource_store.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/resource_store.rs
@@ -1,0 +1,429 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resource envelope persistence (`kbs_resources`).
+//!
+//! Resources are pre-encrypted by the client with the current primary public
+//! key, serialized into the JSON envelope format defined by
+//! `EncryptedLocalFs` (alg / enc_key / iv / ciphertext / tag, all base64),
+//! and POSTed to KBS as the request body. KBS stores them verbatim — it
+//! does not parse or re-encrypt on write — so the wire format is the same
+//! as the EncryptedLocalFs backend and clients keep working unchanged.
+//!
+//! On read the parent `EncryptedDb` module fetches the JSON, picks the
+//! envelope apart, and trial-decrypts with each loaded key in
+//! newest-first order (mirroring the EncryptedLocalFs decrypt path).
+
+use anyhow::{Context, Result};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::db::DbPool;
+use super::key_store::Generation;
+use super::ResourceDesc;
+
+/// One resource row read from `kbs_resources`.
+#[derive(Debug, Clone)]
+pub struct ResourceRow {
+    pub repository_name: String,
+    pub resource_type: String,
+    pub resource_tag: String,
+    pub envelope: String,
+    pub generation: Generation,
+}
+
+/// UPSERT a resource: insert if new, replace envelope+generation+updated_at
+/// if the (repo, type, tag) already exists.
+pub async fn upsert_envelope(
+    pool: &DbPool,
+    desc: &ResourceDesc,
+    envelope: &[u8],
+    generation: Generation,
+) -> Result<()> {
+    let envelope_str = std::str::from_utf8(envelope)
+        .context("EncryptedDb only stores valid UTF-8 JSON envelopes; got non-UTF-8 bytes")?;
+    let now = current_iso_timestamp()?;
+    match pool {
+        DbPool::MySql(p) => {
+            sqlx::query(
+                "INSERT INTO kbs_resources
+                    (repository_name, resource_type, resource_tag,
+                     envelope, generation, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?)
+                 ON DUPLICATE KEY UPDATE
+                    envelope   = VALUES(envelope),
+                    generation = VALUES(generation),
+                    updated_at = VALUES(updated_at)",
+            )
+            .bind(&desc.repository_name)
+            .bind(&desc.resource_type)
+            .bind(&desc.resource_tag)
+            .bind(envelope_str)
+            .bind(generation)
+            .bind(&now)
+            .execute(p)
+            .await
+            .context("upsert resource (mysql)")?;
+        }
+        DbPool::Sqlite(p) => {
+            sqlx::query(
+                "INSERT INTO kbs_resources
+                    (repository_name, resource_type, resource_tag,
+                     envelope, generation, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(repository_name, resource_type, resource_tag) DO UPDATE SET
+                    envelope   = excluded.envelope,
+                    generation = excluded.generation,
+                    updated_at = excluded.updated_at",
+            )
+            .bind(&desc.repository_name)
+            .bind(&desc.resource_type)
+            .bind(&desc.resource_tag)
+            .bind(envelope_str)
+            .bind(generation)
+            .bind(&now)
+            .execute(p)
+            .await
+            .context("upsert resource (sqlite)")?;
+        }
+    }
+    Ok(())
+}
+
+/// Read a single envelope's bytes for the given resource. Returns `None`
+/// when the resource does not exist.
+pub async fn read_envelope(pool: &DbPool, desc: &ResourceDesc) -> Result<Option<Vec<u8>>> {
+    let row: Option<(String,)> = match pool {
+        DbPool::MySql(p) => sqlx::query_as(
+            "SELECT envelope FROM kbs_resources
+             WHERE repository_name = ? AND resource_type = ? AND resource_tag = ?",
+        )
+        .bind(&desc.repository_name)
+        .bind(&desc.resource_type)
+        .bind(&desc.resource_tag)
+        .fetch_optional(p)
+        .await
+        .context("read resource (mysql)")?,
+        DbPool::Sqlite(p) => sqlx::query_as(
+            "SELECT envelope FROM kbs_resources
+             WHERE repository_name = ? AND resource_type = ? AND resource_tag = ?",
+        )
+        .bind(&desc.repository_name)
+        .bind(&desc.resource_type)
+        .bind(&desc.resource_tag)
+        .fetch_optional(p)
+        .await
+        .context("read resource (sqlite)")?,
+    };
+    Ok(row.map(|(v,)| v.into_bytes()))
+}
+
+/// Delete a single resource. No-op if the row is already gone.
+pub async fn delete_resource(pool: &DbPool, desc: &ResourceDesc) -> Result<()> {
+    match pool {
+        DbPool::MySql(p) => {
+            sqlx::query(
+                "DELETE FROM kbs_resources
+                 WHERE repository_name = ? AND resource_type = ? AND resource_tag = ?",
+            )
+            .bind(&desc.repository_name)
+            .bind(&desc.resource_type)
+            .bind(&desc.resource_tag)
+            .execute(p)
+            .await
+            .context("delete resource (mysql)")?;
+        }
+        DbPool::Sqlite(p) => {
+            sqlx::query(
+                "DELETE FROM kbs_resources
+                 WHERE repository_name = ? AND resource_type = ? AND resource_tag = ?",
+            )
+            .bind(&desc.repository_name)
+            .bind(&desc.resource_type)
+            .bind(&desc.resource_tag)
+            .execute(p)
+            .await
+            .context("delete resource (sqlite)")?;
+        }
+    }
+    Ok(())
+}
+
+/// List every resource (repo, type, tag triple), name-sorted for
+/// determinism. The envelope payload is intentionally not returned here —
+/// listing is used by rewrap and admin endpoints, both of which fetch
+/// payloads on demand.
+pub async fn list_resources(pool: &DbPool) -> Result<Vec<ResourceDesc>> {
+    let rows: Vec<(String, String, String)> = match pool {
+        DbPool::MySql(p) => sqlx::query_as(
+            "SELECT repository_name, resource_type, resource_tag
+             FROM kbs_resources
+             ORDER BY repository_name, resource_type, resource_tag",
+        )
+        .fetch_all(p)
+        .await
+        .context("list resources (mysql)")?,
+        DbPool::Sqlite(p) => sqlx::query_as(
+            "SELECT repository_name, resource_type, resource_tag
+             FROM kbs_resources
+             ORDER BY repository_name, resource_type, resource_tag",
+        )
+        .fetch_all(p)
+        .await
+        .context("list resources (sqlite)")?,
+    };
+    Ok(rows
+        .into_iter()
+        .map(|(r, t, g)| ResourceDesc {
+            repository_name: r,
+            resource_type: t,
+            resource_tag: g,
+        })
+        .collect())
+}
+
+/// Fetch a batch of resources strictly older than `cutoff_generation`
+/// (i.e. wrapped under a key that pre-dates the new primary). Used by
+/// the rewrap pass.
+pub async fn fetch_batch_older_than(
+    pool: &DbPool,
+    cutoff_generation: Generation,
+    limit: i64,
+) -> Result<Vec<ResourceRow>> {
+    let rows: Vec<(String, String, String, String, Generation)> = match pool {
+        DbPool::MySql(p) => sqlx::query_as(
+            "SELECT repository_name, resource_type, resource_tag, envelope, generation
+             FROM kbs_resources
+             WHERE generation < ?
+             ORDER BY repository_name, resource_type, resource_tag
+             LIMIT ?",
+        )
+        .bind(cutoff_generation)
+        .bind(limit)
+        .fetch_all(p)
+        .await
+        .context("fetch batch (mysql)")?,
+        DbPool::Sqlite(p) => sqlx::query_as(
+            "SELECT repository_name, resource_type, resource_tag, envelope, generation
+             FROM kbs_resources
+             WHERE generation < ?
+             ORDER BY repository_name, resource_type, resource_tag
+             LIMIT ?",
+        )
+        .bind(cutoff_generation)
+        .bind(limit)
+        .fetch_all(p)
+        .await
+        .context("fetch batch (sqlite)")?,
+    };
+    Ok(rows
+        .into_iter()
+        .map(|(r, t, g, e, gen)| ResourceRow {
+            repository_name: r,
+            resource_type: t,
+            resource_tag: g,
+            envelope: e,
+            generation: gen,
+        })
+        .collect())
+}
+
+/// Fetch every resource (no generation filter). Used by the purge pass to
+/// catch stragglers a prior rewrap missed.
+pub async fn fetch_all(pool: &DbPool) -> Result<Vec<ResourceRow>> {
+    let rows: Vec<(String, String, String, String, Generation)> = match pool {
+        DbPool::MySql(p) => sqlx::query_as(
+            "SELECT repository_name, resource_type, resource_tag, envelope, generation
+             FROM kbs_resources
+             ORDER BY repository_name, resource_type, resource_tag",
+        )
+        .fetch_all(p)
+        .await
+        .context("fetch all (mysql)")?,
+        DbPool::Sqlite(p) => sqlx::query_as(
+            "SELECT repository_name, resource_type, resource_tag, envelope, generation
+             FROM kbs_resources
+             ORDER BY repository_name, resource_type, resource_tag",
+        )
+        .fetch_all(p)
+        .await
+        .context("fetch all (sqlite)")?,
+    };
+    Ok(rows
+        .into_iter()
+        .map(|(r, t, g, e, gen)| ResourceRow {
+            repository_name: r,
+            resource_type: t,
+            resource_tag: g,
+            envelope: e,
+            generation: gen,
+        })
+        .collect())
+}
+
+/// Update a single envelope's payload + generation (used by rewrap).
+pub async fn update_envelope(
+    pool: &DbPool,
+    desc: &ResourceDesc,
+    envelope: &[u8],
+    generation: Generation,
+) -> Result<()> {
+    let envelope_str = std::str::from_utf8(envelope)
+        .context("re-wrapped envelope is not valid UTF-8 JSON")?;
+    let now = current_iso_timestamp()?;
+    match pool {
+        DbPool::MySql(p) => {
+            sqlx::query(
+                "UPDATE kbs_resources
+                 SET envelope = ?, generation = ?, updated_at = ?
+                 WHERE repository_name = ? AND resource_type = ? AND resource_tag = ?",
+            )
+            .bind(envelope_str)
+            .bind(generation)
+            .bind(&now)
+            .bind(&desc.repository_name)
+            .bind(&desc.resource_type)
+            .bind(&desc.resource_tag)
+            .execute(p)
+            .await
+            .context("update envelope (mysql)")?;
+        }
+        DbPool::Sqlite(p) => {
+            sqlx::query(
+                "UPDATE kbs_resources
+                 SET envelope = ?, generation = ?, updated_at = ?
+                 WHERE repository_name = ? AND resource_type = ? AND resource_tag = ?",
+            )
+            .bind(envelope_str)
+            .bind(generation)
+            .bind(&now)
+            .bind(&desc.repository_name)
+            .bind(&desc.resource_type)
+            .bind(&desc.resource_tag)
+            .execute(p)
+            .await
+            .context("update envelope (sqlite)")?;
+        }
+    }
+    Ok(())
+}
+
+fn current_iso_timestamp() -> Result<String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before unix epoch")?;
+    let secs = now.as_secs() as i64;
+    let micros = now.subsec_micros();
+    let datetime = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, micros * 1_000)
+        .ok_or_else(|| anyhow::anyhow!("convert system time to chrono"))?;
+    Ok(datetime.format("%Y-%m-%d %H:%M:%S%.6f").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::implementations::resource::encrypted_db::schema::{
+        ensure_meta_defaults, migrate_schema,
+    };
+
+    async fn fresh_pool() -> DbPool {
+        let pool = DbPool::connect_sqlite_memory().await.unwrap();
+        migrate_schema(&pool).await.unwrap();
+        ensure_meta_defaults(&pool, None).await.unwrap();
+        pool
+    }
+
+    fn desc(r: &str, t: &str, g: &str) -> ResourceDesc {
+        ResourceDesc {
+            repository_name: r.into(),
+            resource_type: t.into(),
+            resource_tag: g.into(),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn upsert_then_read() {
+        let pool = fresh_pool().await;
+        let d = desc("repo", "secret", "r1");
+        upsert_envelope(&pool, &d, b"{\"alg\":\"X\"}", 100).await.unwrap();
+        let got = read_envelope(&pool, &d).await.unwrap();
+        assert_eq!(got.as_deref(), Some(b"{\"alg\":\"X\"}".as_slice()));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn upsert_replaces_on_conflict() {
+        let pool = fresh_pool().await;
+        let d = desc("repo", "secret", "r1");
+        upsert_envelope(&pool, &d, b"v1", 100).await.unwrap();
+        upsert_envelope(&pool, &d, b"v2", 200).await.unwrap();
+        let got = read_envelope(&pool, &d).await.unwrap();
+        assert_eq!(got.as_deref(), Some(b"v2".as_slice()));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn read_missing_returns_none() {
+        let pool = fresh_pool().await;
+        let got = read_envelope(&pool, &desc("repo", "secret", "missing"))
+            .await
+            .unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn delete_then_read_returns_none() {
+        let pool = fresh_pool().await;
+        let d = desc("repo", "secret", "r1");
+        upsert_envelope(&pool, &d, b"v1", 100).await.unwrap();
+        delete_resource(&pool, &d).await.unwrap();
+        assert!(read_envelope(&pool, &d).await.unwrap().is_none());
+        // Idempotent: re-deleting is fine.
+        delete_resource(&pool, &d).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn list_is_sorted() {
+        let pool = fresh_pool().await;
+        upsert_envelope(&pool, &desc("repo", "secret", "b"), b"x", 1)
+            .await
+            .unwrap();
+        upsert_envelope(&pool, &desc("repo", "secret", "a"), b"x", 1)
+            .await
+            .unwrap();
+        upsert_envelope(&pool, &desc("repo", "key", "a"), b"x", 1)
+            .await
+            .unwrap();
+        let lst = list_resources(&pool).await.unwrap();
+        let tags: Vec<String> = lst
+            .iter()
+            .map(|d| format!("{}/{}/{}", d.repository_name, d.resource_type, d.resource_tag))
+            .collect();
+        assert_eq!(
+            tags,
+            vec!["repo/key/a".to_string(), "repo/secret/a".into(), "repo/secret/b".into()]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fetch_batch_filters_by_generation() {
+        let pool = fresh_pool().await;
+        upsert_envelope(&pool, &desc("repo", "secret", "old"), b"x", 100)
+            .await
+            .unwrap();
+        upsert_envelope(&pool, &desc("repo", "secret", "new"), b"x", 200)
+            .await
+            .unwrap();
+        let batch = fetch_batch_older_than(&pool, 200, 10).await.unwrap();
+        let tags: Vec<String> = batch.iter().map(|r| r.resource_tag.clone()).collect();
+        assert_eq!(tags, vec!["old".to_string()]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn update_envelope_writes_back() {
+        let pool = fresh_pool().await;
+        let d = desc("repo", "secret", "r1");
+        upsert_envelope(&pool, &d, b"v1", 100).await.unwrap();
+        update_envelope(&pool, &d, b"v2", 200).await.unwrap();
+        let got = read_envelope(&pool, &d).await.unwrap();
+        assert_eq!(got.as_deref(), Some(b"v2".as_slice()));
+    }
+}

--- a/kbs/src/plugins/implementations/resource/encrypted_db/schema.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/schema.rs
@@ -89,7 +89,7 @@ CREATE TABLE IF NOT EXISTS kbs_resources (
     repository_name  VARCHAR(255)    NOT NULL,
     resource_type    VARCHAR(255)    NOT NULL,
     resource_tag     VARCHAR(255)    NOT NULL,
-    envelope         JSON            NOT NULL,
+    envelope         MEDIUMTEXT      NOT NULL,
     generation       BIGINT          NOT NULL,
     updated_at       DATETIME(6)     NOT NULL,
     PRIMARY KEY (repository_name, resource_type, resource_tag),

--- a/kbs/src/plugins/implementations/resource/encrypted_db/schema.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/schema.rs
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Schema bootstrap for the `EncryptedDb` backend.
+//!
+//! The schema is created with `CREATE TABLE IF NOT EXISTS` (idempotent) so
+//! every replica can run the same code on startup. On MySQL we additionally
+//! take a named server-side advisory lock (`GET_LOCK`) for the duration of
+//! the migration, so two replicas booting at once cannot race; on SQLite the
+//! lock is a no-op (single-writer file or in-memory database).
+//!
+//! The metadata table seeds default rows on first start, including a fresh
+//! random salt and the canary ciphertext used to verify the master secret.
+
+use anyhow::{anyhow, Context, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+use super::db::DbPool;
+use super::master_secret::{
+    encrypt_canary, generate_salt, Argon2Params, MasterKey, DEFAULT_ARGON2_M_COST,
+    DEFAULT_ARGON2_P_COST, DEFAULT_ARGON2_T_COST,
+};
+
+/// Schema version. Bump when introducing breaking changes.
+pub const SCHEMA_VERSION: i64 = 1;
+
+/// Name of the MySQL advisory lock taken during schema migration.
+const MIGRATION_LOCK_NAME: &str = "trustee_kbs_encrypted_db_migrate";
+
+/// Lock timeout in seconds (`GET_LOCK` second argument).
+const MIGRATION_LOCK_TIMEOUT_SECS: i64 = 30;
+
+/// `kbs_meta` keys.
+pub mod meta {
+    pub const SCHEMA_VERSION: &str = "schema_version";
+    pub const KDF_ALGO: &str = "kdf.algo";
+    pub const KDF_SALT: &str = "kdf.salt_b64";
+    pub const KDF_M_COST: &str = "kdf.m_cost";
+    pub const KDF_T_COST: &str = "kdf.t_cost";
+    pub const KDF_P_COST: &str = "kdf.p_cost";
+    pub const CANARY_NONCE: &str = "canary.iv_b64";
+    pub const CANARY_TAG: &str = "canary.tag_b64";
+    pub const CANARY_CIPHERTEXT: &str = "canary.ciphertext_b64";
+    pub const PRIMARY_GENERATION: &str = "primary_generation";
+}
+
+/// Run all CREATE TABLE statements (idempotent).
+pub async fn migrate_schema(pool: &DbPool) -> Result<()> {
+    match pool {
+        DbPool::MySql(p) => {
+            let row: (Option<i64>,) = sqlx::query_as("SELECT GET_LOCK(?, ?)")
+                .bind(MIGRATION_LOCK_NAME)
+                .bind(MIGRATION_LOCK_TIMEOUT_SECS)
+                .fetch_one(p)
+                .await
+                .context("acquire migration lock")?;
+            if row.0 != Some(1) {
+                return Err(anyhow!(
+                    "failed to acquire MySQL advisory lock `{MIGRATION_LOCK_NAME}` within {MIGRATION_LOCK_TIMEOUT_SECS}s"
+                ));
+            }
+            let result = create_tables_mysql(p).await;
+            // Best-effort release.
+            let _ = sqlx::query("SELECT RELEASE_LOCK(?)")
+                .bind(MIGRATION_LOCK_NAME)
+                .execute(p)
+                .await;
+            result
+        }
+        DbPool::Sqlite(p) => create_tables_sqlite(p).await,
+    }
+}
+
+const MYSQL_CREATE_KEYS: &str = r#"
+CREATE TABLE IF NOT EXISTS kbs_managed_keys (
+    generation       BIGINT          NOT NULL PRIMARY KEY,
+    public_key_pem   TEXT            NOT NULL,
+    enc_private_key  VARBINARY(8192) NOT NULL,
+    iv               VARBINARY(12)   NOT NULL,
+    tag              VARBINARY(16)   NOT NULL,
+    created_at       DATETIME(6)     NOT NULL,
+    retired_at       DATETIME(6)     NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+"#;
+
+const MYSQL_CREATE_RESOURCES: &str = r#"
+CREATE TABLE IF NOT EXISTS kbs_resources (
+    repository_name  VARCHAR(255)    NOT NULL,
+    resource_type    VARCHAR(255)    NOT NULL,
+    resource_tag     VARCHAR(255)    NOT NULL,
+    envelope         JSON            NOT NULL,
+    generation       BIGINT          NOT NULL,
+    updated_at       DATETIME(6)     NOT NULL,
+    PRIMARY KEY (repository_name, resource_type, resource_tag),
+    KEY idx_generation (generation)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+"#;
+
+const MYSQL_CREATE_META: &str = r#"
+CREATE TABLE IF NOT EXISTS kbs_meta (
+    k     VARCHAR(64) NOT NULL PRIMARY KEY,
+    v     TEXT        NOT NULL,
+    bump  BIGINT      NOT NULL DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+"#;
+
+const SQLITE_CREATE_KEYS: &str = r#"
+CREATE TABLE IF NOT EXISTS kbs_managed_keys (
+    generation       INTEGER NOT NULL PRIMARY KEY,
+    public_key_pem   TEXT    NOT NULL,
+    enc_private_key  BLOB    NOT NULL,
+    iv               BLOB    NOT NULL,
+    tag              BLOB    NOT NULL,
+    created_at       TEXT    NOT NULL,
+    retired_at       TEXT    NULL
+)
+"#;
+
+const SQLITE_CREATE_RESOURCES: &str = r#"
+CREATE TABLE IF NOT EXISTS kbs_resources (
+    repository_name  TEXT    NOT NULL,
+    resource_type    TEXT    NOT NULL,
+    resource_tag     TEXT    NOT NULL,
+    envelope         TEXT    NOT NULL,
+    generation       INTEGER NOT NULL,
+    updated_at       TEXT    NOT NULL,
+    PRIMARY KEY (repository_name, resource_type, resource_tag)
+)
+"#;
+
+const SQLITE_CREATE_RESOURCES_INDEX: &str =
+    "CREATE INDEX IF NOT EXISTS idx_kbs_resources_generation ON kbs_resources(generation)";
+
+const SQLITE_CREATE_META: &str = r#"
+CREATE TABLE IF NOT EXISTS kbs_meta (
+    k     TEXT    NOT NULL PRIMARY KEY,
+    v     TEXT    NOT NULL,
+    bump  INTEGER NOT NULL DEFAULT 0
+)
+"#;
+
+async fn create_tables_mysql(pool: &sqlx::MySqlPool) -> Result<()> {
+    for stmt in [MYSQL_CREATE_KEYS, MYSQL_CREATE_RESOURCES, MYSQL_CREATE_META] {
+        sqlx::query(stmt)
+            .execute(pool)
+            .await
+            .with_context(|| format!("execute mysql schema: {}", first_line(stmt)))?;
+    }
+    Ok(())
+}
+
+async fn create_tables_sqlite(pool: &sqlx::SqlitePool) -> Result<()> {
+    for stmt in [
+        SQLITE_CREATE_KEYS,
+        SQLITE_CREATE_RESOURCES,
+        SQLITE_CREATE_RESOURCES_INDEX,
+        SQLITE_CREATE_META,
+    ] {
+        sqlx::query(stmt)
+            .execute(pool)
+            .await
+            .with_context(|| format!("execute sqlite schema: {}", first_line(stmt)))?;
+    }
+    Ok(())
+}
+
+fn first_line(s: &str) -> &str {
+    s.lines().find(|l| !l.trim().is_empty()).unwrap_or(s).trim()
+}
+
+/// Insert default rows in `kbs_meta` (no-ops if already present). Generates a
+/// fresh salt the first time, and a canary ciphertext the first time a
+/// master key is supplied.
+pub async fn ensure_meta_defaults(pool: &DbPool, master_key: Option<&MasterKey>) -> Result<()> {
+    insert_meta_if_absent(pool, meta::SCHEMA_VERSION, &SCHEMA_VERSION.to_string()).await?;
+    insert_meta_if_absent(pool, meta::KDF_ALGO, "argon2id").await?;
+    insert_meta_if_absent(
+        pool,
+        meta::KDF_M_COST,
+        &DEFAULT_ARGON2_M_COST.to_string(),
+    )
+    .await?;
+    insert_meta_if_absent(
+        pool,
+        meta::KDF_T_COST,
+        &DEFAULT_ARGON2_T_COST.to_string(),
+    )
+    .await?;
+    insert_meta_if_absent(
+        pool,
+        meta::KDF_P_COST,
+        &DEFAULT_ARGON2_P_COST.to_string(),
+    )
+    .await?;
+
+    if read_meta_string(pool, meta::KDF_SALT).await?.is_none() {
+        let salt = generate_salt();
+        let salt_b64 = STANDARD.encode(salt);
+        // INSERT IGNORE so a peer replica that beat us leaves theirs intact.
+        insert_meta_if_absent(pool, meta::KDF_SALT, &salt_b64).await?;
+    }
+
+    if let Some(key) = master_key {
+        if read_meta_string(pool, meta::CANARY_CIPHERTEXT).await?.is_none() {
+            let (nonce, tag, ct) = encrypt_canary(key)?;
+            insert_meta_if_absent(pool, meta::CANARY_NONCE, &STANDARD.encode(&nonce)).await?;
+            insert_meta_if_absent(pool, meta::CANARY_TAG, &STANDARD.encode(&tag)).await?;
+            insert_meta_if_absent(pool, meta::CANARY_CIPHERTEXT, &STANDARD.encode(&ct)).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Idempotent `INSERT IGNORE` (or `INSERT OR IGNORE`) into `kbs_meta`.
+pub async fn insert_meta_if_absent(pool: &DbPool, key: &str, value: &str) -> Result<()> {
+    match pool {
+        DbPool::MySql(p) => {
+            sqlx::query("INSERT IGNORE INTO kbs_meta (k, v, bump) VALUES (?, ?, 0)")
+                .bind(key)
+                .bind(value)
+                .execute(p)
+                .await
+                .with_context(|| format!("insert {key} (mysql)"))?;
+        }
+        DbPool::Sqlite(p) => {
+            sqlx::query("INSERT OR IGNORE INTO kbs_meta (k, v, bump) VALUES (?, ?, 0)")
+                .bind(key)
+                .bind(value)
+                .execute(p)
+                .await
+                .with_context(|| format!("insert {key} (sqlite)"))?;
+        }
+    }
+    Ok(())
+}
+
+/// Read a single `kbs_meta.v` value as a UTF-8 string.
+pub async fn read_meta_string(pool: &DbPool, key: &str) -> Result<Option<String>> {
+    let row: Option<(String,)> = match pool {
+        DbPool::MySql(p) => sqlx::query_as("SELECT v FROM kbs_meta WHERE k = ?")
+            .bind(key)
+            .fetch_optional(p)
+            .await
+            .with_context(|| format!("read meta {key}"))?,
+        DbPool::Sqlite(p) => sqlx::query_as("SELECT v FROM kbs_meta WHERE k = ?")
+            .bind(key)
+            .fetch_optional(p)
+            .await
+            .with_context(|| format!("read meta {key}"))?,
+    };
+    Ok(row.map(|(v,)| v))
+}
+
+/// Read the persisted Argon2id parameters. Falls back to defaults if any are
+/// missing (should not happen after `ensure_meta_defaults`).
+pub async fn read_argon2_params(pool: &DbPool) -> Result<Argon2Params> {
+    let m_cost = parse_or_default(
+        read_meta_string(pool, meta::KDF_M_COST).await?,
+        DEFAULT_ARGON2_M_COST,
+        "m_cost",
+    )?;
+    let t_cost = parse_or_default(
+        read_meta_string(pool, meta::KDF_T_COST).await?,
+        DEFAULT_ARGON2_T_COST,
+        "t_cost",
+    )?;
+    let p_cost = parse_or_default(
+        read_meta_string(pool, meta::KDF_P_COST).await?,
+        DEFAULT_ARGON2_P_COST,
+        "p_cost",
+    )?;
+    Ok(Argon2Params {
+        m_cost,
+        t_cost,
+        p_cost,
+    })
+}
+
+fn parse_or_default(v: Option<String>, default: u32, name: &str) -> Result<u32> {
+    match v {
+        None => Ok(default),
+        Some(s) => s
+            .parse::<u32>()
+            .map_err(|e| anyhow!("parse argon2 {name}: {e}")),
+    }
+}
+
+/// Read the persisted KDF salt (decoded bytes).
+pub async fn read_salt(pool: &DbPool) -> Result<Vec<u8>> {
+    let v = read_meta_string(pool, meta::KDF_SALT)
+        .await?
+        .ok_or_else(|| anyhow!("kbs_meta.kdf.salt_b64 missing (run schema migration first)"))?;
+    STANDARD.decode(v).map_err(|e| anyhow!("decode salt: {e}"))
+}
+
+/// Read the persisted canary parts as `(nonce, tag, ciphertext)` if present.
+pub async fn read_canary(pool: &DbPool) -> Result<Option<(Vec<u8>, Vec<u8>, Vec<u8>)>> {
+    let nonce = read_meta_string(pool, meta::CANARY_NONCE).await?;
+    let tag = read_meta_string(pool, meta::CANARY_TAG).await?;
+    let ct = read_meta_string(pool, meta::CANARY_CIPHERTEXT).await?;
+    let (Some(n), Some(t), Some(c)) = (nonce, tag, ct) else {
+        return Ok(None);
+    };
+    let n = STANDARD
+        .decode(n)
+        .map_err(|e| anyhow!("decode canary nonce: {e}"))?;
+    let t = STANDARD
+        .decode(t)
+        .map_err(|e| anyhow!("decode canary tag: {e}"))?;
+    let c = STANDARD
+        .decode(c)
+        .map_err(|e| anyhow!("decode canary ciphertext: {e}"))?;
+    Ok(Some((n, t, c)))
+}

--- a/kbs/src/plugins/implementations/resource/encrypted_db/schema.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/schema.rs
@@ -175,24 +175,9 @@ fn first_line(s: &str) -> &str {
 pub async fn ensure_meta_defaults(pool: &DbPool, master_key: Option<&MasterKey>) -> Result<()> {
     insert_meta_if_absent(pool, meta::SCHEMA_VERSION, &SCHEMA_VERSION.to_string()).await?;
     insert_meta_if_absent(pool, meta::KDF_ALGO, "argon2id").await?;
-    insert_meta_if_absent(
-        pool,
-        meta::KDF_M_COST,
-        &DEFAULT_ARGON2_M_COST.to_string(),
-    )
-    .await?;
-    insert_meta_if_absent(
-        pool,
-        meta::KDF_T_COST,
-        &DEFAULT_ARGON2_T_COST.to_string(),
-    )
-    .await?;
-    insert_meta_if_absent(
-        pool,
-        meta::KDF_P_COST,
-        &DEFAULT_ARGON2_P_COST.to_string(),
-    )
-    .await?;
+    insert_meta_if_absent(pool, meta::KDF_M_COST, &DEFAULT_ARGON2_M_COST.to_string()).await?;
+    insert_meta_if_absent(pool, meta::KDF_T_COST, &DEFAULT_ARGON2_T_COST.to_string()).await?;
+    insert_meta_if_absent(pool, meta::KDF_P_COST, &DEFAULT_ARGON2_P_COST.to_string()).await?;
 
     if read_meta_string(pool, meta::KDF_SALT).await?.is_none() {
         let salt = generate_salt();
@@ -202,7 +187,10 @@ pub async fn ensure_meta_defaults(pool: &DbPool, master_key: Option<&MasterKey>)
     }
 
     if let Some(key) = master_key {
-        if read_meta_string(pool, meta::CANARY_CIPHERTEXT).await?.is_none() {
+        if read_meta_string(pool, meta::CANARY_CIPHERTEXT)
+            .await?
+            .is_none()
+        {
             let (nonce, tag, ct) = encrypt_canary(key)?;
             insert_meta_if_absent(pool, meta::CANARY_NONCE, &STANDARD.encode(&nonce)).await?;
             insert_meta_if_absent(pool, meta::CANARY_TAG, &STANDARD.encode(&tag)).await?;

--- a/kbs/src/plugins/implementations/resource/encrypted_local_fs.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_local_fs.rs
@@ -214,6 +214,7 @@ impl StorageBackend for EncryptedLocalFs {
             skipped: rewrap.skipped,
             failed: rewrap.failed,
             retired_keys: retired,
+            purged_keys: 0,
         })
     }
 }

--- a/kbs/src/plugins/implementations/resource/mod.rs
+++ b/kbs/src/plugins/implementations/resource/mod.rs
@@ -7,6 +7,9 @@ pub mod local_fs;
 #[cfg(feature = "encrypted-local-fs")]
 pub mod encrypted_local_fs;
 
+#[cfg(feature = "encrypted-db")]
+pub mod encrypted_db;
+
 #[cfg(feature = "aliyun")]
 pub mod aliyun_kms;
 

--- a/kbs/tests/encrypted_db_mysql_e2e.rs
+++ b/kbs/tests/encrypted_db_mysql_e2e.rs
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+//! End-to-end test for the EncryptedDb backend against a real MySQL.
+//!
+//! Skipped unless `MYSQL_TEST_URL` is set (typical local invocation:
+//!
+//! ```bash
+//! docker run -d --name kbs-mysql-test \
+//!   -e MYSQL_ROOT_PASSWORD=test-root \
+//!   -e MYSQL_DATABASE=trustee_kbs_test \
+//!   -p 33307:3306 mysql:8.0
+//!
+//! MYSQL_TEST_URL=mysql://root:test-root@127.0.0.1:33307/trustee_kbs_test \
+//!   cargo test -p kbs --features encrypted-db --test encrypted_db_mysql_e2e -- --nocapture
+//! ```
+//!
+//! The test mirrors the multi-replica deployment scenario from the plan
+//! (`/home/xinjian.zjl/.claude/plans/glittery-wishing-wilkes.md`):
+//!
+//!   1. Replica A returns a public key P1.
+//!   2. A client encrypts a resource r1 with P1 and POSTs to A.
+//!   3. Replica B reads r1 — must succeed (multi-replica path).
+//!   4. POST /rotate to B → returns a new public key P2.
+//!   5. A picks up the new pubkey within poll_interval.
+//!   6. Client uses P2 to upload r2 → A reads it.
+//!   7. Old r1 is rewrapped to P2 and still readable.
+//!   8. A reinitialized replica still uses P2.
+//!   9. A new replica started under a wrong passphrase fails canary check.
+//!  10. DELETE r1 — invisible from both replicas.
+//!  11. Backdate retired_at to simulate the grace period elapsing, run
+//!      another rotate, and observe purged_keys > 0 + the row gone.
+
+#![cfg(feature = "encrypted-db")]
+
+use std::env;
+use std::io::Write;
+use std::time::Duration;
+
+use aes_gcm::aead::{generic_array::GenericArray, AeadInPlace, KeyInit};
+use aes_gcm::{Aes256Gcm, Nonce};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use rand::RngCore;
+use rsa::pkcs8::DecodePublicKey;
+use rsa::sha2::Sha256;
+use rsa::{Oaep, RsaPublicKey};
+use tempfile::NamedTempFile;
+
+use kbs::plugins::implementations::resource::encrypted_db::{
+    DatabaseConfig, EncryptedDb, EncryptedDbBackendConfig,
+};
+use kbs::plugins::implementations::resource::{ResourceDesc, StorageBackend};
+
+const PASSPHRASE: &[u8] = b"e2e-master-secret-pls-change";
+
+/// Prepare a fresh schema by dropping the tables EncryptedDb owns. We do
+/// this via a side-channel sqlx connection so the per-test state is
+/// deterministic.
+async fn reset_mysql_schema(dsn: &str) {
+    let pool = sqlx::MySqlPool::connect(dsn).await.expect("connect mysql");
+    for stmt in [
+        "DROP TABLE IF EXISTS kbs_resources",
+        "DROP TABLE IF EXISTS kbs_managed_keys",
+        "DROP TABLE IF EXISTS kbs_meta",
+    ] {
+        sqlx::query(stmt).execute(&pool).await.unwrap();
+    }
+    pool.close().await;
+}
+
+fn write_passphrase(bytes: &[u8]) -> NamedTempFile {
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(bytes).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+fn cfg(dsn: &str, secret_path: &str) -> EncryptedDbBackendConfig {
+    EncryptedDbBackendConfig {
+        master_secret_path: secret_path.to_string(),
+        bump_poll_interval_ms: 250, // short so tests don't drag
+        database: DatabaseConfig {
+            kind: "mysql".to_string(),
+            dsn: dsn.to_string(),
+            ..Default::default()
+        },
+    }
+}
+
+fn desc(r: &str, t: &str, g: &str) -> ResourceDesc {
+    ResourceDesc {
+        repository_name: r.into(),
+        resource_type: t.into(),
+        resource_tag: g.into(),
+    }
+}
+
+/// Encrypt `plaintext` for the given PEM public key using the same
+/// envelope schema KBS expects (RSA-OAEP-256 wraps a 32-byte CEK that
+/// AES-256-GCM encrypts the body). Returns the JSON envelope a client
+/// would POST to `/repo/secret/<tag>`.
+fn encrypt_for_pubkey(public_pem: &str, plaintext: &[u8]) -> Vec<u8> {
+    let pub_key = RsaPublicKey::from_public_key_pem(public_pem).unwrap();
+    let mut cek = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut cek);
+    let mut iv = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut iv);
+    let cipher = Aes256Gcm::new_from_slice(&cek).unwrap();
+    let nonce = Nonce::from_slice(&iv);
+    let mut buf = plaintext.to_vec();
+    let tag = cipher
+        .encrypt_in_place_detached(nonce, b"", &mut buf)
+        .unwrap();
+    let enc_key = pub_key
+        .encrypt(&mut rand::thread_rng(), Oaep::new::<Sha256>(), &cek)
+        .unwrap();
+    let env = serde_json::json!({
+        "alg": "RSA-OAEP-256",
+        "enc_key": STANDARD.encode(enc_key),
+        "iv": STANDARD.encode(iv),
+        "ciphertext": STANDARD.encode(buf),
+        "tag": STANDARD.encode(GenericArray::from(tag).as_slice()),
+    });
+    serde_json::to_vec(&env).unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn end_to_end_two_replicas() {
+    let Ok(dsn) = env::var("MYSQL_TEST_URL") else {
+        eprintln!("MYSQL_TEST_URL not set — skipping MySQL e2e test");
+        return;
+    };
+    reset_mysql_schema(&dsn).await;
+
+    let secret = write_passphrase(PASSPHRASE);
+    let secret_path = secret.path().to_string_lossy().into_owned();
+
+    // Replica A: bootstraps the schema, the canary, and the first wrap key.
+    let replica_a = EncryptedDb::init_async(&cfg(&dsn, &secret_path))
+        .await
+        .expect("replica A init");
+    // Replica B: same DSN, same passphrase, same shared state.
+    let replica_b = EncryptedDb::init_async(&cfg(&dsn, &secret_path))
+        .await
+        .expect("replica B init");
+
+    // 1+2. A returns P1, client wraps r1 with P1, POSTs to A.
+    let p1 = replica_a.current_public_key_pem().await.unwrap();
+    let env_r1 = encrypt_for_pubkey(&p1, b"r1-payload");
+    replica_a
+        .write_secret_resource(desc("repo", "secret", "r1"), &env_r1)
+        .await
+        .unwrap();
+
+    // 3. B reads r1 — the critical multi-replica path.
+    let plain = replica_b
+        .read_secret_resource(desc("repo", "secret", "r1"))
+        .await
+        .unwrap();
+    assert_eq!(plain, b"r1-payload", "B must decrypt what A wrote");
+
+    // 4. POST /rotate to B.
+    let rotate = replica_b.rotate_keys().await.unwrap();
+    assert_eq!(rotate.failed, 0, "rotate must not fail");
+    assert!(
+        rotate.rewrapped >= 1,
+        "r1 should have been rewrapped during rotate, got {}",
+        rotate.rewrapped
+    );
+    assert!(rotate.public_key.contains("BEGIN PUBLIC KEY"));
+    assert!(
+        rotate.retired_keys >= 1,
+        "old generation should be retired"
+    );
+    let p2 = rotate.public_key.clone();
+
+    // 5. A picks up the new pubkey within poll_interval. We wait a beat
+    //    longer than the configured 250ms throttle, then read /pubkey.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    let p_seen_by_a = replica_a.current_public_key_pem().await.unwrap();
+    assert_eq!(p_seen_by_a, p2, "A must observe the rotated pubkey");
+
+    // 6. Client uses P2 to upload r2 → A reads it.
+    let env_r2 = encrypt_for_pubkey(&p2, b"r2-payload");
+    replica_b
+        .write_secret_resource(desc("repo", "secret", "r2"), &env_r2)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    let plain = replica_a
+        .read_secret_resource(desc("repo", "secret", "r2"))
+        .await
+        .unwrap();
+    assert_eq!(plain, b"r2-payload");
+
+    // 7. Old r1 still readable from both replicas (was rewrapped to P2).
+    for replica in [&replica_a, &replica_b] {
+        let plain = replica
+            .read_secret_resource(desc("repo", "secret", "r1"))
+            .await
+            .unwrap();
+        assert_eq!(plain, b"r1-payload");
+    }
+
+    // 8. A "fresh" replica (init from scratch) ends up with P2 as primary.
+    drop(replica_a);
+    let replica_c = EncryptedDb::init_async(&cfg(&dsn, &secret_path))
+        .await
+        .unwrap();
+    let p_c = replica_c.current_public_key_pem().await.unwrap();
+    assert_eq!(p_c, p2);
+
+    // 9. Wrong passphrase ⇒ canary refuses to start.
+    let wrong = write_passphrase(b"WRONG-passphrase");
+    let err = EncryptedDb::init_async(&cfg(
+        &dsn,
+        &wrong.path().to_string_lossy(),
+    ))
+    .await
+    .err()
+    .expect("wrong passphrase must fail");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("canary") || msg.contains("authentication"),
+        "expected canary error, got: {msg}"
+    );
+
+    // 10. DELETE r1 — invisible from any replica.
+    replica_b
+        .delete_secret_resource(desc("repo", "secret", "r1"))
+        .await
+        .unwrap();
+    for replica in [&replica_b, &replica_c] {
+        let res = replica
+            .read_secret_resource(desc("repo", "secret", "r1"))
+            .await;
+        assert!(res.is_err(), "deleted r1 must not be readable");
+    }
+
+    // 11. Back-date retired_at to simulate the grace period elapsing, then
+    //     rotate one more time and observe purged_keys > 0.
+    let pool = sqlx::MySqlPool::connect(&dsn).await.unwrap();
+    let pre_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM kbs_managed_keys WHERE retired_at IS NOT NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(pre_count.0 >= 1, "must have at least one retired key");
+    sqlx::query(
+        "UPDATE kbs_managed_keys SET retired_at = '2020-01-01 00:00:00.000000' WHERE retired_at IS NOT NULL",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool.close().await;
+
+    let rotate2 = replica_b.rotate_keys().await.unwrap();
+    assert_eq!(rotate2.failed, 0);
+    assert!(
+        rotate2.purged_keys >= pre_count.0 as usize,
+        "expected purge to remove the back-dated retired keys, got {}",
+        rotate2.purged_keys
+    );
+
+    let pool = sqlx::MySqlPool::connect(&dsn).await.unwrap();
+    let post_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM kbs_managed_keys WHERE retired_at IS NOT NULL AND retired_at < '2021-01-01'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        post_count.0, 0,
+        "back-dated retired keys must be physically deleted"
+    );
+    pool.close().await;
+}

--- a/kbs/tests/encrypted_db_mysql_e2e.rs
+++ b/kbs/tests/encrypted_db_mysql_e2e.rs
@@ -170,10 +170,7 @@ async fn end_to_end_two_replicas() {
         rotate.rewrapped
     );
     assert!(rotate.public_key.contains("BEGIN PUBLIC KEY"));
-    assert!(
-        rotate.retired_keys >= 1,
-        "old generation should be retired"
-    );
+    assert!(rotate.retired_keys >= 1, "old generation should be retired");
     let p2 = rotate.public_key.clone();
 
     // 5. A picks up the new pubkey within poll_interval. We wait a beat
@@ -214,13 +211,10 @@ async fn end_to_end_two_replicas() {
 
     // 9. Wrong passphrase ⇒ canary refuses to start.
     let wrong = write_passphrase(b"WRONG-passphrase");
-    let err = EncryptedDb::init_async(&cfg(
-        &dsn,
-        &wrong.path().to_string_lossy(),
-    ))
-    .await
-    .err()
-    .expect("wrong passphrase must fail");
+    let err = EncryptedDb::init_async(&cfg(&dsn, &wrong.path().to_string_lossy()))
+        .await
+        .err()
+        .expect("wrong passphrase must fail");
     let msg = format!("{err:#}");
     assert!(
         msg.contains("canary") || msg.contains("authentication"),

--- a/rpm/trustee.spec
+++ b/rpm/trustee.spec
@@ -4,7 +4,7 @@
 %global __brp_mangle_shebangs %{nil}
 
 Name:           trustee
-Version:        1.8.5
+Version:        1.8.6
 Release:	    %{alinux_release}%{?dist}
 Summary:        Daemon services for attestation and secret distribution
 Group:          Applications/System
@@ -148,6 +148,12 @@ fi
 /var/lib/attestation/token/ear/policies/opa/default.rego
 
 %changelog
+* Tue Jun 02 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> -1.8.6-1
+- KBS: add EncryptedDb resource backend for multi-replica deployments
+  (shared MySQL/SQLite-backed wrap-key store + envelope storage,
+  AES-256-GCM at-rest under an Argon2id-derived master key, atomic
+  rotation, deferred key purge with configurable grace period)
+
 * Mon Jun 01 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> -1.8.5-1
 - KBS: allow resource plugin configuration override via environment variables
 - KBS: self-manage EncryptedLocalFs keys with one-shot rotation API


### PR DESCRIPTION
## Summary

Adds a new resource backend, `EncryptedDb`, that stores **both** the wrap keys and the resource envelopes in a shared SQL database (MySQL or SQLite). It is the recommended backend for multi-replica KBS deployments where every replica needs to agree on which key wraps each resource.

`EncryptedLocalFs` is left untouched and remains the right choice for single-instance / BYOK setups.

### Why

`EncryptedLocalFs` keeps wrap keys (as `mkey-<nanos>.pem` files) and envelopes on the local filesystem. Run more than one replica and you hit:

1. **Key divergence on cold start** — every replica generates its own initial key.
2. **Rotation tearing** — `/rotate` on one replica deletes its old keys; other replicas keep using stale cached keys until restart or `/reload`.
3. **Resource invisibility** — resources written via replica A are simply not present on replica B.

This PR solves all three by making the database the source of truth and a deployment-level **master secret** (a Kubernetes Secret mounted as a tmpfs file at `/run/trustee/master.passphrase` by default) the only thing operators have to keep out of band.

### Design

- Wrap private keys → `kbs_managed_keys`, AES-256-GCM encrypted under a 32-byte master key derived from the passphrase via Argon2id (salt + KDF parameters live in `kbs_meta`). The generation identifier is bound as AAD so a copy-paste of ciphertext fails authentication.
- Resource envelopes → `kbs_resources`, JSON column. Wire format and `/pubkey` / `/rotate` / `/reload` / `/rewrap` admin API are byte-for-byte the same as `EncryptedLocalFs`, so existing client tooling (e.g. `kbs/sdk/python/encrypt_resource.py`) keeps working.
- A `bump` counter in `kbs_meta` advertises rotations across replicas; each replica cheap-polls (default 5 s throttle) to know when to reload its in-memory key ring.
- Rotation runs in a short transaction (insert new generation + bump pointer), with the rewrap pass over `kbs_resources` streamed in 200-row batches outside the lock.
- Retired keys are kept in the table for `retired_key_purge_after` (default 30 days) so resources uploaded with a stale public key during the rotation window remain decryptable. The next `/rotate` does a final straggler-rewrap pass and physically deletes the row.

### What's in this PR

| Commit | Subject |
|---|---|
| 1 | `kbs: fix clippy lints in resource backend env-override path` (replaces #179) |
| 2 | `kbs: add encrypted-db feature scaffold and dependencies` |
| 3 | `kbs: add file-based MasterSecretProvider with Argon2id KDF and canary` |
| 4 | `kbs: add EncryptedDb DB layer (schema + key store)` |
| 5 | `kbs: add EncryptedDb resource store (envelope CRUD)` |
| 6 | `kbs: implement EncryptedDb backend wiring key + resource stores` |
| 7 | `kbs: purge retired wrap keys after a configurable grace period` |
| 8 | `kbs: add MySQL e2e tests and document the EncryptedDb backend` |

If #179 lands first, commit 1 will rebase out cleanly. Otherwise it's the same patch, included here so this PR is self-contained for CI.

### What's NOT in this PR (scope)

- BYOK mode for `EncryptedDb` — managed-keys-only.
- Master-secret hot rotation — v1 requires a coordinated restart with the new passphrase.
- A migration tool from `EncryptedLocalFs` to `EncryptedDb`.
- Helm chart updates.
- env-var-based DSN configuration (sensitive fields stay in the config file).

### Test Plan

- [x] `cargo test -p kbs --features encrypted-db --no-default-features --features coco-as-builtin,coco-as-grpc,encrypted-local-fs` — **31 unit tests**, all green
  - master_secret KDF / canary / file trim (7)
  - schema + key_store CRUD, race, AAD binding, retire (6)
  - resource_store CRUD round-trip (7)
  - EncryptedDb lifecycle, rotate, canary rejection, purge grace (8)
  - small helpers (3)
- [x] `MYSQL_TEST_URL=mysql://root:test-root@127.0.0.1:33307/trustee_kbs_test cargo test -p kbs --features encrypted-db --test encrypted_db_mysql_e2e` — full 11-step **multi-replica end-to-end** (180s, mostly RSA-3072 keygen):
  1. A returns P1
  2. Client encrypts r1 with P1, POSTs to A
  3. B reads r1 (multi-replica path)
  4. POST /rotate to B → P2
  5. A picks up P2 within `bump_poll_interval`
  6. Client uses P2 to upload r2; A reads it
  7. r1 (rewrapped to P2) still readable
  8. Fresh replica also lands on P2
  9. Wrong passphrase → canary refuses startup
  10. DELETE r1 propagates to all replicas
  11. Backdate retired_at + rotate → `purged_keys > 0`, row gone
- [x] `cargo clippy -p kbs --locked -- -D warnings` (default features, what CI runs) — clean
- [x] `cargo build -p kbs --features encrypted-db --no-default-features --features coco-as-builtin,coco-as-grpc,encrypted-local-fs` — clean

### Reproducer for the e2e

```bash
docker run -d --name kbs-mysql-test   -e MYSQL_ROOT_PASSWORD=test-root   -e MYSQL_DATABASE=trustee_kbs_test   -p 33307:3306 mysql:8.0

MYSQL_TEST_URL=mysql://root:test-root@127.0.0.1:33307/trustee_kbs_test   cargo test -p kbs --features encrypted-db     --no-default-features --features coco-as-builtin,coco-as-grpc,encrypted-local-fs     --test encrypted_db_mysql_e2e -- --nocapture
```

### Documentation

- `kbs/docs/resource_storage_backend.md` — short subsection linking out
- `kbs/docs/resource_storage_backend_encrypted_db.md` — full architecture, schema, master secret model, concurrency model
- `kbs/docs/encrypted_db_key_rotation.md` — lifecycle + step-by-step rotate + comparison with EncryptedLocalFs
- `kbs/docs/config.md` — properties table + `[plugins.database]` schema + example