### PR TITLE
kbs: support env var overrides for EncryptedDb backend

### DIFF
--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -220,13 +220,27 @@ set to create one from environment variables.
 
 | Environment Variable | Description |
 |----------------------|-------------|
-| `KBS_RESOURCE_STORAGE_TYPE` | Replaces or creates the resource backend type. Supported values: `LocalFs`, `EncryptedLocalFs`, `EncryptedDb`, `Aliyun`, `ExternalKms`. (For `EncryptedDb`, the database connection settings still need to come from the config file — they cannot be supplied through environment variables.) |
+| `KBS_RESOURCE_STORAGE_TYPE` | Replaces or creates the resource backend type. Supported values: `LocalFs`, `EncryptedLocalFs`, `EncryptedDb`, `Aliyun`, `ExternalKms`. |
 | `KBS_RESOURCE_STORAGE_DIR_PATH` | Overrides `dir_path` for `LocalFs` and `EncryptedLocalFs`. |
 | `KBS_RESOURCE_STORAGE_PRIVATE_KEY_PATH` | Overrides `private_key_path` for `EncryptedLocalFs`. |
 | `KBS_RESOURCE_STORAGE_LIBRARY_PATH` | Overrides `library_path` for `ExternalKms`. |
 | `KBS_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE` | Overrides `initial_buffer_size` for `ExternalKms`. |
 | `KBS_RESOURCE_STORAGE_MAX_BUFFER_SIZE` | Overrides `max_buffer_size` for `ExternalKms`. |
 | `KBS_RESOURCE_STORAGE_ERROR_BUFFER_SIZE` | Overrides `error_buffer_size` for `ExternalKms`. |
+
+`EncryptedDb` backend fields can be overridden with the following variables:
+
+| Environment Variable | Description |
+|----------------------|-------------|
+| `KBS_RESOURCE_STORAGE_MASTER_SECRET_PATH` | Overrides `master_secret_path`. |
+| `KBS_RESOURCE_STORAGE_BUMP_POLL_INTERVAL_MS` | Overrides `bump_poll_interval_ms`. |
+| `KBS_RESOURCE_STORAGE_DB_TYPE` | Overrides `database.type` (`mysql` or `sqlite`). |
+| `KBS_RESOURCE_STORAGE_DB_DSN` | Overrides `database.dsn`. Recommended for cloud deployments where the DSN (and the password it embeds) is provided through a secret-manager-backed env var rather than baked into the config file. |
+| `KBS_RESOURCE_STORAGE_DB_PATH` | Overrides `database.path` (SQLite). |
+| `KBS_RESOURCE_STORAGE_DB_MAX_OPEN_CONNS` | Overrides `database.max_open_conns`. |
+| `KBS_RESOURCE_STORAGE_DB_MAX_IDLE_CONNS` | Overrides `database.max_idle_conns`. |
+| `KBS_RESOURCE_STORAGE_DB_CONN_MAX_LIFETIME` | Overrides `database.conn_max_lifetime`. |
+| `KBS_RESOURCE_STORAGE_RETIRED_KEY_PURGE_AFTER` | Overrides `database.retired_key_purge_after`. |
 
 Aliyun backend fields can be overridden with the following variables:
 

--- a/kbs/docs/resource_storage_backend_encrypted_db.md
+++ b/kbs/docs/resource_storage_backend_encrypted_db.md
@@ -101,8 +101,14 @@ Field reference:
 | `database.conn_max_lifetime` | no | `"1h"`, `"30m"`, etc. (humantime-style). Maps to `PoolOptions::max_lifetime`. |
 | `database.retired_key_purge_after` | no (default `"30d"`) | Grace period a retired key remains in the DB for late-arriving reads before being physically deleted. `"0"` disables purging. The minimum non-zero value is `"1h"`. |
 
