### PR TITLE
kbs: zeroize JWE key material to prevent recovery from memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+ "zeroize",
 ]
 
 [[package]]
@@ -305,6 +306,7 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1281,11 +1283,12 @@ checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
 
 [[package]]
 name = "const_format"
-version = "0.2.34"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -3405,6 +3408,7 @@ dependencies = [
  "actix",
  "actix-web",
  "actix-web-httpauth",
+ "aes",
  "aes-gcm",
  "aes-kw",
  "anyhow",
@@ -3431,6 +3435,7 @@ dependencies = [
  "mobc",
  "openssl",
  "p256",
+ "polyval",
  "prost",
  "rand",
  "reference-value-provider-service",
@@ -3512,6 +3517,21 @@ dependencies = [
  "url",
  "yasna 0.5.2",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "language-tags"
@@ -4610,6 +4630,7 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+ "zeroize",
 ]
 
 [[package]]

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -13,7 +13,7 @@ default = ["coco-as-builtin", "coco-as-grpc"]
 encrypted-local-fs = []
 
 # Enable encrypted DB-backed resource backend (multi-replica wrap-key sharing)
-encrypted-db = ["sqlx", "argon2", "zeroize", "chrono"]
+encrypted-db = ["sqlx", "argon2", "chrono"]
 
 # Support a backend attestation service for KBS
 as = []
@@ -47,7 +47,11 @@ tpm-pca = []
 actix = "0.13.5"
 actix-web = { workspace = true, features = ["openssl"] }
 actix-web-httpauth.workspace = true
-aes-gcm = "0.10.1"
+aes-gcm = { version = "0.10.1", features = ["zeroize"] }
+# Direct deps to activate their `zeroize` feature: `aes-gcm`'s own `zeroize`
+# feature does not propagate down to `aes` or `polyval`. Do not remove.
+aes = { version = "0.8", features = ["zeroize"] }
+polyval = { version = "0.6", features = ["zeroize"] }
 aes-kw = "0.2.1"
 anyhow.workspace = true
 argon2 = { workspace = true, optional = true }
@@ -93,7 +97,7 @@ derivative = "2.2.0"
 rustls-pki-types = "1.14.0"
 rustls-webpki = { version = "0.103.9", features = ["ring"] }
 x509-cert = "0.2.5"
-zeroize = { workspace = true, optional = true }
+zeroize.workspace = true
 
 [target.'cfg(not(any(target_arch = "s390x", target_arch = "aarch64")))'.dependencies]
 attestation-service = { path = "../attestation-service", default-features = false, features = [

--- a/kbs/src/jwe.rs
+++ b/kbs/src/jwe.rs
@@ -19,6 +19,7 @@ use p256::{
 use rand::{rngs::OsRng, Rng};
 use rsa::{sha2::Sha256, BigUint, Oaep, Pkcs1v15Encrypt, RsaPublicKey};
 use serde_json::{json, Map};
+use zeroize::Zeroizing;
 
 /// RSA PKCS#1 v1.5
 const RSA1_5_ALGORITHM: &str = "RSA1_5";
@@ -49,7 +50,7 @@ fn rsa_1v15(k_mod: String, k_exp: String, mut payload_data: Vec<u8>) -> Result<R
     warn!("Get JWE request using deprecated kcs#1 v1.5 encryption, which has potential security issues.");
     let mut rng = rand::thread_rng();
 
-    let aes_sym_key = Aes256Gcm::generate_key(&mut OsRng);
+    let aes_sym_key = Zeroizing::new(Aes256Gcm::generate_key(&mut OsRng));
     let mut cipher = Aes256Gcm::new(&aes_sym_key);
     let iv = rng.gen::<[u8; 12]>();
     let nonce = Nonce::from_slice(&iv);
@@ -94,7 +95,7 @@ fn rsa_1v15(k_mod: String, k_exp: String, mut payload_data: Vec<u8>) -> Result<R
 fn rsa_oaep256(k_mod: String, k_exp: String, mut payload_data: Vec<u8>) -> Result<Response> {
     let mut rng = rand::thread_rng();
 
-    let aes_sym_key = Aes256Gcm::generate_key(&mut OsRng);
+    let aes_sym_key = Zeroizing::new(Aes256Gcm::generate_key(&mut OsRng));
     let mut cipher = Aes256Gcm::new(&aes_sym_key);
     let iv = rng.gen::<[u8; 12]>();
     let nonce = Nonce::from_slice(&iv);
@@ -141,7 +142,7 @@ fn ecdh_es_a256kw_p256(x: String, y: String, mut payload_data: Vec<u8>) -> Resul
     let mut rng = rand::thread_rng();
 
     // 1. Generate a random CEK
-    let cek = Aes256Gcm::generate_key(&mut rng);
+    let cek = Zeroizing::new(Aes256Gcm::generate_key(&mut rng));
 
     // 2. Wrap the CEK and generate ProtectedHeader
     let x: [u8; 32] = URL_SAFE_NO_PAD
@@ -163,32 +164,29 @@ fn ecdh_es_a256kw_p256(x: String, y: String, mut payload_data: Vec<u8>) -> Resul
         .into_option()
         .ok_or(anyhow!("invalid TEE public key"))?;
     let encrypter_secret = EphemeralSecret::random(&mut rng);
-    let z = encrypter_secret
-        .diffie_hellman(&public_key)
-        .raw_secret_bytes()
-        .to_vec();
+    let z = Zeroizing::new(
+        encrypter_secret
+            .diffie_hellman(&public_key)
+            .raw_secret_bytes()
+            .to_vec(),
+    );
     let mut key_derivation_materials = Vec::new();
     key_derivation_materials.extend_from_slice(&(ECDH_ES_A256KW.len() as u32).to_be_bytes());
     key_derivation_materials.extend_from_slice(ECDH_ES_A256KW.as_bytes());
     key_derivation_materials.extend_from_slice(&(0_u32).to_be_bytes());
     key_derivation_materials.extend_from_slice(&(0_u32).to_be_bytes());
     key_derivation_materials.extend_from_slice(&AES_GCM_256_KEY_BITS.to_be_bytes());
-    let mut wrapping_key = vec![0; 32];
+    let mut wrapping_key = Zeroizing::new(vec![0u8; 32]);
     concat_kdf::derive_key_into::<rsa::sha2::Sha256>(
         &z,
         &key_derivation_materials,
         &mut wrapping_key,
     )
     .map_err(|e| anyhow!("failed to do concat KDF: {e:?}"))?;
-    let wrapping_key: [u8; 32] = wrapping_key
-        .try_into()
-        .map_err(|_| anyhow!("invalid bytes length of AES wrapping key"))?;
-    let wrapping_key: KekAes256 = Kek::new(&GenericArray::from(wrapping_key));
+    let wrapping_kek: KekAes256 = Kek::new(GenericArray::from_slice(&wrapping_key));
     let mut encrypted_key = vec![0; 40];
-    encrypted_key.resize(40, 0);
-    let cek = cek.to_vec();
-    wrapping_key
-        .wrap(&cek, &mut encrypted_key)
+    wrapping_kek
+        .wrap(cek.as_slice(), &mut encrypted_key)
         .map_err(|e| anyhow!("failed to do AES wrapping: {e:?}"))?;
 
     let point = EncodedPoint::from(encrypter_secret.public_key());
@@ -217,7 +215,7 @@ fn ecdh_es_a256kw_p256(x: String, y: String, mut payload_data: Vec<u8>) -> Resul
     };
 
     // 3. Encrypt content with CEK
-    let mut cek_cipher = Aes256Gcm::new(GenericArray::from_slice(&cek));
+    let mut cek_cipher = Aes256Gcm::new(&cek);
 
     let iv = rand::thread_rng().gen::<[u8; 12]>();
     let nonce = Nonce::from_slice(&iv);


### PR DESCRIPTION
## 背景

吸收上游 confidential-containers/trustee 的 JWE 密钥材料 zeroize 安全加固，降低密钥在内存/core dump/cold-boot 场景下被恢复的风险。

- 上游 commit：confidential-containers/trustee `2274aa44`（kbs: zeroize JWE key material to prevent recovery from memory）

## 改动内容

- `kbs/src/jwe.rs`：将 ECDH 共享密钥 `z`、KDF 派生的 wrapping key、CEK、以及 RSA 路径的 AES 对称密钥用 `zeroize::Zeroizing` 包装，drop 时清零。
- `kbs/Cargo.toml`：为 `aes-gcm` / `aes` / `polyval` 启用 `zeroize` feature（使 AES、GHASH key schedule 也被各自 crate 清零）；将 `zeroize` 依赖转为常驻（从 `encrypted-db` feature 列表移除）。

> 说明：`aes-kw` 的 `KekAes256` 派生了 `Copy`，无法 `ZeroizeOnDrop`，其内部 AES key schedule 无法覆盖（与上游一致的已知限制）。

## 适配说明（相对上游）

按本 fork 的 `jwe.rs` 布局重写（仅 P-256、使用 `concat_kdf::derive_key_into`、`aes_kw::Kek` API、`thread_rng` / `log`），而非直接 cherry-pick coco 的不同实现。

## 兼容性

- 纯内部安全加固，外部不可观测。
- 不新增/修改/删除任何 API、配置项或 wire-format。
- 不改变默认行为；现有部署不受影响。

## 验证

- `cargo check -p kbs` 通过。
- `cargo test -p kbs --lib jwe::` —— 3 个 JWE 兼容性测试全部通过（EC ECDH-ES+A256KW / RSA-OAEP-256 / RSA1.5，均用 josekit 解密回验），证明加密逻辑未被破坏。
