### PR TITLE
fix(gateway): expose resource key lifecycle APIs

### DIFF
--- a/.github/workflows/gateway-check.yml
+++ b/.github/workflows/gateway-check.yml
@@ -1,0 +1,33 @@
+name: Trustee Gateway Check
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'trustee-gateway/**'
+      - '.github/workflows/gateway-check.yml'
+  pull_request:
+    paths:
+      - 'trustee-gateway/**'
+      - '.github/workflows/gateway-check.yml'
+
+jobs:
+  gateway-check:
+    name: Go Test and Vet
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: trustee-gateway
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: trustee-gateway/go.mod
+          cache-dependency-path: trustee-gateway/go.sum
+      - name: Gateway test
+        run: go test ./...
+      - name: Gateway vet
+        run: go vet ./...

--- a/rpm/trustee.spec
+++ b/rpm/trustee.spec
@@ -1,4 +1,4 @@
-%define alinux_release 2
+%define alinux_release 3
 %global config_dir /etc/trustee
 %global debug_package %{nil}
 %global __brp_mangle_shebangs %{nil}
@@ -145,6 +145,11 @@ fi
 /var/lib/attestation/token/ear/policies/opa/default.rego
 
 %changelog
+* Tue Jul 21 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> -1.8.7-3
+- Gateway: expose the resource public-key, key reload, rewrap, and rotation
+  APIs required by EncryptedDb and EncryptedLocalFs deployments
+- Gateway: add end-to-end route coverage for the complete KBS resource API
+
 * Tue Jul 21 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> -1.8.7-2
 - KBS: keep EncryptedDb resource keys within the legacy InnoDB 767-byte
   index limit while preserving their full 255-character capacity

--- a/trustee-gateway/README.md
+++ b/trustee-gateway/README.md
@@ -68,6 +68,11 @@ Gateway 提供以下主要 API 端点：
 - `/api/kbs/v0/attestation-policy` - 证明策略管理
 - `/api/kbs/v0/resource-policy` - 资源策略管理
 - `/api/kbs/v0/resource/:repository/:type/:tag` - 资源管理
+- `/api/kbs/v0/resources` - 资源列表
+- `/api/kbs/v0/resource/pubkey` - 获取客户端加密公钥
+- `/api/kbs/v0/resource/reload` - 热加载托管密钥
+- `/api/kbs/v0/resource/rewrap` - 使用当前主密钥重包资源
+- `/api/kbs/v0/resource/rotate` - 一次性轮转托管密钥并重包资源
 
 ### RVPS 相关 API
 
@@ -131,4 +136,4 @@ docker logs trustee-gateway
 
 ## 许可证
 
-与 Trustee 项目其他组件一致，遵循 Apache 2.0 许可证。 
+与 Trustee 项目其他组件一致，遵循 Apache 2.0 许可证。

