### PR TITLE
attestation-service: make challenge signing key path configurable

### DIFF
--- a/attestation-service/docs/config.md
+++ b/attestation-service/docs/config.md
@@ -18,6 +18,7 @@ section:
 | `work_dir`                 | String                      | The location for Attestation Service to store data. | False      | Firstly try to read from ENV `AS_WORK_DIR`. If not any, use `/opt/confidential-containers/attestation-service`       |
 | `rvps_config`              | [RVPSConfiguration][2]      | RVPS configuration                                  | False      | -       |
 | `attestation_token_broker` | [AttestationTokeBroker][1]  | Attestation result token configuration.             | False      | -       |
+| `challenge_key_path`       | String                      | Path to the RSA private key (PEM) used to sign and verify attestation challenge (nonce) tokens. The key is generated on first use if the file does not exist. | False | `/etc/trustee/attestation-service/nonce_token_issuer/key.pem` |
 
 [1]: #attestationtokenbroker
 [2]: #rvps-configuration

--- a/attestation-service/src/bin/attestation-challenge-client/config.rs
+++ b/attestation-service/src/bin/attestation-challenge-client/config.rs
@@ -40,6 +40,7 @@ pub fn build_default_config(work_dir: &Path) -> Result<Config> {
         work_dir: work_dir.to_path_buf(),
         rvps_config,
         attestation_token_broker: AttestationTokenConfig::Ear(ear_cfg),
+        challenge_key_path: None,
     })
 }
 

