### PR TITLE
kbs: support legacy InnoDB resource indexes

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -35,6 +35,19 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-24.04
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: trustee_kbs_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping --silent"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
     steps:
     - name: Code checkout
       uses: actions/checkout@v5
@@ -84,7 +97,12 @@ jobs:
 
     - name: KBS EncryptedDb Test
       working-directory: kbs
-      run: make check TEST_FEATURES=encrypted-db
+      env:
+        MYSQL_TEST_URL: mysql://root@127.0.0.1:3306/trustee_kbs_test
+      run: |
+        docker exec ${{ job.services.mysql.id }} \
+          mysql -uroot -e "SET GLOBAL innodb_default_row_format=COMPACT"
+        make check TEST_FEATURES=encrypted-db
 
   as-check:
     if: |

--- a/kbs/src/plugins/implementations/resource/encrypted_db/schema.rs
+++ b/kbs/src/plugins/implementations/resource/encrypted_db/schema.rs
@@ -86,9 +86,9 @@ CREATE TABLE IF NOT EXISTS kbs_managed_keys (
 
 const MYSQL_CREATE_RESOURCES: &str = r#"
 CREATE TABLE IF NOT EXISTS kbs_resources (
-    repository_name  VARCHAR(255)    NOT NULL,
-    resource_type    VARCHAR(255)    NOT NULL,
-    resource_tag     VARCHAR(255)    NOT NULL,
+    repository_name  VARCHAR(255) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    resource_type    VARCHAR(255) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    resource_tag     VARCHAR(255) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
     envelope         MEDIUMTEXT      NOT NULL,
     generation       BIGINT          NOT NULL,
     updated_at       DATETIME(6)     NOT NULL,

--- a/kbs/tests/encrypted_db_mysql_e2e.rs
+++ b/kbs/tests/encrypted_db_mysql_e2e.rs
@@ -55,6 +55,8 @@ use kbs::plugins::implementations::resource::{ResourceDesc, StorageBackend};
 
 const PASSPHRASE: &[u8] = b"e2e-master-secret-pls-change";
 
+type ResourceKeyColumn = (String, Option<String>, Option<String>, Option<i64>);
+
 /// Prepare a fresh schema by dropping the tables EncryptedDb owns. We do
 /// this via a side-channel sqlx connection so the per-test state is
 /// deterministic.
@@ -66,6 +68,36 @@ async fn reset_mysql_schema(dsn: &str) {
         "DROP TABLE IF EXISTS kbs_meta",
     ] {
         sqlx::query(stmt).execute(&pool).await.unwrap();
+    }
+    pool.close().await;
+}
+
+/// The resource path grammar is ASCII-only, so keeping these columns in the
+/// one-byte `ascii` character set preserves their 255-character capacity and
+/// keeps the three-column primary key below InnoDB's legacy 767-byte limit.
+async fn assert_resource_key_schema(dsn: &str) {
+    let pool = sqlx::MySqlPool::connect(dsn).await.expect("connect mysql");
+    let columns: Vec<ResourceKeyColumn> = sqlx::query_as(
+        "SELECT COLUMN_NAME, CHARACTER_SET_NAME, COLLATION_NAME,
+                CHARACTER_MAXIMUM_LENGTH
+         FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE()
+           AND TABLE_NAME = 'kbs_resources'
+           AND COLUMN_NAME IN ('repository_name', 'resource_type', 'resource_tag')
+         ORDER BY ORDINAL_POSITION",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("inspect kbs_resources key schema");
+    assert_eq!(columns.len(), 3);
+    for (name, charset, collation, max_len) in columns {
+        assert_eq!(charset.as_deref(), Some("ascii"), "charset for {name}");
+        assert_eq!(
+            collation.as_deref(),
+            Some("ascii_bin"),
+            "collation for {name}"
+        );
+        assert_eq!(max_len, Some(255), "maximum length for {name}");
     }
     pool.close().await;
 }
@@ -141,6 +173,7 @@ async fn end_to_end_two_replicas() {
     let replica_a = EncryptedDb::init_async(&cfg(&dsn, &secret_path))
         .await
         .expect("replica A init");
+    assert_resource_key_schema(&dsn).await;
     // Replica B: same DSN, same passphrase, same shared state.
     let replica_b = EncryptedDb::init_async(&cfg(&dsn, &secret_path))
         .await
@@ -160,6 +193,19 @@ async fn end_to_end_two_replicas() {
         .await
         .unwrap();
     assert_eq!(plain, b"r1-payload", "B must decrypt what A wrote");
+
+    // Exercise the full declared capacity of every primary-key component.
+    // On an InnoDB COMPACT table these three ASCII columns occupy 765 index
+    // bytes; the old utf8mb4 schema required up to 3060 and failed to create.
+    let max_component = "a".repeat(255);
+    let max_desc = desc(&max_component, &max_component, &max_component);
+    let max_envelope = encrypt_for_pubkey(&p1, b"max-length-resource-key");
+    replica_a
+        .write_secret_resource(max_desc.clone(), &max_envelope)
+        .await
+        .unwrap();
+    let plain = replica_b.read_secret_resource(max_desc).await.unwrap();
+    assert_eq!(plain, b"max-length-resource-key");
 
     // 4. POST /rotate to B.
     let rotate = replica_b.rotate_keys().await.unwrap();

--- a/rpm/trustee.spec
+++ b/rpm/trustee.spec
@@ -145,7 +145,9 @@ fi
 /var/lib/attestation/token/ear/policies/opa/default.rego
 
 %changelog
-* Mon Jul 20 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> -1.8.7-2
+* Tue Jul 21 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> -1.8.7-2
+- KBS: keep EncryptedDb resource keys within the legacy InnoDB 767-byte
+  index limit while preserving their full 255-character capacity
 - KBS: initialize EncryptedDb on the existing Actix/Tokio runtime to prevent
   a nested-runtime panic during service startup
 - Verifier/TDX: split quote verification into pluggable backends and add an


### PR DESCRIPTION
## Summary

- store the three EncryptedDb resource-key columns with the one-byte `ascii_bin` collation
- preserve the full 255-character capacity while keeping the composite primary key at 765 bytes
- exercise the maximum-length key in the real MySQL two-replica end-to-end test
- run the EncryptedDb CI suite against a MySQL `COMPACT` table configuration
- record the compatibility fix in the Trustee 1.8.7-2 RPM changelog

## Root cause

`kbs_resources` used three `VARCHAR(255)` columns under `utf8mb4` as its composite primary key. That key can require 3060 bytes, so KBS failed to initialize on InnoDB configurations with the legacy 767-byte key limit.

Resource descriptors already accept only ASCII letters, digits, `_`, `-`, and `.`, so an explicit `ascii_bin` collation retains the existing input contract and case-sensitive identity while reducing the maximum key size to 765 bytes.

## Validation

- reproduced the pre-fix failure with MySQL 8.0 and `innodb_default_row_format=COMPACT`
- `make -C kbs check TEST_FEATURES=encrypted-db` with the COMPACT MySQL test database
  - 79 KBS unit tests passed
  - EncryptedDb MySQL two-replica E2E passed
  - PluginManager initialization regression passed
  - doc tests passed
- targeted Rust 1.76 Clippy passed with only pre-existing test allowances
- Rustfmt, Actionlint, `rpmspec -P`, and `git diff --check` passed
