### PR TITLE
kbs: initialize EncryptedDb on the existing runtime

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -82,6 +82,10 @@ jobs:
       working-directory: kbs
       run: make check
 
+    - name: KBS EncryptedDb Test
+      working-directory: kbs
+      run: make check TEST_FEATURES=encrypted-db
+
   as-check:
     if: |
       github.event_name == 'pull_request' || 

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -80,7 +80,8 @@ impl ApiServer {
     }
 
     pub async fn new(config: KbsConfig) -> Result<Self> {
-        let plugin_manager = PluginManager::try_from(config.plugins.clone())
+        let plugin_manager = PluginManager::new(config.plugins.clone())
+            .await
             .map_err(|e| Error::PluginManagerInitialization { source: e })?;
         let token_verifier = TokenVerifier::from_config(config.attestation_token.clone()).await?;
         let policy_engine = PolicyEngine::new(&config.policy_engine).await?;

--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -434,10 +434,8 @@ pub struct ResourceStorage {
     backend: RepositoryInstance,
 }
 
-impl TryFrom<RepositoryConfig> for ResourceStorage {
-    type Error = Error;
-
-    fn try_from(value: RepositoryConfig) -> Result<Self> {
+impl ResourceStorage {
+    pub async fn new(value: RepositoryConfig) -> Result<Self> {
         match value {
             RepositoryConfig::LocalFs(desc) => {
                 let backend = local_fs::LocalFs::new(&desc)
@@ -456,7 +454,8 @@ impl TryFrom<RepositoryConfig> for ResourceStorage {
             }
             #[cfg(feature = "encrypted-db")]
             RepositoryConfig::EncryptedDb(config) => {
-                let backend = super::encrypted_db::EncryptedDb::new(&config)
+                let backend = super::encrypted_db::EncryptedDb::init_async(&config)
+                    .await
                     .context("Failed to initialize encrypted DB Resource Storage")?;
                 Ok(Self {
                     backend: Arc::new(backend),
@@ -477,9 +476,7 @@ impl TryFrom<RepositoryConfig> for ResourceStorage {
             }
         }
     }
-}
 
-impl ResourceStorage {
     pub(crate) async fn set_secret_resource(
         &self,
         resource_desc: ResourceDesc,

--- a/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/mod.rs
@@ -159,18 +159,9 @@ fn parse_purge_after(s: &str) -> Result<Option<Duration>> {
 }
 
 impl EncryptedDb {
-    pub fn new(config: &EncryptedDbBackendConfig) -> Result<Self> {
-        // The plug-in framework calls us synchronously, but everything we
-        // actually do is async. Spin up a small block_on bridge.
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("build tokio runtime for EncryptedDb init")?;
-        runtime.block_on(Self::init_async(config))
-    }
-
-    /// Async constructor used by integration tests. Production code should
-    /// use [`EncryptedDb::new`] which builds a small bridge runtime.
+    /// Initialize the encrypted database backend on the caller's async
+    /// runtime. Keeping the SQLx pool on that runtime also keeps its
+    /// background connection tasks alive for the lifetime of the backend.
     pub async fn init_async(config: &EncryptedDbBackendConfig) -> Result<Self> {
         let pool = DbPool::connect(&config.database).await?;
         migrate_schema(&pool).await?;

--- a/kbs/src/plugins/plugin_manager.rs
+++ b/kbs/src/plugins/plugin_manager.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 use actix_web::http::Method;
-use anyhow::{Context, Error, Result};
+use anyhow::{Context, Result};
 use serde::Deserialize;
 
 use super::{sample, RepositoryConfig, ResourceStorage};
@@ -97,10 +97,8 @@ impl Display for PluginsConfig {
     }
 }
 
-impl TryInto<ClientPluginInstance> for PluginsConfig {
-    type Error = Error;
-
-    fn try_into(self) -> Result<ClientPluginInstance> {
+impl PluginsConfig {
+    async fn into_client_plugin(self) -> Result<ClientPluginInstance> {
         let plugin = match self {
             PluginsConfig::Sample(cfg) => {
                 let sample_plugin =
@@ -108,7 +106,8 @@ impl TryInto<ClientPluginInstance> for PluginsConfig {
                 Arc::new(sample_plugin) as _
             }
             PluginsConfig::ResourceStorage(repository_config) => {
-                let resource_storage = ResourceStorage::try_from(repository_config)
+                let resource_storage = ResourceStorage::new(repository_config)
+                    .await
                     .context("Initialize 'Resource' plugin failed")?;
                 Arc::new(resource_storage) as _
             }
@@ -142,23 +141,17 @@ pub struct PluginManager {
     plugins: HashMap<String, ClientPluginInstance>,
 }
 
-impl TryFrom<Vec<PluginsConfig>> for PluginManager {
-    type Error = Error;
-
-    fn try_from(value: Vec<PluginsConfig>) -> Result<Self> {
-        let plugins = value
-            .into_iter()
-            .map(|cfg| {
-                let name = cfg.to_string();
-                let plugin: ClientPluginInstance = cfg.try_into()?;
-                Ok((name, plugin))
-            })
-            .collect::<Result<HashMap<String, ClientPluginInstance>>>()?;
+impl PluginManager {
+    pub async fn new(configs: Vec<PluginsConfig>) -> Result<Self> {
+        let mut plugins = HashMap::new();
+        for config in configs {
+            let name = config.to_string();
+            let plugin = config.into_client_plugin().await?;
+            plugins.insert(name, plugin);
+        }
         Ok(Self { plugins })
     }
-}
 
-impl PluginManager {
     pub fn get(&self, name: &str) -> Option<ClientPluginInstance> {
         self.plugins.get(name).cloned()
     }

--- a/kbs/tests/encrypted_db_plugin_init.rs
+++ b/kbs/tests/encrypted_db_plugin_init.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression test for initializing EncryptedDb through the production plugin
+//! manager while already running inside the KBS async runtime.
+
+#![cfg(feature = "encrypted-db")]
+
+use std::io::Write;
+
+use kbs::plugins::implementations::resource::encrypted_db::{
+    DatabaseConfig, EncryptedDbBackendConfig,
+};
+use kbs::plugins::{PluginManager, PluginsConfig, RepositoryConfig};
+use tempfile::NamedTempFile;
+
+#[tokio::test]
+async fn initializes_encrypted_db_through_plugin_manager() {
+    let mut secret = NamedTempFile::new().expect("create master secret");
+    secret
+        .write_all(b"plugin-manager-runtime-regression")
+        .expect("write master secret");
+    secret.flush().expect("flush master secret");
+
+    let config = EncryptedDbBackendConfig {
+        master_secret_path: secret.path().to_string_lossy().into_owned(),
+        database: DatabaseConfig {
+            kind: "sqlite".to_string(),
+            path: ":memory:".to_string(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let manager = PluginManager::new(vec![PluginsConfig::ResourceStorage(
+        RepositoryConfig::EncryptedDb(config),
+    )])
+    .await
+    .expect("EncryptedDb must initialize on the existing async runtime");
+
+    assert!(manager.get("resource").is_some());
+}


### PR DESCRIPTION
## What changed

- initialize KBS plugins asynchronously on the existing Actix/Tokio runtime
- initialize `EncryptedDb` with `init_async()` instead of creating and blocking a nested runtime
- add a regression test that constructs the production plugin manager from inside an async runtime
- run the EncryptedDb test configuration in the Rust CI suite

## Root cause

KBS starts under `#[actix_web::main]`, but the EncryptedDb synchronous constructor created another Tokio runtime and called `block_on()`. Tokio rejects that nested runtime entry and panics before the SQL backend can initialize:

```text
Cannot start a runtime from within a runtime
```

The container could remain reported as healthy when a wrapper process kept running, while the KBS listener itself was gone.

## Impact

KBS can now start with the `EncryptedDb` resource backend under its normal Actix runtime. The SQLx pool and its background tasks remain attached to the runtime that owns the KBS process.

## Validation

- reproduced the original exit code 101 and nested-runtime backtrace with Rust 1.76, KBS, and MySQL 8.0
- passed 79 KBS unit tests with `--no-default-features --features encrypted-db`
- passed the real MySQL two-replica EncryptedDb E2E test
- passed the new async plugin-manager regression test
- started the fixed KBS against MySQL and verified `GET /kbs/v0/resource/pubkey` returns HTTP 200
- passed Rust 1.76 EncryptedDb library clippy with warnings denied

Signed-off-by: Jiale Zhang <zhangjiale@linux.alibaba.com>
