### PR TITLE
build(deps): drop libgit2-sys by disabling shadow-rs default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,9 +1308,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_fn"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
+checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "const_format"
@@ -6204,7 +6204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c401e795850edb4e9fdde5940f856364f0fbab573e8dea58f6ee5f85fcf471d"
 dependencies = [
  "const_format",
- "git2",
  "is_debug",
  "time",
  "tzdb 0.5.10",
@@ -7323,9 +7322,9 @@ dependencies = [
 
 [[package]]
 name = "tzdb_data"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4471adcfcbd3052e8c5b5890a04a559837444b3be26b9cbbd622063171cec9d"
+checksum = "e866b98f6ed570c3ef7bc92f15021a9f9be377b7e6f8b1f0161179fdf84a442c"
 dependencies = [
  "tz-rs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ serde_qs = "0.13.0"
 serde_with = { version = "1.11.0", features = ["base64", "hex"] }
 serial_test = "0.9.0"
 sha2 = "0.10"
-shadow-rs = "0.19.0"
+shadow-rs = { version = "0.19.0", default-features = false, features = ["tzdb"] }
 const_format = "0.2"
 sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio-rustls", "mysql", "sqlite", "any", "json", "chrono"] }
 strum = { version = "0.25", features = ["derive"] }

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -82,7 +82,7 @@ serde_json.workspace = true
 serde_variant = "0.1.2"
 sha2.workspace = true
 sm3 = "0.4.2"
-shadow-rs = { workspace = true, default-features = false }
+shadow-rs.workspace = true
 strum.workspace = true
 tempfile.workspace = true
 time = { version = "0.3.23", features = ["std"] }


### PR DESCRIPTION
Disable shadow-rs default features (which pull in git2/libgit2-sys) and keep only tzdb. This trims the dependency tree/binary size and improves cross-platform (incl. wasm) build support.

fix https://github.com/inclavare-containers/TNG/actions/runs/29817017793/job/88590627418?pr=172