### PR TITLE
rpm: record the EncryptedDb runtime fix in 1.8.7-2

### DIFF
--- a/rpm/trustee.spec
+++ b/rpm/trustee.spec
@@ -145,7 +145,9 @@ fi
 /var/lib/attestation/token/ear/policies/opa/default.rego
 
 %changelog
-* Mon Jul 13 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> -1.8.7-2
+* Mon Jul 20 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> -1.8.7-2
+- KBS: initialize EncryptedDb on the existing Actix/Tokio runtime to prevent
+  a nested-runtime panic during service startup
 - Verifier/TDX: split quote verification into pluggable backends and add an
   opt-in pure-Rust dcap-qvl backend (tdx-dcap-rust) that needs no libsgx DCAP
   shared library; the default build keeps the FFI backend


### PR DESCRIPTION
## What changed

- update the top `1.8.7-2` RPM changelog date for the final package build
- record the EncryptedDb nested-runtime startup fix merged in #196

## Version

The spec already defines `Version: 1.8.7` and `%define alinux_release 2`.
This change keeps that intended NVR and completes its changelog for the final
`1.8.7-2` package.

## Validation

- `rpmspec -P rpm/trustee.spec`
- `rpmspec -q` resolves all three binary packages as `1.8.7-2.al8.x86_64`
- `git diff --check`

Signed-off-by: Jiale Zhang <zhangjiale@linux.alibaba.com>
