### PR TITLE
trustee-gateway: handle CORS and preflight OPTIONS requests

### DIFF
--- a/trustee-gateway/cmd/server/main.go
+++ b/trustee-gateway/cmd/server/main.go
@@ -86,6 +86,9 @@ func main() {
 	router := gin.New()
 	router.Use(gin.Recovery())
 	router.Use(middleware.Logger())
+	if cfg.Server.CORS.Enabled {
+		router.Use(middleware.CORS(cfg.Server.CORS))
+	}
 
 	// API routes
 	setupRoutes(router, kbsHandler, rvpsHandler, attestationServiceHandler, auditHandler, healthCheckHandler, p, aaInstanceHandler, credentialHandler)

--- a/trustee-gateway/config.yaml
+++ b/trustee-gateway/config.yaml
@@ -5,6 +5,18 @@ server:
   tls:
     cert_file: ""
     key_file: ""
+  # Cross-Origin Resource Sharing. Enabled by default so browser-based consoles
+  # can call the gateway and their preflight (OPTIONS) requests are answered
+  # instead of returning 404.
+  cors:
+    enabled: true
+    allowed_origins: ["*"]
+    allowed_methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
+    allowed_headers: ["*"]
+    # allow_credentials cannot be combined with a "*" origin; when true the
+    # request origin is reflected instead.
+    allow_credentials: false
+    max_age: 86400
 
 kbs:
   url: "http://localhost:8080"

--- a/trustee-gateway/internal/config/config.go
+++ b/trustee-gateway/internal/config/config.go
@@ -20,10 +20,23 @@ type Config struct {
 
 // ServerConfig holds the gateway server configuration
 type ServerConfig struct {
-	Host         string    `mapstructure:"host"`
-	Port         int       `mapstructure:"port"`
-	TLS          TLSConfig `mapstructure:"tls"`
-	InsecureHTTP bool      `mapstructure:"insecure_http"`
+	Host         string     `mapstructure:"host"`
+	Port         int        `mapstructure:"port"`
+	TLS          TLSConfig  `mapstructure:"tls"`
+	InsecureHTTP bool       `mapstructure:"insecure_http"`
+	CORS         CORSConfig `mapstructure:"cors"`
+}
+
+// CORSConfig holds Cross-Origin Resource Sharing configuration. It controls the
+// headers returned for cross-origin requests and how browser preflight
+// (OPTIONS) requests are answered.
+type CORSConfig struct {
+	Enabled          bool     `mapstructure:"enabled"`
+	AllowedOrigins   []string `mapstructure:"allowed_origins"`
+	AllowedMethods   []string `mapstructure:"allowed_methods"`
+	AllowedHeaders   []string `mapstructure:"allowed_headers"`
+	AllowCredentials bool     `mapstructure:"allow_credentials"`
+	MaxAge           int      `mapstructure:"max_age"`
 }
 
 // TLSConfig holds TLS configuration
@@ -93,6 +106,14 @@ func LoadConfig(configPath string) (*Config, error) {
 	viper.SetDefault("server.host", "0.0.0.0")
 	viper.SetDefault("server.port", 8081)
 	viper.SetDefault("server.insecure_http", true)
+	// CORS: enabled by default so browser-based consoles can call the gateway
+	// and their preflight (OPTIONS) requests are answered instead of 404ing.
+	viper.SetDefault("server.cors.enabled", true)
+	viper.SetDefault("server.cors.allowed_origins", []string{"*"})
+	viper.SetDefault("server.cors.allowed_methods", []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"})
+	viper.SetDefault("server.cors.allowed_headers", []string{"*"})
+	viper.SetDefault("server.cors.allow_credentials", false)
+	viper.SetDefault("server.cors.max_age", 86400)
 	viper.SetDefault("kbs.url", "http://localhost:8080")
 	viper.SetDefault("attestation_service.url", "http://localhost:50005")
 	viper.SetDefault("rvps.grpc_addr", "localhost:50003")

--- a/trustee-gateway/internal/middleware/cors.go
+++ b/trustee-gateway/internal/middleware/cors.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openanolis/trustee/gateway/internal/config"
+)
+
+// CORS returns a middleware that handles Cross-Origin Resource Sharing.
+//
+// It sets the appropriate Access-Control-* response headers for cross-origin
+// requests and short-circuits browser preflight (OPTIONS) requests with a
+// 204 response. Registered globally, it also runs for routes that only expose
+// non-OPTIONS methods, so preflight requests no longer fall through to the
+// gin NoRoute handler and return 404.
+func CORS(cfg config.CORSConfig) gin.HandlerFunc {
+	allowedMethods := strings.Join(cfg.AllowedMethods, ", ")
+	allowedHeaders := strings.Join(cfg.AllowedHeaders, ", ")
+	maxAge := strconv.Itoa(cfg.MaxAge)
+
+	allowAllOrigins := false
+	originSet := make(map[string]struct{}, len(cfg.AllowedOrigins))
+	for _, o := range cfg.AllowedOrigins {
+		if o == "*" {
+			allowAllOrigins = true
+		}
+		originSet[o] = struct{}{}
+	}
+
+	// Reflect the requested headers only when the configuration allows any header.
+	reflectHeaders := len(cfg.AllowedHeaders) == 1 && cfg.AllowedHeaders[0] == "*"
+
+	return func(c *gin.Context) {
+		origin := c.Request.Header.Get("Origin")
+		if origin != "" {
+			switch {
+			case allowAllOrigins && !cfg.AllowCredentials:
+				c.Header("Access-Control-Allow-Origin", "*")
+			case allowAllOrigins:
+				// "*" cannot be combined with credentials, so reflect the origin.
+				c.Header("Access-Control-Allow-Origin", origin)
+				c.Header("Vary", "Origin")
+			default:
+				if _, ok := originSet[origin]; ok {
+					c.Header("Access-Control-Allow-Origin", origin)
+					c.Header("Vary", "Origin")
+				}
+			}
+
+			c.Header("Access-Control-Allow-Methods", allowedMethods)
+
+			if reflectHeaders {
+				if reqHeaders := c.Request.Header.Get("Access-Control-Request-Headers"); reqHeaders != "" {
+					c.Header("Access-Control-Allow-Headers", reqHeaders)
+				} else {
+					c.Header("Access-Control-Allow-Headers", "*")
+				}
+			} else {
+				c.Header("Access-Control-Allow-Headers", allowedHeaders)
+			}
+
+			if cfg.AllowCredentials {
+				c.Header("Access-Control-Allow-Credentials", "true")
+			}
+			c.Header("Access-Control-Max-Age", maxAge)
+		}
+
+		// Short-circuit preflight requests.
+		if c.Request.Method == http.MethodOptions {
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/trustee-gateway/internal/middleware/cors_test.go
+++ b/trustee-gateway/internal/middleware/cors_test.go
@@ -1,0 +1,108 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openanolis/trustee/gateway/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func defaultCORSConfig() config.CORSConfig {
+	return config.CORSConfig{
+		Enabled:          true,
+		AllowedOrigins:   []string{"*"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"},
+		AllowedHeaders:   []string{"*"},
+		AllowCredentials: false,
+		MaxAge:           86400,
+	}
+}
+
+func newCORSRouter(cfg config.CORSConfig) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(CORS(cfg))
+	// Only a POST handler is registered, mirroring the real routes that do not
+	// expose an explicit OPTIONS method.
+	router.POST("/api/as/challenge", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+	return router
+}
+
+// TestCORSPreflightReturns204 ensures a preflight OPTIONS request to a route
+// that only registers non-OPTIONS methods is answered with 204 and the proper
+// CORS headers, instead of falling through to gin's 404 NoRoute handler.
+func TestCORSPreflightReturns204(t *testing.T) {
+	router := newCORSRouter(defaultCORSConfig())
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/as/challenge", nil)
+	req.Header.Set("Origin", "http://127.0.0.1:8083")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, w.Header().Get("Access-Control-Allow-Methods"), "POST")
+	assert.Equal(t, "content-type", w.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "86400", w.Header().Get("Access-Control-Max-Age"))
+}
+
+// TestCORSActualRequestPassesThrough ensures non-preflight requests still reach
+// their handler and carry the Allow-Origin header.
+func TestCORSActualRequestPassesThrough(t *testing.T) {
+	router := newCORSRouter(defaultCORSConfig())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/as/challenge", nil)
+	req.Header.Set("Origin", "http://127.0.0.1:8083")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+}
+
+// TestCORSAllowCredentialsReflectsOrigin ensures that when credentials are
+// allowed the concrete origin is reflected (since "*" is invalid with
+// credentials) and the credentials header is set.
+func TestCORSAllowCredentialsReflectsOrigin(t *testing.T) {
+	cfg := defaultCORSConfig()
+	cfg.AllowCredentials = true
+	router := newCORSRouter(cfg)
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/as/challenge", nil)
+	req.Header.Set("Origin", "http://127.0.0.1:8083")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, "http://127.0.0.1:8083", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "true", w.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, "Origin", w.Header().Get("Vary"))
+}
+
+// TestCORSSpecificOriginRejectsUnlisted ensures that when explicit origins are
+// configured, an unlisted origin does not receive an Allow-Origin header.
+func TestCORSSpecificOriginRejectsUnlisted(t *testing.T) {
+	cfg := defaultCORSConfig()
+	cfg.AllowedOrigins = []string{"http://allowed.example"}
+	router := newCORSRouter(cfg)
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/as/challenge", nil)
+	req.Header.Set("Origin", "http://evil.example")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Preflight is still short-circuited, but no origin is granted.
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+}


### PR DESCRIPTION
## Problem

The trustee-gateway registers only concrete HTTP methods (`POST`/`GET`/...) on its routes. Browser preflight `OPTIONS` requests therefore match no route and fall through to gin's `NoRoute` handler, returning **404**:

```
{"method":"OPTIONS","path":"/api/as/challenge","status":404,"referer":"http://127.0.0.1:8083/",...}
```

This breaks cross-origin calls from browser-based consoles even though the upstream `restful-as` already supports CORS (58da7b30) — the preflight is rejected at the gateway before it ever reaches the attestation service.

## Fix

Add a global CORS middleware that:

- sets the `Access-Control-*` response headers for cross-origin requests, and
- short-circuits preflight `OPTIONS` requests with `204 No Content`.

Because it is registered globally, it also runs for gin's `NoRoute`/`NoMethod` chains, so preflight requests to routes that only expose non-OPTIONS methods are answered correctly.

To keep the gateway the single source of CORS policy, upstream `Access-Control-*` response headers are **dropped when proxying**. Otherwise a CORS-enabled upstream (e.g. `restful-as` started with `--allowed_origin`) would emit its own `Access-Control-Allow-Origin`, and the proxied response would carry two conflicting values, which browsers reject.

## Configuration

Behaviour is configurable under `server.cors` and enabled by default with a permissive `*` origin:

```yaml
server:
  cors:
    enabled: true
    allowed_origins: ["*"]
    allowed_methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
    allowed_headers: ["*"]
    allow_credentials: false
    max_age: 86400
```

When `allow_credentials` is `true` the request origin is reflected instead of `*`, as required by the CORS spec.

## Impact on existing APIs

- Non-preflight requests are unchanged apart from the added `Access-Control-*` response headers (ignored by non-browser clients).
- The only route that previously matched `OPTIONS` was the `rvps.Any("/*path")` catch-all; `OPTIONS /api/rvps/*` now returns `204` (preflight) instead of being proxied. RVPS defines no semantic `OPTIONS` operation, so this only affects preflight.
- Can be fully disabled with `server.cors.enabled: false`.

## Testing

- `internal/middleware/cors_test.go`: preflight on a POST-only route returns 204 with headers (reproduces the 404 bug), actual requests pass through, credentials reflect the origin, unlisted origins are not granted.
- `internal/proxy/proxy_test.go`: upstream `Access-Control-*` headers are stripped so no duplicate `Access-Control-Allow-Origin` reaches the client.
- `go build ./...`, `go vet ./...`, and the middleware/proxy tests pass.