### PR TITLE
kbs: print the config guide when fail to parse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,11 +1281,12 @@ checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
 
 [[package]]
 name = "const_format"
-version = "0.2.34"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -3417,6 +3418,7 @@ dependencies = [
  "clap",
  "concat-kdf",
  "config",
+ "const_format",
  "cryptoki",
  "derivative",
  "env_logger 0.10.2",
@@ -3512,6 +3514,21 @@ dependencies = [
  "url",
  "yasna 0.5.2",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "language-tags"

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -58,6 +58,7 @@ cfg-if.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 config.workspace = true
 concat-kdf = "0.1.0"
+const_format = "0.2.36"
 cryptoki = { version = "0.8.0", optional = true }
 env_logger.workspace = true
 jsonwebtoken = { workspace = true, default-features = false }

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -9,6 +9,7 @@ use crate::token::AttestationTokenVerifierConfig;
 use anyhow::anyhow;
 use clap::Parser;
 use config::{Config, File};
+use const_format::concatcp;
 use serde::Deserialize;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -75,6 +76,53 @@ pub struct KbsConfig {
     pub plugins: Vec<PluginsConfig>,
 }
 
+/// The commit ref of the config documentation in the openanolis/trustee repository.
+const DOC_COMMIT_REF: &str = "6cae09a2";
+
+const CONFIG_DOC: &str = concatcp!(
+    "https://github.com/openanolis/trustee/blob/",
+    DOC_COMMIT_REF,
+    "/kbs/docs/config.md"
+);
+
+/// Best-effort mapping from a config error string to the relevant section anchor
+/// in the KBS configuration documentation.
+fn config_section_hint(err: &str) -> Option<&'static str> {
+    if err.contains("admin") {
+        return Some(concatcp!(CONFIG_DOC, "#admin-api-configuration"));
+    }
+    if err.contains("attestation_service") {
+        return Some(concatcp!(CONFIG_DOC, "#attestation-configuration"));
+    }
+    if err.contains("attestation_token") {
+        return Some(concatcp!(CONFIG_DOC, "#attestation-token-configuration"));
+    }
+    if err.contains("http_server") {
+        return Some(concatcp!(CONFIG_DOC, "#http-server-configuration"));
+    }
+    if err.contains("policy_engine") {
+        return Some(concatcp!(CONFIG_DOC, "#policy-engine-configuration"));
+    }
+    if err.contains("plugins") {
+        return Some(concatcp!(CONFIG_DOC, "#plugins-configuration"));
+    }
+    None
+}
+
+fn format_config_load_error(config_path: &Path, err: impl std::fmt::Display) -> anyhow::Error {
+    let err_str = err.to_string();
+    let mut message = format!(
+        "failed to load configuration file {}: {err_str}",
+        config_path.display()
+    );
+    if let Some(doc) = config_section_hint(&err_str) {
+        message.push_str("\nSee ");
+        message.push_str(doc);
+        message.push('.');
+    }
+    anyhow!(message)
+}
+
 impl KbsConfig {
     fn apply_resource_plugin_env_overrides(&mut self) -> anyhow::Result<()> {
         if !RepositoryConfig::env_overrides_present() {
@@ -115,11 +163,12 @@ impl TryFrom<&Path> for KbsConfig {
             )?
             .set_default("attestation_service.policy_ids", Vec::<&str>::new())?
             .add_source(File::with_name(config_path.to_str().unwrap()))
-            .build()?;
+            .build()
+            .map_err(|e| format_config_load_error(config_path, e))?;
 
         let mut kbs_config: Self = c
             .try_deserialize()
-            .map_err(|e| anyhow!("invalid config: {}", e.to_string()))?;
+            .map_err(|e| format_config_load_error(config_path, e))?;
         kbs_config.apply_resource_plugin_env_overrides()?;
         Ok(kbs_config)
     }


### PR DESCRIPTION
## 背景

吸收上游 confidential-containers/trustee 的「配置解析失败时打印配置指引」改进，提升 KBS 配置出错时的可诊断性。

- 上游 commit：confidential-containers/trustee `9f1c010c`（kbs: print the config guide when fail to parse）

## 改动内容

- `kbs/src/config.rs`：`KbsConfig` 加载/反序列化失败时，错误信息附带指向 KBS 配置文档对应小节的链接。
- `kbs/Cargo.toml`：新增 `const_format = "0.2.36"`。

## 适配说明（相对上游）

- 文档链接指向 **openanolis/trustee** 的 `kbs/docs/config.md`（pin 到 commit `6cae09a2`）。
- hint 小节列表按本 fork 的 KBS 配置 schema 调整：去掉 coco-only 的 `storage_backend`，加入本 fork 的 `policy_engine`。

## 兼容性

- 不新增/修改/删除任何 API。
- 不修改现有配置项；新增行为仅作用于「配置解析本就失败」时的错误提示。
- 不改变默认行为；现有部署不受影响。

## 验证

- `cargo check -p kbs` 通过。