--- a/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/src/bin/grpc/mod.rs
@@ -142,7 +142,9 @@ impl AttestationService for Arc<RwLock<AttestationServer>> {
                             .map_err(|e| Status::aborted(format!(
                                 "parse structured runtime data: {e}")))?;
                         if let Some(jwt) = structured.get("challenge_token").and_then(|x| x.as_str()) {
-                            verify_challenge_and_extract_nonce_b64url(jwt)
+                            let challenge_key_path =
+                                self.read().await.attestation_service.challenge_key_path();
+                            verify_challenge_and_extract_nonce_b64url(jwt, &challenge_key_path)
                                 .map_err(|e| Status::aborted(format!(
                                     "verify challenge_token failed: {e}")))?;
                         }

--- a/attestation-service/src/bin/restful/mod.rs
+++ b/attestation-service/src/bin/restful/mod.rs
@@ -187,9 +187,11 @@ pub async fn attestation(
             Some(RuntimeData::Structured(v)) => {
                 if let Some(jwt) = v.get("challenge_token").and_then(|x| x.as_str()) {
                     // 验证 token，但不修改 runtime_data 内容
-                    let _ = verify_challenge_and_extract_nonce_b64url(jwt).map_err(|e| {
-                        Error::Unauthorized(anyhow!("verify challenge_token failed: {e}"))
-                    })?;
+                    let challenge_key_path = cocoas.read().await.challenge_key_path();
+                    let _ = verify_challenge_and_extract_nonce_b64url(jwt, &challenge_key_path)
+                        .map_err(|e| {
+                            Error::Unauthorized(anyhow!("verify challenge_token failed: {e}"))
+                        })?;
                 }
                 Some(parse_runtime_data(RuntimeData::Structured(v))?)
             }

--- a/attestation-service/src/challenge.rs
+++ b/attestation-service/src/challenge.rs
@@ -8,22 +8,30 @@ use openssl::rsa::Rsa;
 use openssl::sign::Signer;
 use serde_json::{json, Value};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const RSA_KEY_BITS: u32 = 2048;
 const TOKEN_ALG: &str = "RS384";
-const KEY_DIR: &str = "/etc/trustee/attestation-service/nonce_token_issuer";
-const PRIV_KEY_PEM: &str = "key.pem";
+const DEFAULT_KEY_DIR: &str = "/etc/trustee/attestation-service/nonce_token_issuer";
+const DEFAULT_PRIV_KEY_PEM: &str = "key.pem";
 
-fn ensure_keypair() -> Result<Rsa<Private>> {
-    let dir = Path::new(KEY_DIR);
-    if !dir.exists() {
-        fs::create_dir_all(dir).with_context(|| format!("create dir {} failed", KEY_DIR))?;
+/// Default filesystem path of the RSA private key used to sign/verify
+/// attestation challenge (nonce) tokens. Used when no explicit path is
+/// configured in the Attestation Service config.
+pub fn default_challenge_key_path() -> PathBuf {
+    Path::new(DEFAULT_KEY_DIR).join(DEFAULT_PRIV_KEY_PEM)
+}
+
+fn ensure_keypair(key_path: &Path) -> Result<Rsa<Private>> {
+    if let Some(dir) = key_path.parent() {
+        if !dir.as_os_str().is_empty() && !dir.exists() {
+            fs::create_dir_all(dir)
+                .with_context(|| format!("create dir {} failed", dir.display()))?;
+        }
     }
 
-    let key_path = dir.join(PRIV_KEY_PEM);
     if key_path.exists() {
-        let pem = fs::read(&key_path).context("read private key pem failed")?;
+        let pem = fs::read(key_path).context("read private key pem failed")?;
         let rsa = Rsa::private_key_from_pem(&pem).context("parse private key pem failed")?;
         return Ok(rsa);
     }
@@ -32,7 +40,7 @@ fn ensure_keypair() -> Result<Rsa<Private>> {
     let pem = rsa
         .private_key_to_pem()
         .context("dump private key to pem failed")?;
-    fs::write(&key_path, pem).context("write private key pem failed")?;
+    fs::write(key_path, pem).context("write private key pem failed")?;
     Ok(rsa)
 }
 
@@ -43,7 +51,7 @@ fn rs384_sign(rsa: &Rsa<Private>, payload: &[u8]) -> Result<Vec<u8>> {
     Ok(signer.sign_to_vec()?)
 }
 
-pub fn generate_common_challenge() -> Result<String> {
+pub fn generate_common_challenge(key_path: &Path) -> Result<String> {
     // nonce
     let mut nonce = [0u8; 32];
     rand_bytes(&mut nonce)?;
@@ -73,7 +81,7 @@ pub fn generate_common_challenge() -> Result<String> {
 
     // sign
     let signing_input = format!("{}.{}", header_b64, claims_b64);
-    let rsa = ensure_keypair()?;
+    let rsa = ensure_keypair(key_path)?;
     let signature = rs384_sign(&rsa, signing_input.as_bytes())?;
     let signature_b64 = URL_SAFE_NO_PAD.encode(signature);
     let jwt = format!("{}.{}", signing_input, signature_b64);
@@ -86,7 +94,7 @@ pub fn generate_common_challenge() -> Result<String> {
     Ok(serde_json::to_string(&output)?)
 }
 
-pub fn verify_challenge_and_extract_nonce_b64url(token: &str) -> Result<String> {
+pub fn verify_challenge_and_extract_nonce_b64url(token: &str, key_path: &Path) -> Result<String> {
     let parts: Vec<&str> = token.split('.').collect();
     if parts.len() != 3 {
         bail!("invalid JWT format in challenge_token");
@@ -97,8 +105,7 @@ pub fn verify_challenge_and_extract_nonce_b64url(token: &str) -> Result<String> 
         .decode(parts[2])
         .context("invalid JWT signature encoding")?;
 
-    let pem =
-        fs::read(Path::new(KEY_DIR).join(PRIV_KEY_PEM)).context("read nonce token key failed")?;
+    let pem = fs::read(key_path).context("read nonce token key failed")?;
     let rsa = Rsa::private_key_from_pem(&pem).context("parse nonce token key failed")?;
     let pkey = PKey::from_rsa(rsa).context("load nonce token key failed")?;
 

--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -23,6 +23,13 @@ pub struct Config {
     /// The Attestation Result Token Broker Config
     #[serde(default)]
     pub attestation_token_broker: AttestationTokenConfig,
+
+    /// Optional path to the RSA private key used to sign and verify
+    /// attestation challenge (nonce) tokens. When unset, a built-in default
+    /// path (`/etc/trustee/attestation-service/nonce_token_issuer/key.pem`)
+    /// is used, and the key is generated on first use if it does not exist.
+    #[serde(default)]
+    pub challenge_key_path: Option<PathBuf>,
 }
 
 fn default_work_dir() -> PathBuf {
@@ -48,6 +55,7 @@ impl Default for Config {
             work_dir: default_work_dir(),
             rvps_config: RvpsConfig::default(),
             attestation_token_broker: AttestationTokenConfig::default(),
+            challenge_key_path: None,
         }
     }
 }
@@ -99,7 +107,8 @@ mod tests {
             issuer_name: "test".into(),
             signer: None,
             policy_dir: "/var/lib/attestation-service/policies".into(),
-        })
+        }),
+        challenge_key_path: None,
     })]
     #[case("./tests/configs/example2.json", Config {
         work_dir: PathBuf::from("/var/lib/attestation-service/"),
@@ -115,7 +124,8 @@ mod tests {
                 cert_url: Some("https://example.io".into()),
                 cert_path: Some("/etc/cert.pem".into())
             })
-        })
+        }),
+        challenge_key_path: None,
     })]
     #[case("./tests/configs/example3.json", Config {
         work_dir: PathBuf::from("/var/lib/attestation-service/"),
