### PR TITLE
attestation-service: make HTTP keep-alive configurable

### DIFF
--- a/attestation-service/docs/restful-as.md
+++ b/attestation-service/docs/restful-as.md
@@ -96,6 +96,11 @@ Start Attestation Service and specify the listen port of its web service:
 restful-as --socket 127.0.0.1:8080
 ```
 
+The HTTP/1.1 keep-alive timeout defaults to 120 seconds. It should be longer
+than the idle connection timeout of clients or local gateways so that clients
+close pooled connections first. Configure it with
+`--http-keep-alive-secs <SECONDS>`; set it to `0` to disable HTTP keep-alive.
+
 If you want to see the runtime log, run:
 ```shell
 RUST_LOG=debug restful-as --socket 127.0.0.1:8080 -c config.json

--- a/attestation-service/src/bin/restful-as.rs
+++ b/attestation-service/src/bin/restful-as.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::Path, sync::Arc};
+use std::{net::SocketAddr, path::Path, sync::Arc, time::Duration};
 
 use actix_cors::Cors;
 use actix_web::{http::header, web, App, HttpServer};
@@ -48,6 +48,12 @@ pub struct Cli {
     /// (the default), no CORS origins are allowed.
     #[arg(short = 'r', long = "allowed_origin", value_delimiter = ',', num_args = 1..)]
     pub allowed_origin: Vec<String>,
+
+    /// HTTP/1.1 keep-alive timeout in seconds. Set to 0 to disable keep-alive.
+    /// Keep this longer than the client's idle connection timeout to avoid
+    /// clients reusing connections while the server is closing them.
+    #[arg(long, default_value_t = 120)]
+    pub http_keep_alive_secs: u64,
 }
 
 #[derive(EnumString, AsRefStr)]
@@ -130,6 +136,12 @@ async fn main() -> Result<(), RestfulError> {
 
     let cli = Cli::parse();
 
+    let http_keep_alive = Duration::from_secs(cli.http_keep_alive_secs);
+    info!(
+        "HTTP keep-alive timeout: {} seconds",
+        cli.http_keep_alive_secs
+    );
+
     let config = match cli.config_file {
         Some(path) => {
             info!("Using config file {path}");
@@ -170,7 +182,8 @@ async fn main() -> Result<(), RestfulError> {
                     .route(web::get().to(get_openid_configuration)),
             )
             .app_data(web::Data::clone(&attestation_service))
-    });
+    })
+    .keep_alive(http_keep_alive);
 
     let server = match (cli.https_prikey, cli.https_pubkey_cert) {
         (Some(prikey), Some(pubkey_cert)) => {
@@ -201,4 +214,39 @@ async fn main() -> Result<(), RestfulError> {
 
     server.await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_keep_alive_defaults_to_120_seconds() {
+        let cli = Cli::try_parse_from(["restful-as", "--socket", "127.0.0.1:8080"])
+            .expect("parse default CLI options");
+        assert_eq!(cli.http_keep_alive_secs, 120);
+    }
+
+    #[test]
+    fn http_keep_alive_can_be_configured_or_disabled() {
+        let cli = Cli::try_parse_from([
+            "restful-as",
+            "--socket",
+            "127.0.0.1:8080",
+            "--http-keep-alive-secs",
+            "30",
+        ])
+        .expect("parse configured keep-alive");
+        assert_eq!(cli.http_keep_alive_secs, 30);
+
+        let cli = Cli::try_parse_from([
+            "restful-as",
+            "--socket",
+            "127.0.0.1:8080",
+            "--http-keep-alive-secs",
+            "0",
+        ])
+        .expect("parse disabled keep-alive");
+        assert_eq!(cli.http_keep_alive_secs, 0);
+    }
 }


### PR DESCRIPTION
## Summary

- add `--http-keep-alive-secs` to `restful-as`
- default the HTTP/1.1 keep-alive timeout to 120 seconds
- allow setting the timeout to `0` to disable keep-alive
- document the option and cover its default, custom, and disabled values

## Root cause

`restful-as` did not configure `HttpServer::keep_alive`, so it inherited
Actix HTTP's 5-second default. A pooled client can race with the server while
reusing a connection that is being closed, causing an occasional POST
`/attestation` EOF or connection reset even though the AS process remains
healthy.

The 120-second default is longer than Go's default 90-second idle connection
timeout, allowing the client to retire pooled connections first. Deployments
with different client timeouts can tune the value explicitly.

## Validation

- `cargo build --release -p attestation-service --bin restful-as --no-default-features --features restful-bin,all-verifier-rust`
- `cargo test --release -p attestation-service --bin restful-as --no-default-features --features restful-bin,all-verifier-rust` (2 passed)
- `cargo clippy --release --no-deps -p attestation-service --bin restful-as --no-default-features --features restful-bin,all-verifier-rust -- -D warnings`
- real TDX evidence end-to-end verification returned HTTP 200
- two-core, concurrency-60 sustained test: 200,000/200,000 successful after the change
- keep-alive boundary test before the change: 62 failures in 2,400 requests, including 47 EOFs and 63 TCP RSTs
- identical boundary test after the change: 2,400/2,400 successful, 0 EOFs, 0 TCP RSTs
- no throughput or latency regression was observed