-> Sensitive fields (DSN, master secret path) are intentionally **not**
-> overridable through the `KBS_RESOURCE_STORAGE_*` environment variables.
+All `EncryptedDb` fields can be overridden with `KBS_RESOURCE_STORAGE_*`
+environment variables — see the
+[Resource Configuration](./config.md#resource-configuration) section of the
+top-level config reference for the full list. The most common pattern in
+Kubernetes deployments is to leave the config file with placeholder values
+and pull `KBS_RESOURCE_STORAGE_DB_DSN` from a `Secret` via
+`secretKeyRef`, so the DSN (and the database password it embeds) never lives
+on disk inside the pod.
 
 ## Master secret
 

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -181,6 +181,15 @@ mod tests {
         "KBS_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE",
         "KBS_RESOURCE_STORAGE_MAX_BUFFER_SIZE",
         "KBS_RESOURCE_STORAGE_ERROR_BUFFER_SIZE",
+        "KBS_RESOURCE_STORAGE_MASTER_SECRET_PATH",
+        "KBS_RESOURCE_STORAGE_BUMP_POLL_INTERVAL_MS",
+        "KBS_RESOURCE_STORAGE_DB_TYPE",
+        "KBS_RESOURCE_STORAGE_DB_DSN",
+        "KBS_RESOURCE_STORAGE_DB_PATH",
+        "KBS_RESOURCE_STORAGE_DB_MAX_OPEN_CONNS",
+        "KBS_RESOURCE_STORAGE_DB_MAX_IDLE_CONNS",
+        "KBS_RESOURCE_STORAGE_DB_CONN_MAX_LIFETIME",
+        "KBS_RESOURCE_STORAGE_RETIRED_KEY_PURGE_AFTER",
         "KBS_RESOURCE_STORAGE_ALIYUN_CLIENT_KEY",
         "KBS_RESOURCE_STORAGE_ALIYUN_KMS_INSTANCE_ID",
         "KBS_RESOURCE_STORAGE_ALIYUN_PASSWORD",
@@ -524,5 +533,95 @@ mod tests {
         assert!(err
             .to_string()
             .contains("KBS_RESOURCE_STORAGE_TYPE is required"));
+    }
+
+    #[cfg(feature = "encrypted-db")]
+    #[test]
+    #[serial]
+    fn resource_storage_env_overrides_existing_encrypted_db() {
+        use crate::plugins::implementations::resource::encrypted_db::{
+            DatabaseConfig, EncryptedDbBackendConfig,
+        };
+
+        let _env = EnvGuard::clear();
+        env::set_var(
+            "KBS_RESOURCE_STORAGE_DB_DSN",
+            "mysql://kbs:env-pass@db.env:3306/trustee_kbs",
+        );
+        env::set_var(
+            "KBS_RESOURCE_STORAGE_MASTER_SECRET_PATH",
+            "/env/master.passphrase",
+        );
+        env::set_var("KBS_RESOURCE_STORAGE_BUMP_POLL_INTERVAL_MS", "1234");
+        env::set_var("KBS_RESOURCE_STORAGE_DB_MAX_OPEN_CONNS", "42");
+        env::set_var("KBS_RESOURCE_STORAGE_DB_CONN_MAX_LIFETIME", "30m");
+        env::set_var("KBS_RESOURCE_STORAGE_RETIRED_KEY_PURGE_AFTER", "7d");
+
+        let config = KbsConfig::try_from(Path::new(
+            "test_data/configs/coco-as-grpc-encrypted-db.toml",
+        ))
+        .unwrap();
+
+        assert_eq!(
+            config.plugins[0],
+            PluginsConfig::ResourceStorage(RepositoryConfig::EncryptedDb(
+                EncryptedDbBackendConfig {
+                    master_secret_path: "/env/master.passphrase".into(),
+                    bump_poll_interval_ms: 1234,
+                    database: DatabaseConfig {
+                        kind: "mysql".into(),
+                        dsn: "mysql://kbs:env-pass@db.env:3306/trustee_kbs".into(),
+                        path: "".into(),
+                        max_open_conns: 42,
+                        max_idle_conns: 5,
+                        conn_max_lifetime: "30m".into(),
+                        retired_key_purge_after: "7d".into(),
+                    },
+                }
+            ))
+        );
+    }
+
+    #[cfg(feature = "encrypted-db")]
+    #[test]
+    #[serial]
+    fn resource_storage_env_adds_encrypted_db_plugin() {
+        use crate::plugins::implementations::resource::encrypted_db::{
+            DatabaseConfig, EncryptedDbBackendConfig,
+        };
+
+        let _env = EnvGuard::clear();
+        env::set_var("KBS_RESOURCE_STORAGE_TYPE", "EncryptedDb");
+        env::set_var("KBS_RESOURCE_STORAGE_DB_TYPE", "mysql");
+        env::set_var(
+            "KBS_RESOURCE_STORAGE_DB_DSN",
+            "mysql://kbs:env-pass@db.env:3306/trustee_kbs",
+        );
+        env::set_var(
+            "KBS_RESOURCE_STORAGE_MASTER_SECRET_PATH",
+            "/env/master.passphrase",
+        );
+
+        let config =
+            KbsConfig::try_from(Path::new("test_data/configs/coco-as-grpc-3.toml")).unwrap();
+
+        assert_eq!(
+            config.plugins,
+            vec![PluginsConfig::ResourceStorage(
+                RepositoryConfig::EncryptedDb(EncryptedDbBackendConfig {
+                    master_secret_path: "/env/master.passphrase".into(),
+                    bump_poll_interval_ms: 0,
+                    database: DatabaseConfig {
+                        kind: "mysql".into(),
+                        dsn: "mysql://kbs:env-pass@db.env:3306/trustee_kbs".into(),
+                        path: "".into(),
+                        max_open_conns: 0,
+                        max_idle_conns: 0,
+                        conn_max_lifetime: "".into(),
+                        retired_key_purge_after: "".into(),
+                    },
+                })
+            )]
+        );
     }
 }

--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -30,6 +30,27 @@ const ENV_RESOURCE_STORAGE_INITIAL_BUFFER_SIZE: &str = "KBS_RESOURCE_STORAGE_INI
 const ENV_RESOURCE_STORAGE_MAX_BUFFER_SIZE: &str = "KBS_RESOURCE_STORAGE_MAX_BUFFER_SIZE";
 const ENV_RESOURCE_STORAGE_ERROR_BUFFER_SIZE: &str = "KBS_RESOURCE_STORAGE_ERROR_BUFFER_SIZE";
 
+#[cfg(feature = "encrypted-db")]
+const ENV_RESOURCE_STORAGE_MASTER_SECRET_PATH: &str = "KBS_RESOURCE_STORAGE_MASTER_SECRET_PATH";
+#[cfg(feature = "encrypted-db")]
+const ENV_RESOURCE_STORAGE_BUMP_POLL_INTERVAL_MS: &str =
+    "KBS_RESOURCE_STORAGE_BUMP_POLL_INTERVAL_MS";
+#[cfg(feature = "encrypted-db")]
+const ENV_RESOURCE_STORAGE_DB_TYPE: &str = "KBS_RESOURCE_STORAGE_DB_TYPE";
+#[cfg(feature = "encrypted-db")]
+const ENV_RESOURCE_STORAGE_DB_DSN: &str = "KBS_RESOURCE_STORAGE_DB_DSN";
+#[cfg(feature = "encrypted-db")]
+const ENV_RESOURCE_STORAGE_DB_PATH: &str = "KBS_RESOURCE_STORAGE_DB_PATH";
+#[cfg(feature = "encrypted-db")]
+const ENV_RESOURCE_STORAGE_DB_MAX_OPEN_CONNS: &str = "KBS_RESOURCE_STORAGE_DB_MAX_OPEN_CONNS";
+#[cfg(feature = "encrypted-db")]
+const ENV_RESOURCE_STORAGE_DB_MAX_IDLE_CONNS: &str = "KBS_RESOURCE_STORAGE_DB_MAX_IDLE_CONNS";
+#[cfg(feature = "encrypted-db")]
+const ENV_RESOURCE_STORAGE_DB_CONN_MAX_LIFETIME: &str = "KBS_RESOURCE_STORAGE_DB_CONN_MAX_LIFETIME";
+#[cfg(feature = "encrypted-db")]
+const ENV_RESOURCE_STORAGE_RETIRED_KEY_PURGE_AFTER: &str =
+    "KBS_RESOURCE_STORAGE_RETIRED_KEY_PURGE_AFTER";
+
 /// Interface of a `Repository`.
 #[async_trait::async_trait]
 pub trait StorageBackend: Send + Sync {
@@ -199,6 +220,27 @@ impl RepositoryConfig {
             return true;
         }
 
+        #[cfg(feature = "encrypted-db")]
+        {
+            let encrypted_db_present = [
+                ENV_RESOURCE_STORAGE_MASTER_SECRET_PATH,
+                ENV_RESOURCE_STORAGE_BUMP_POLL_INTERVAL_MS,
+                ENV_RESOURCE_STORAGE_DB_TYPE,
+                ENV_RESOURCE_STORAGE_DB_DSN,
+                ENV_RESOURCE_STORAGE_DB_PATH,
+                ENV_RESOURCE_STORAGE_DB_MAX_OPEN_CONNS,
+                ENV_RESOURCE_STORAGE_DB_MAX_IDLE_CONNS,
+                ENV_RESOURCE_STORAGE_DB_CONN_MAX_LIFETIME,
+                ENV_RESOURCE_STORAGE_RETIRED_KEY_PURGE_AFTER,
+            ]
+            .into_iter()
+            .any(|name| env::var_os(name).is_some());
+
+            if encrypted_db_present {
+                return true;
+            }
+        }
+
         #[cfg(feature = "aliyun")]
         if super::aliyun_kms::AliyunKmsBackendConfig::env_overrides_present() {
             return true;
@@ -269,11 +311,9 @@ impl RepositoryConfig {
             "encrypteddb" => {
                 #[cfg(feature = "encrypted-db")]
                 {
-                    bail!(
-                        "{ENV_RESOURCE_STORAGE_TYPE}=EncryptedDb cannot be configured purely from \
-                         environment variables; provide a config file with the [plugins.database] \
-                         table"
-                    )
+                    Ok(Self::EncryptedDb(
+                        super::encrypted_db::EncryptedDbBackendConfig::default(),
+                    ))
                 }
                 #[cfg(not(feature = "encrypted-db"))]
                 {
@@ -303,9 +343,42 @@ impl RepositoryConfig {
                 }
             }
             #[cfg(feature = "encrypted-db")]
-            Self::EncryptedDb(_) => {
-                // Sensitive fields (DSN, master_secret_path) are intentionally
-                // not overridable through environment variables.
+            Self::EncryptedDb(config) => {
+                if let Some(master_secret_path) =
+                    env_string(ENV_RESOURCE_STORAGE_MASTER_SECRET_PATH)?
+                {
+                    config.master_secret_path = master_secret_path;
+                }
+                if let Some(bump_poll_interval_ms) =
+                    env_parse(ENV_RESOURCE_STORAGE_BUMP_POLL_INTERVAL_MS)?
+                {
+                    config.bump_poll_interval_ms = bump_poll_interval_ms;
+                }
+                if let Some(db_type) = env_string(ENV_RESOURCE_STORAGE_DB_TYPE)? {
+                    config.database.kind = db_type;
+                }
+                if let Some(db_dsn) = env_string(ENV_RESOURCE_STORAGE_DB_DSN)? {
+                    config.database.dsn = db_dsn;
+                }
+                if let Some(db_path) = env_string(ENV_RESOURCE_STORAGE_DB_PATH)? {
+                    config.database.path = db_path;
+                }
+                if let Some(max_open_conns) = env_parse(ENV_RESOURCE_STORAGE_DB_MAX_OPEN_CONNS)? {
+                    config.database.max_open_conns = max_open_conns;
+                }
+                if let Some(max_idle_conns) = env_parse(ENV_RESOURCE_STORAGE_DB_MAX_IDLE_CONNS)? {
+                    config.database.max_idle_conns = max_idle_conns;
+                }
+                if let Some(conn_max_lifetime) =
+                    env_string(ENV_RESOURCE_STORAGE_DB_CONN_MAX_LIFETIME)?
+                {
+                    config.database.conn_max_lifetime = conn_max_lifetime;
+                }
+                if let Some(retired_key_purge_after) =
+                    env_string(ENV_RESOURCE_STORAGE_RETIRED_KEY_PURGE_AFTER)?
+                {
+                    config.database.retired_key_purge_after = retired_key_purge_after;
+                }
             }
             #[cfg(feature = "aliyun")]
             Self::Aliyun(config) => {

--- a/kbs/test_data/configs/coco-as-grpc-encrypted-db.toml
+++ b/kbs/test_data/configs/coco-as-grpc-encrypted-db.toml
@@ -1,0 +1,32 @@
+[attestation_token]
+trusted_certs_paths = ["/etc/ca"]
+
+[attestation_service]
+type = "coco_as_grpc"
+as_addr = "http://127.0.0.1:50001"
+pool_size = 100
+timeout = 600
+
+[http_server]
+sockets = ["0.0.0.0:8080"]
+insecure_http = true
+
+[admin]
+insecure_api = true
+
+[policy_engine]
+policy_path = "/etc/kbs-policy.rego"
+
+[[plugins]]
+name = "resource"
+type = "EncryptedDb"
+master_secret_path = "/etc/file/master.passphrase"
+bump_poll_interval_ms = 5000
+
+  [plugins.database]
+  type = "mysql"
+  dsn = "mysql://kbs:file-pass@db.file:3306/trustee_kbs"
+  max_open_conns = 20
+  max_idle_conns = 5
+  conn_max_lifetime = "1h"
+  retired_key_purge_after = "30d"


### PR DESCRIPTION
## Summary

- The `EncryptedDb` resource backend previously refused to read any of its fields from environment variables (`apply_field_env_overrides()` left the struct untouched, and `from_env_type()` bailed when `KBS_RESOURCE_STORAGE_TYPE=EncryptedDb`). Cloud deployments were forced to bake the database DSN — and the password it embeds — into the on-disk config file instead of pulling it from a Kubernetes `Secret` via `secretKeyRef`.
- This PR adds the same `KBS_RESOURCE_STORAGE_*` plumbing that LocalFs / EncryptedLocalFs / ExternalKms / Aliyun already have for every `EncryptedDbBackendConfig` field:

| Variable | Field |
|---|---|
| `KBS_RESOURCE_STORAGE_MASTER_SECRET_PATH` | `master_secret_path` |
| `KBS_RESOURCE_STORAGE_BUMP_POLL_INTERVAL_MS` | `bump_poll_interval_ms` |
| `KBS_RESOURCE_STORAGE_DB_TYPE` | `database.type` |
| `KBS_RESOURCE_STORAGE_DB_DSN` | `database.dsn` |
| `KBS_RESOURCE_STORAGE_DB_PATH` | `database.path` |
| `KBS_RESOURCE_STORAGE_DB_MAX_OPEN_CONNS` | `database.max_open_conns` |
| `KBS_RESOURCE_STORAGE_DB_MAX_IDLE_CONNS` | `database.max_idle_conns` |
| `KBS_RESOURCE_STORAGE_DB_CONN_MAX_LIFETIME` | `database.conn_max_lifetime` |
| `KBS_RESOURCE_STORAGE_RETIRED_KEY_PURGE_AFTER` | `database.retired_key_purge_after` |

- Both override-existing-plugin and create-from-env paths are wired through `env_overrides_present()`, `apply_field_env_overrides()`, and `from_env_type()`.
- Docs (`kbs/docs/config.md` and `kbs/docs/resource_storage_backend_encrypted_db.md`) are updated to drop the previous "intentionally not overridable" note and document the new variables.

I audited the other resource backends while at it: LocalFs / EncryptedLocalFs / ExternalKms / Aliyun were already covered. The non-resource plugins (sample, pkcs11, nebula-ca, tpm-pca) currently have no env var support at all — that is out of scope here and can be a follow-up if there is interest.

## Test plan

- [x] `cargo build -p kbs --features encrypted-db,encrypted-local-fs,aliyun,coco-as-grpc`
- [x] `cargo check -p kbs --no-default-features --features coco-as-grpc` (verifies the cfg gates)
- [x] `cargo test -p kbs --features encrypted-db,encrypted-local-fs,aliyun,coco-as-grpc --lib` — 94 passed, including two new `config::tests`:
  - `resource_storage_env_overrides_existing_encrypted_db`
  - `resource_storage_env_adds_encrypted_db_plugin`
- [x] `cargo fmt -p kbs --check` clean
- [x] `cargo clippy -p kbs --features encrypted-db,encrypted-local-fs,aliyun,coco-as-grpc --no-deps` clean for changed code