@@ -130,7 +140,8 @@ mod tests {
             developer_name: "someone".into(),
             build_name: "0.1.0".into(),
             profile_name: "tag:github.com,2024:confidential-containers/Trustee".into()
-        })
+        }),
+        challenge_key_path: None,
     })]
     #[case("./tests/configs/example4.json", Config {
         work_dir: PathBuf::from("/var/lib/attestation-service/"),
@@ -149,7 +160,8 @@ mod tests {
                 cert_url: Some("https://example.io".into()),
                 cert_path: Some("/etc/cert.pem".into())
             })
-        })
+        }),
+        challenge_key_path: None,
     })]
     fn read_config(#[case] config: &str, #[case] expected: Config) {
         let config = std::fs::read_to_string(config).unwrap();

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -373,13 +373,23 @@ impl AttestationService {
             .await
     }
 
+    /// Filesystem path of the RSA private key used to sign and verify
+    /// attestation challenge (nonce) tokens. Falls back to the built-in
+    /// default when not set in the config.
+    pub fn challenge_key_path(&self) -> std::path::PathBuf {
+        self._config
+            .challenge_key_path
+            .clone()
+            .unwrap_or_else(challenge::default_challenge_key_path)
+    }
+
     pub async fn generate_challenge(
         &self,
         tee: Option<Tee>,
         tee_parameters: Option<String>,
     ) -> Result<String> {
         match tee {
-            None => challenge::generate_common_challenge(),
+            None => challenge::generate_common_challenge(&self.challenge_key_path()),
             Some(t) => {
                 self.generate_supplemental_challenge(t, tee_parameters.unwrap_or_default())
                     .await

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -344,6 +344,7 @@ mod tests {
                             signer: None,
                             ..Default::default()
                         }),
+                        challenge_key_path: None,
                     }
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,
@@ -415,6 +416,7 @@ mod tests {
                             duration_min: 5,
                             ..Default::default()
                         }),
+                        challenge_key_path: None,
                     }
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,
@@ -478,6 +480,7 @@ mod tests {
                             policy_dir: "/opt/confidential-containers/attestation-service/simple-policies".into(),
                             ..Default::default()
                         }),
+                        challenge_key_path: None,
                     }
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,


### PR DESCRIPTION
## What

The RSA private key used to sign and verify attestation challenge (nonce) tokens was hard-coded to `/etc/trustee/attestation-service/nonce_token_issuer/key.pem` (constants in `attestation-service/src/challenge.rs`), so a deployment had no way to relocate it — for example onto a mounted secret volume or a shared path.

This adds an optional `challenge_key_path` field to the AS `Config`:

- **Unset (default):** behaves exactly as before — the built-in default path is used, and the key is generated on first use if it does not exist. Existing deployments are unaffected.
- **Set:** the challenge signing/verification key is read from (and, if absent, generated at) the configured path.

## How

- `challenge.rs`: replace the `KEY_DIR` / `PRIV_KEY_PEM` constants with a `default_challenge_key_path()` helper; `generate_common_challenge` and `verify_challenge_and_extract_nonce_b64url` now take the resolved key path as a parameter. `ensure_keypair` creates the parent directory of the given path when needed.
- `config.rs`: add `pub challenge_key_path: Option<PathBuf>` (`#[serde(default)]`), plus `Default` and existing config-parsing tests.
- `lib.rs`: add `AttestationService::challenge_key_path()` which resolves the config value or falls back to the default, and thread it into `generate_challenge`.
- RESTful and gRPC front-ends resolve the path from the running `AttestationService` and pass it to the challenge verification helper.
- Document the new `challenge_key_path` global property in `attestation-service/docs/config.md`.

## Compatibility

Fully backward compatible — no behavior change when the field is omitted.

## Test

- `cargo check -p attestation-service --bins --lib` passes.
- `cargo test -p attestation-service --lib config::tests::read_config` passes (4 cases).