### PR TITLE
trustee-gateway: drop upstream CORS headers when proxying

### DIFF
--- a/trustee-gateway/internal/proxy/proxy.go
+++ b/trustee-gateway/internal/proxy/proxy.go
@@ -291,12 +291,27 @@ func (p *Proxy) forwardRequest(c *gin.Context, serviceType ServiceType) (*http.R
 	return resp, nil
 }
 
+// isCORSHeader reports whether a header is a CORS response header owned by the
+// gateway's CORS middleware. Such headers are dropped when copying an upstream
+// response so the gateway remains the single source of CORS policy; otherwise a
+// CORS-enabled upstream (e.g. restful-as started with --allowed_origin) would
+// emit its own Access-Control-Allow-Origin and the response would carry two
+// conflicting values, which browsers reject.
+func isCORSHeader(canonicalKey string) bool {
+	return strings.HasPrefix(canonicalKey, "Access-Control-")
+}
+
 // CopyHeaders copies headers from a source response to the destination gin context
 func CopyHeaders(dst *gin.Context, src *http.Response) {
 	for k, vv := range src.Header {
+		ck := http.CanonicalHeaderKey(k)
 		// Cookies will be set via http.SetCookie() in CopyCookies().
 		// Avoid duplicating Set-Cookie header.
-		if http.CanonicalHeaderKey(k) == "Set-Cookie" {
+		if ck == "Set-Cookie" {
+			continue
+		}
+		// The gateway's CORS middleware owns Access-Control-* headers.
+		if isCORSHeader(ck) {
 			continue
 		}
 		for _, v := range vv {
@@ -316,6 +331,10 @@ func CopyHeadersExceptContentLength(dst *gin.Context, src *http.Response) {
 		}
 		// Avoid duplicating Set-Cookie header; CopyCookies handles it.
 		if ck == "Set-Cookie" {
+			continue
+		}
+		// The gateway's CORS middleware owns Access-Control-* headers.
+		if isCORSHeader(ck) {
 			continue
 		}
 		for _, v := range vv {

--- a/trustee-gateway/internal/proxy/proxy_test.go
+++ b/trustee-gateway/internal/proxy/proxy_test.go
@@ -101,3 +101,34 @@ func TestProxy_ForwardRequest(t *testing.T) {
 		t.Errorf("Unexpected response body: %s", string(respBody))
 	}
 }
+
+// TestCopyHeaders_StripsUpstreamCORS ensures Access-Control-* headers coming
+// from an upstream response are dropped, so the gateway's CORS middleware stays
+// the single source of CORS policy and the response never carries duplicate
+// Access-Control-Allow-Origin values.
+func TestCopyHeaders_StripsUpstreamCORS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	src := &http.Response{Header: http.Header{}}
+	src.Header.Add("Access-Control-Allow-Origin", "http://upstream.example")
+	src.Header.Add("Access-Control-Allow-Methods", "GET, POST")
+	src.Header.Add("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	// Simulate the gateway CORS middleware having already set the header.
+	c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+
+	CopyHeaders(c, src)
+
+	got := c.Writer.Header().Values("Access-Control-Allow-Origin")
+	if len(got) != 1 || got[0] != "*" {
+		t.Fatalf("expected a single gateway Access-Control-Allow-Origin '*', got: %#v", got)
+	}
+	if c.Writer.Header().Get("Access-Control-Allow-Methods") != "" {
+		t.Fatalf("upstream Access-Control-Allow-Methods should be stripped, got: %q", c.Writer.Header().Get("Access-Control-Allow-Methods"))
+	}
+	if c.Writer.Header().Get("Content-Type") != "application/json" {
+		t.Fatalf("non-CORS headers must still be copied, got Content-Type: %q", c.Writer.Header().Get("Content-Type"))
+	}
+}


### PR DESCRIPTION
## Background

Follow-up to #188, which added CORS support to the trustee-gateway. That PR gave the gateway middleware ownership of the `Access-Control-*` response headers, but did not touch the proxy's header-copying path.

## Problem

The proxy copies upstream response headers with `Header().Add()` (append, not set). So when an upstream service **also** emits CORS headers — e.g. `restful-as` started with `--allowed_origin` (added in 58da7b30) — the proxied response ends up carrying **two** `Access-Control-Allow-Origin` values: one from the gateway middleware and one from the upstream.

Browsers reject responses that contain multiple `Access-Control-Allow-Origin` values:

```
The 'Access-Control-Allow-Origin' header contains multiple values '*, http://…', but only one is allowed.
```

This breaks the very cross-origin calls CORS is meant to enable, and it only shows up once the upstream AS is itself configured for CORS — an easy footgun.

## Fix

Make the gateway the single source of CORS policy: skip upstream `Access-Control-*` headers in `CopyHeaders` / `CopyHeadersExceptContentLength`, so only the gateway middleware's headers reach the client.

## Testing

Added `TestCopyHeaders_StripsUpstreamCORS`: an upstream response carrying `Access-Control-Allow-Origin` / `Access-Control-Allow-Methods` yields exactly one gateway-owned `Access-Control-Allow-Origin` and no leaked upstream CORS header, while non-CORS headers (e.g. `Content-Type`) are still copied. `go build ./...`, `go vet ./...`, and the proxy tests pass.