--- a/trustee-gateway/cmd/server/main.go
+++ b/trustee-gateway/cmd/server/main.go
@@ -149,29 +149,7 @@ func main() {
 }
 
 func setupRoutes(router *gin.Engine, kbsHandler *handlers.KBSHandler, rvpsHandler *handlers.RVPSHandler, attestationServiceHandler *handlers.AttestationServiceHandler, auditHandler *handlers.AuditHandler, healthCheckHandler *handlers.HealthCheckHandler, p *proxy.Proxy, aaInstanceHandler *handlers.AAInstanceHandler, credentialHandler *handlers.CredentialHandler) {
-	// KBS API routes
-	kbs := router.Group("/api/kbs/v0")
-	{
-		// Attestation routes
-		kbs.POST("/auth", kbsHandler.HandleAuth)
-		kbs.POST("/attest", kbsHandler.HandleAttest)
-
-		// Policy routes
-		kbs.POST("/attestation-policy", kbsHandler.HandleSetAttestationPolicy)
-		kbs.GET("/attestation-policy/:id", kbsHandler.GetAttestationPolicy)
-		kbs.GET("/attestation-policies", kbsHandler.ListAttestationPolicies)
-		kbs.DELETE("/attestation-policy/:id", kbsHandler.DeleteAttestationPolicy)
-
-		kbs.POST("/resource-policy", kbsHandler.HandleSetResourcePolicy)
-		kbs.GET("/resource-policy", kbsHandler.GetResourcePolicy)
-
-		// Resource routes with explicit repository
-		kbs.GET("/resource/:repository/:type/:tag", kbsHandler.HandleGetResource)
-		kbs.POST("/resource/:repository/:type/:tag", kbsHandler.HandleSetResource)
-		kbs.DELETE("/resource/:repository/:type/:tag", kbsHandler.HandleDeleteResource)
-
-		kbs.GET("/resources", kbsHandler.ListResources)
-	}
+	setupKBSRoutes(router, kbsHandler)
 
 	// Attestation Service API routes
 	attestationSvc := router.Group("/api/attestation-service")
@@ -230,5 +208,38 @@ func setupRoutes(router *gin.Engine, kbsHandler *handlers.KBSHandler, rvpsHandle
 	{
 		aa.POST("/heartbeat", aaInstanceHandler.HandleHeartbeat)
 		aa.GET("/list", aaInstanceHandler.HandleGetActiveAAInstances)
+	}
+}
+
+func setupKBSRoutes(router *gin.Engine, kbsHandler *handlers.KBSHandler) {
+	// KBS API routes
+	kbs := router.Group("/api/kbs/v0")
+	{
+		// Attestation routes
+		kbs.POST("/auth", kbsHandler.HandleAuth)
+		kbs.POST("/attest", kbsHandler.HandleAttest)
+
+		// Policy routes
+		kbs.POST("/attestation-policy", kbsHandler.HandleSetAttestationPolicy)
+		kbs.GET("/attestation-policy/:id", kbsHandler.GetAttestationPolicy)
+		kbs.GET("/attestation-policies", kbsHandler.ListAttestationPolicies)
+		kbs.DELETE("/attestation-policy/:id", kbsHandler.DeleteAttestationPolicy)
+
+		kbs.POST("/resource-policy", kbsHandler.HandleSetResourcePolicy)
+		kbs.GET("/resource-policy", kbsHandler.GetResourcePolicy)
+
+		// Resource routes with explicit repository
+		kbs.GET("/resource/:repository/:type/:tag", kbsHandler.HandleGetResource)
+		kbs.POST("/resource/:repository/:type/:tag", kbsHandler.HandleSetResource)
+		kbs.DELETE("/resource/:repository/:type/:tag", kbsHandler.HandleDeleteResource)
+
+		// Resource storage maintenance routes. EncryptedLocalFs and EncryptedDb
+		// use these APIs for client-side encryption and managed-key lifecycle.
+		kbs.GET("/resource/pubkey", kbsHandler.HandleResourceAdminRequest)
+		kbs.POST("/resource/reload", kbsHandler.HandleResourceAdminRequest)
+		kbs.POST("/resource/rewrap", kbsHandler.HandleResourceAdminRequest)
+		kbs.POST("/resource/rotate", kbsHandler.HandleResourceAdminRequest)
+
+		kbs.GET("/resources", kbsHandler.ListResources)
 	}
 }

--- a/trustee-gateway/cmd/server/main_test.go
+++ b/trustee-gateway/cmd/server/main_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openanolis/trustee/gateway/internal/config"
+	"github.com/openanolis/trustee/gateway/internal/handlers"
+	"github.com/openanolis/trustee/gateway/internal/models"
+	"github.com/openanolis/trustee/gateway/internal/persistence/repository"
+	"github.com/openanolis/trustee/gateway/internal/persistence/storage"
+	"github.com/openanolis/trustee/gateway/internal/proxy"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type forwardedRequest struct {
+	method        string
+	path          string
+	body          string
+	authorization string
+	cookie        string
+}
+
+func TestKBSResourceRoutesForwardCompleteAPI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	forwarded := make(chan forwardedRequest, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read upstream request body: %v", err)
+			return
+		}
+		forwarded <- forwardedRequest{
+			method:        r.Method,
+			path:          r.URL.Path,
+			body:          string(body),
+			authorization: r.Header.Get("Authorization"),
+			cookie:        r.Header.Get("Cookie"),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Upstream-Coverage", "complete")
+		http.SetCookie(w, &http.Cookie{Name: "kbs-session-id", Value: "returned-session"})
+		if r.URL.Path == "/kbs/v0/resources" {
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"forwarded":%q}`, r.Method+" "+r.URL.Path)
+	}))
+	defer upstream.Close()
+
+	p, err := proxy.NewProxy(&config.Config{
+		KBS:                config.ServiceConfig{URL: upstream.URL},
+		AttestationService: config.ServiceConfig{URL: upstream.URL},
+	})
+	require.NoError(t, err)
+
+	db, err := gorm.Open(sqlite.Open("file:kbs_resource_routes?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AttestationRecord{}, &models.ResourceRequest{}))
+	auditRepo := repository.NewAuditRepository(&storage.Database{DB: db})
+
+	router := gin.New()
+	setupKBSRoutes(router, handlers.NewKBSHandler(p, auditRepo))
+
+	tests := []struct {
+		name          string
+		method        string
+		gatewayPath   string
+		upstreamPath  string
+		body          string
+		copiesCookies bool
+	}{
+		{name: "public key", method: http.MethodGet, gatewayPath: "/api/kbs/v0/resource/pubkey", upstreamPath: "/kbs/v0/resource/pubkey", copiesCookies: true},
+		{name: "reload keys", method: http.MethodPost, gatewayPath: "/api/kbs/v0/resource/reload", upstreamPath: "/kbs/v0/resource/reload", body: `{}`, copiesCookies: true},
+		{name: "rewrap resources", method: http.MethodPost, gatewayPath: "/api/kbs/v0/resource/rewrap", upstreamPath: "/kbs/v0/resource/rewrap", body: `{}`, copiesCookies: true},
+		{name: "rotate keys", method: http.MethodPost, gatewayPath: "/api/kbs/v0/resource/rotate", upstreamPath: "/kbs/v0/resource/rotate", body: `{}`, copiesCookies: true},
+		{name: "get resource", method: http.MethodGet, gatewayPath: "/api/kbs/v0/resource/repo/secret/tag", upstreamPath: "/kbs/v0/resource/repo/secret/tag", copiesCookies: true},
+		{name: "set resource", method: http.MethodPost, gatewayPath: "/api/kbs/v0/resource/repo/secret/tag", upstreamPath: "/kbs/v0/resource/repo/secret/tag", body: `encrypted-envelope`},
+		{name: "delete resource", method: http.MethodDelete, gatewayPath: "/api/kbs/v0/resource/repo/secret/tag", upstreamPath: "/kbs/v0/resource/repo/secret/tag"},
+		{name: "list resources", method: http.MethodGet, gatewayPath: "/api/kbs/v0/resources", upstreamPath: "/kbs/v0/resources"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.gatewayPath, bytes.NewBufferString(tc.body))
+			req.Header.Set("Authorization", "Bearer admin-token")
+			req.AddCookie(&http.Cookie{Name: "kbs-session-id", Value: "request-session"})
+			recorder := httptest.NewRecorder()
+
+			router.ServeHTTP(recorder, req)
+			require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+			require.Equal(t, "complete", recorder.Header().Get("X-Upstream-Coverage"))
+
+			select {
+			case got := <-forwarded:
+				require.Equal(t, tc.method, got.method)
+				require.Equal(t, tc.upstreamPath, got.path)
+				require.Equal(t, tc.body, got.body)
+				require.Equal(t, "Bearer admin-token", got.authorization)
+				require.Equal(t, "kbs-session-id=request-session", got.cookie)
+			case <-time.After(time.Second):
+				t.Fatal("request was not forwarded to KBS")
+			}
+
+			if tc.copiesCookies {
+				cookies := recorder.Result().Cookies()
+				require.Len(t, cookies, 1)
+				require.Equal(t, "kbs-session-id", cookies[0].Name)
+				require.Equal(t, "returned-session", cookies[0].Value)
+			}
+		})
+	}
+}

--- a/trustee-gateway/internal/handlers/kbs_handlers.go
+++ b/trustee-gateway/internal/handlers/kbs_handlers.go
@@ -199,6 +199,31 @@ func extractClaims(tokenString string) (string, error) {
 	return claims, nil
 }
 
+// HandleResourceAdminRequest proxies resource-storage maintenance endpoints to
+// KBS. These endpoints are admin authenticated by KBS and intentionally use a
+// dedicated handler so they cannot be confused with attested resource reads.
+func (h *KBSHandler) HandleResourceAdminRequest(c *gin.Context) {
+	resp, err := h.proxy.ForwardToKBS(c)
+	if err != nil {
+		logrus.Errorf("Failed to forward resource admin request to KBS: %v", err)
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to forward request to KBS"})
+		return
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logrus.Errorf("Failed to read KBS resource admin response: %v", err)
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to read KBS response"})
+		return
+	}
+
+	proxy.CopyHeaders(c, resp)
+	proxy.CopyCookies(c, resp)
+	c.Status(resp.StatusCode)
+	_, _ = c.Writer.Write(responseBody)
+}
+
 // HandleSetAttestationPolicy handles setting an attestation policy
 func (h *KBSHandler) HandleSetAttestationPolicy(c *gin.Context) {
 	// Read the request body
@@ -589,7 +614,7 @@ func (h *KBSHandler) DeleteAttestationPolicy(c *gin.Context) {
 		return
 	}
 	defer resp.Body.Close()
-	
+
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logrus.Errorf("Failed to read KBS delete attestation policy response: %v", err)

--- a/trustee-gateway/internal/persistence/repository/audit_repository_test.go
+++ b/trustee-gateway/internal/persistence/repository/audit_repository_test.go
@@ -48,12 +48,13 @@ func TestListAttestationRecords(t *testing.T) {
 	baseTime := time.Now()
 	records := []*models.AttestationRecord{
 		{
-			ClientIP:    "192.168.1.1",
-			SessionID:   "session1",
-			RequestBody: "request1",
-			Status:      200,
-			Successful:  true,
-			Timestamp:   baseTime,
+			ClientIP:      "192.168.1.1",
+			SessionID:     "session1",
+			RequestBody:   "request1",
+			SourceService: "auth",
+			Status:        200,
+			Successful:    true,
+			Timestamp:     baseTime,
 		},
 		{
 			ClientIP:    "192.168.1.2",
@@ -64,12 +65,13 @@ func TestListAttestationRecords(t *testing.T) {
 			Timestamp:   baseTime.Add(time.Hour),
 		},
 		{
-			ClientIP:    "192.168.1.3",
-			SessionID:   "session3",
-			RequestBody: "request3",
-			Status:      200,
-			Successful:  true,
-			Timestamp:   baseTime.Add(2 * time.Hour),
+			ClientIP:      "192.168.1.3",
+			SessionID:     "session3",
+			RequestBody:   "request3",
+			SourceService: "auth",
+			Status:        200,
+			Successful:    true,
+			Timestamp:     baseTime.Add(2 * time.Hour),
 		},
 	}
 

--- a/trustee-gateway/trustee_gateway_api.md
+++ b/trustee-gateway/trustee_gateway_api.md
@@ -15,6 +15,10 @@
 - [1.10 设置资源 (Set Resource)](#110-设置资源-set-resource)
 - [1.11 列出资源 (List Resources)](#111-列出资源-list-resources)
 - [1.12 删除资源 (Delete Resource)](#112-删除资源-delete-resource)
+- [1.13 获取资源加密公钥 (Get Resource Public Key)](#113-获取资源加密公钥-get-resource-public-key)
+- [1.14 热加载托管密钥 (Reload Managed Keys)](#114-热加载托管密钥-reload-managed-keys)
+- [1.15 重包资源 (Rewrap Resources)](#115-重包资源-rewrap-resources)
+- [1.16 轮转托管密钥 (Rotate Managed Keys)](#116-轮转托管密钥-rotate-managed-keys)
 
 ### [2. AS API (`/api/attestation-service`)](#as-api-apiattestation-service)
 - [2.1 证明 (Attestation)](#21-证明-attestation-1)
@@ -706,6 +710,60 @@ curl -k -X DELETE http://<gateway-host>:<port>/api/kbs/v0/resource/my-repo/my-ty
 *   **返回示例 (成功 - KBS 返回空内容):**_状态码: 200 OK 或 204 No Content_
 
 ### ![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/2M9qP57A13dzpO01/img/7066c995-d1a1-4d28-b709-013982722a26.png)
+
+#### 1.13 获取资源加密公钥 (Get Resource Public Key)
+
+*   **端点:** `GET /api/kbs/v0/resource/pubkey`
+
+*   **说明:** 获取 `EncryptedDb` 或 `EncryptedLocalFs` 当前主密钥对应的 PEM 公钥。客户端必须先用该公钥加密资源信封，再调用设置资源 API 上传密文。Gateway 将 KBS 的状态码、响应头、Cookie 和响应体原样转发。
+
+```shell
+curl -k http://<gateway-host>:<port>/api/kbs/v0/resource/pubkey \
+     -H "Authorization: Bearer <admin-token>"
+```
+
+*   **成功响应:** `200 OK`，响应体为 `-----BEGIN PUBLIC KEY-----` 开头的 PEM 公钥。
+
+#### 1.14 热加载托管密钥 (Reload Managed Keys)
+
+*   **端点:** `POST /api/kbs/v0/resource/reload`
+
+*   **说明:** 从共享存储重新加载托管密钥，不重启 KBS。适用于离线迁移或需要立即绕过多副本轮询间隔的场景。
+
+```shell
+curl -k -X POST http://<gateway-host>:<port>/api/kbs/v0/resource/reload \
+     -H "Authorization: Bearer <admin-token>"
+```
+
+*   **成功响应:** `200 OK`，例如 `{"reloaded_keys":2}`。
+
+#### 1.15 重包资源 (Rewrap Resources)
+
+*   **端点:** `POST /api/kbs/v0/resource/rewrap`
+
+*   **说明:** 不生成新密钥，将尚未使用当前主密钥的资源重新包装到当前主密钥。该操作由 KBS 执行，Gateway 原样转发报告。
+
+```shell
+curl -k -X POST http://<gateway-host>:<port>/api/kbs/v0/resource/rewrap \
+     -H "Authorization: Bearer <admin-token>"
+```
+
+*   **成功响应:** `200 OK`，响应包含 `total`、`rewrapped`、`skipped` 和 `failed` 计数。
+
+#### 1.16 轮转托管密钥 (Rotate Managed Keys)
+
+*   **端点:** `POST /api/kbs/v0/resource/rotate`
+
+*   **说明:** 生成新的主密钥、重包已有资源、退役旧密钥，并返回新公钥及轮转报告。`EncryptedDb` 会在共享数据库中串行化多副本轮转；客户端应在成功后刷新 `pubkey`。
+
+```shell
+curl -k -X POST http://<gateway-host>:<port>/api/kbs/v0/resource/rotate \
+     -H "Authorization: Bearer <admin-token>"
+```
+
+*   **成功响应:** `200 OK`，响应包含 `public_key`、`rewrapped`、`skipped`、`failed`、`retired_keys`；`EncryptedDb` 还包含 `purged_keys`。
+
+以上四个维护接口均由 KBS 执行管理员认证。若 Gateway 无法转发请求或读取响应，则返回 `500 Internal Server Error`；其他状态码和错误体由 KBS 决定。
 
 ---
 


### PR DESCRIPTION
## Summary

- expose /api/kbs/v0/resource/pubkey, /reload, /rewrap, and /rotate through Trustee Gateway
- add table-driven forwarding coverage for the complete KBS resource API (maintenance, CRUD, and list)
- add dedicated Gateway Go test/vet CI and fix the pre-existing audit test fixture exposed by it
- document the Gateway resource key lifecycle APIs
- bump the RPM release to 1.8.7-3

## Root cause

KBS already implemented the EncryptedDb/EncryptedLocalFs maintenance endpoints, but Trustee Gateway only registered resource CRUD and list routes. Requests such as /api/kbs/v0/resource/pubkey therefore stopped at Gin with a 404 and never reached KBS.

## Validation

- go test -count=1 ./...
- go test -race -count=1 ./...
- go vet ./...
- actionlint .github/workflows/gateway-check.yml
- real MySQL 8.0 EncryptedDb two-replica integration test
- real KBS + Trustee Gateway HTTP lifecycle: fetch public key, encrypted upload, attested-token/JWE read and decrypt, rewrap, rotate, verify old resource after rotation, upload/read with the new key, reload, delete, and list cleanup