### PR TITLE
attestation-service: enable CORS support in restful-as for browser scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more 0.99.19",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +581,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "attestation-service"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-web",
  "aes-gcm",
  "aes-kw",

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -24,7 +24,7 @@ rvps-grpc = [ "prost", "tonic" ]
 grpc-bin = [ "clap", "env_logger", "prost", "tonic" ]
 
 # For restful CoCo-AS binary
-restful-bin = [ "actix-web/openssl", "clap", "env_logger" ]
+restful-bin = [ "actix-cors", "actix-web/openssl", "clap", "env_logger" ]
 
 [[bin]]
 name = "grpc-as"
@@ -39,6 +39,10 @@ name = "attestation-challenge-client"
 path = "src/bin/attestation-challenge-client/main.rs"
 
 [dependencies]
+# Pinned to 0.7.0: actix-cors 0.7.1 pulls in derive_more 2.x which requires
+# rustc >= 1.81, while this fork's toolchain is 1.76. 0.7.0 uses derive_more
+# 0.99 and builds fine. Bump once the MSRV is raised.
+actix-cors = { version = "=0.7.0", optional = true }
 actix-web = { workspace = true, optional = true }
 aes-gcm = "0.10"
 aes-kw = "0.2"

--- a/attestation-service/src/bin/restful-as.rs
+++ b/attestation-service/src/bin/restful-as.rs
@@ -1,6 +1,7 @@
 use std::{net::SocketAddr, path::Path, sync::Arc};
 
-use actix_web::{web, App, HttpServer};
+use actix_cors::Cors;
+use actix_web::{http::header, web, App, HttpServer};
 use anyhow::Result;
 use attestation_service::{config::Config, config::ConfigError, AttestationService, ServiceError};
 use clap::{arg, command, Parser};
@@ -41,6 +42,12 @@ pub struct Cli {
     /// private key are provided then HTTPS will be enabled.
     #[arg(short = 'k', long)]
     pub https_prikey: Option<String>,
+
+    /// Allowed origin for CORS access (e.g., "http://localhost:3000").
+    /// Can be specified multiple times or comma-separated. When empty
+    /// (the default), no CORS origins are allowed.
+    #[arg(short = 'r', long = "allowed_origin", value_delimiter = ',', num_args = 1..)]
+    pub allowed_origin: Vec<String>,
 }
 
 #[derive(EnumString, AsRefStr)]
@@ -87,6 +94,36 @@ pub enum RestfulError {
     Certificate(#[from] anyhow::Error),
 }
 
+fn configure_cors(allowed_origin: &[String]) -> Cors {
+    let mut cors = Cors::default()
+        .allowed_methods(vec!["POST", "GET", "OPTIONS"])
+        .allowed_headers(vec![header::CONTENT_TYPE, header::AUTHORIZATION])
+        .max_age(86400);
+
+    // Parse origin
+    if !allowed_origin.is_empty() {
+        let origins: Vec<String> = allowed_origin
+            .iter()
+            .flat_map(|s| s.split(','))
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        for ori in &origins {
+            if ori.starts_with("http://") || ori.starts_with("https://") {
+                log::info!("Allowed CORS origin: {ori:?}");
+                cors = cors.allowed_origin(ori.as_str());
+            } else {
+                log::error!(
+                    "Invalid CORS origin format: '{ori}'. Must start with http:// or https://"
+                );
+            }
+        }
+    };
+
+    cors
+}
+
 #[actix_web::main]
 async fn main() -> Result<(), RestfulError> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
@@ -106,9 +143,12 @@ async fn main() -> Result<(), RestfulError> {
 
     let attestation_service = AttestationService::new(config).await?;
 
+    let allowed_origin = cli.allowed_origin.clone();
+
     let attestation_service = web::Data::new(Arc::new(RwLock::new(attestation_service)));
     let server = HttpServer::new(move || {
         App::new()
+            .wrap(configure_cors(&allowed_origin))
             .service(web::resource(WebApi::Attestation.as_ref()).route(web::post().to(attestation)))
             .service(
                 web::resource(WebApi::Policy.as_ref())


### PR DESCRIPTION
## 背景

吸收上游 confidential-containers/trustee 的 restful-as CORS 支持，便于浏览器类客户端（如 Open-WebUI）跨域调用 attestation REST API。

- 上游 commit：confidential-containers/trustee `52a71bbc`（Enable CORS support in trustee for browser scenario）

## 改动内容

- `attestation-service/src/bin/restful-as.rs`：新增可选 `--allowed_origin`（`-r`）CLI 参数与 `configure_cors()`；为 `App` 挂上 CORS 层，允许指定 origin 的 POST/GET/OPTIONS + Content-Type/Authorization。
- `attestation-service/Cargo.toml`：新增可选依赖 `actix-cors`，gated 在已有的 `restful-bin` feature 下。

## 适配说明（相对上游）

- 手工塞入本 fork `restful-as.rs` 中更完整的 `App::new()` service 链（本 fork 多 `delete_policy`/`get_certificate`/`get_jwks`/`get_openid_configuration` 等 service）。
- `actix-cors` 固定为 **`=0.7.0`**：0.7.1 会拉入 `derive_more 2.x`（要求 rustc ≥ 1.81），与本 fork 的 1.76 工具链冲突；0.7.0 使用 `derive_more 0.99`，可正常构建。待 MSRV 提升后再 bump。

## 兼容性

- 默认关闭：不传 `--allowed_origin` 时不允许任何跨域 origin，行为与现状一致。
- 不新增/修改/删除任何现有 API 或配置项。
- `actix-cors` 为可选依赖，仅在 `restful-bin` feature 下引入。
- 现有部署不受影响。

## 验证

- `cargo check -p attestation-service --bin restful-as` 通过（rustc 1.76）。
