### PR TITLE
build: make attestation-service / rvps libraries compile without the fs feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7474,7 +7474,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd8dcafa1ca14750d8d7a05aa05988c17aab20886e1f3ae33a40223c58d92ef7"
 dependencies = [
  "getrandom 0.3.1",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ const_format = "0.2"
 sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio-rustls", "mysql", "sqlite", "any", "json", "chrono"] }
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "2.0"
-tokio = { version = "1", default-features = false, features = ["full"] }
+tokio = { version = "1", default-features = false }
 toml = "0.8.23"
 tempfile = "3.4.0"
 tonic = "0.12"

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -90,7 +90,6 @@ thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tonic = { workspace = true, optional = true }
-uuid = { version = "1.1.2", features = ["v4"] }
 verifier = { path = "../deps/verifier", default-features = false }
 const_format.workspace = true
 # x509-cert is used by `token/simple.rs` for PEM/DER certificate-chain parsing
@@ -98,6 +97,10 @@ const_format.workspace = true
 # `Certificate::from_pem` / `to_der`. The `pem` feature enables
 # `der::DecodePem` (used by `from_pem`); `std` is part of the default set.
 x509-cert = { version = "0.2.5", default-features = false, features = ["pem", "std"] }
+[target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies]
+uuid = { version = "1.1.2", features = ["v4"] }
+[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies]
+uuid = { version = "1.1.2", features = ["v4", "js"] }
 
 [build-dependencies]
 shadow-rs.workspace = true

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -26,7 +26,7 @@ se-verifier  = [ "verifier/se-verifier" ]
 system-verifier = [ "verifier/system-verifier" ]
 tpm-verifier = [ "verifier/tpm-verifier" ]
 
-rvps-grpc = [ "prost", "tonic" ]
+rvps-grpc = [ "prost", "tonic", "tokio/sync" ]
 
 # For building gRPC CoCo-AS binary
 grpc-bin = [ "clap", "env_logger", "prost", "tonic", "tokio/full" ]
@@ -91,7 +91,7 @@ strum.workspace = true
 tempfile.workspace = true
 time = { version = "0.3.23", features = ["std"] }
 thiserror.workspace = true
-tokio = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["fs"] }
 toml.workspace = true
 tonic = { workspace = true, optional = true }
 verifier = { path = "../deps/verifier", default-features = false }

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -29,10 +29,13 @@ tpm-verifier = [ "verifier/tpm-verifier" ]
 rvps-grpc = [ "prost", "tonic" ]
 
 # For building gRPC CoCo-AS binary
-grpc-bin = [ "clap", "env_logger", "prost", "tonic" ]
+grpc-bin = [ "clap", "env_logger", "prost", "tonic", "tokio/full" ]
 
 # For restful CoCo-AS binary
-restful-bin = [ "actix-cors", "actix-web/openssl", "clap", "env_logger", "openssl" ]
+restful-bin = [ "actix-cors", "actix-web/openssl", "clap", "env_logger", "openssl", "tokio/full" ]
+
+# For attestation-challenge-client binary
+attestation-challenge-client = [ "tokio/full" ]
 
 [[bin]]
 name = "grpc-as"
@@ -45,6 +48,7 @@ required-features = [ "restful-bin" ]
 [[bin]]
 name = "attestation-challenge-client"
 path = "src/bin/attestation-challenge-client/main.rs"
+required-features = [ "attestation-challenge-client" ]
 
 [dependencies]
 # Pinned to 0.7.0: actix-cors 0.7.1 pulls in derive_more 2.x which requires
@@ -75,7 +79,7 @@ prost = { workspace = true, optional = true }
 rand = "0.8.5"
 reqwest.workspace = true
 rsa = { version = "0.9.2", features = ["sha2"] }
-reference-value-provider-service.path = "../rvps"
+reference-value-provider-service = { path = "../rvps", default-features = false }
 regorus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -87,7 +91,7 @@ strum.workspace = true
 tempfile.workspace = true
 time = { version = "0.3.23", features = ["std"] }
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, optional = true }
 toml.workspace = true
 tonic = { workspace = true, optional = true }
 verifier = { path = "../deps/verifier", default-features = false }
@@ -113,3 +117,4 @@ rstest.workspace = true
 serial_test.workspace = true
 sha2.workspace = true
 testing_logger = "0.1.1"
+tokio = { workspace = true, features = ["full"] }

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = [ "restful-bin", "rvps-grpc", "all-verifier" ]
+default = [ "restful-bin", "rvps-grpc", "all-verifier", "fs" ]
+
+# Filesystem-backed implementations: config-from-file, on-disk OPA policy engine,
+# rvps local_json/local_fs storage, nonce-key persistence, signer transparency
+# file, signer key/cert read by path. Turn off (`default-features = false`) for a
+# pure, fs-free library (e.g. wasm builds).
+fs = [ "tokio/fs" ]
 all-verifier = [ "verifier/all-verifier" ]
 # Like `all-verifier`, but the TDX verifier uses the dcap-qvl backend and SGX is
 # dropped (it would still link the DCAP shared library). See
@@ -29,13 +35,13 @@ tpm-verifier = [ "verifier/tpm-verifier" ]
 rvps-grpc = [ "prost", "tonic", "tokio/sync" ]
 
 # For building gRPC CoCo-AS binary
-grpc-bin = [ "clap", "env_logger", "prost", "tonic", "tokio/full" ]
+grpc-bin = [ "clap", "env_logger", "prost", "tonic", "tokio/full", "fs" ]
 
 # For restful CoCo-AS binary
-restful-bin = [ "actix-cors", "actix-web/openssl", "clap", "env_logger", "openssl", "tokio/full" ]
+restful-bin = [ "actix-cors", "actix-web/openssl", "clap", "env_logger", "openssl", "tokio/full", "fs" ]
 
 # For attestation-challenge-client binary
-attestation-challenge-client = [ "tokio/full" ]
+attestation-challenge-client = [ "tokio/full", "fs" ]
 
 [[bin]]
 name = "grpc-as"
@@ -91,7 +97,7 @@ strum.workspace = true
 tempfile.workspace = true
 time = { version = "0.3.23", features = ["std"] }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["sync"] }
 toml.workspace = true
 tonic = { workspace = true, optional = true }
 verifier = { path = "../deps/verifier", default-features = false }

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -30,9 +30,11 @@ pub use serde_json::Value;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use sm3::Sm3;
 use std::collections::HashMap;
+#[cfg(feature = "fs")]
 use std::io::Read;
 use strum::{AsRefStr, Display, EnumString};
 use thiserror::Error;
+#[cfg(feature = "fs")]
 use tokio::fs;
 use verifier::{InitDataHash, ReportData, TeeEvidenceParsedClaim};
 
@@ -196,6 +198,7 @@ struct Jwk {
 
 impl AttestationService {
     /// Create a new Attestation Service instance.
+    #[cfg(feature = "fs")]
     pub async fn new(config: Config) -> Result<Self, ServiceError> {
         if !config.work_dir.as_path().exists() {
             fs::create_dir_all(&config.work_dir)
@@ -432,6 +435,7 @@ impl AttestationService {
     }
 
     /// Get certificate content from file path or URL
+    #[cfg(feature = "fs")]
     async fn get_cert_content(
         &self,
         cert_path: Option<&str>,

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -405,6 +405,7 @@ impl AttestationService {
 
     /// Get token broker certificate content
     /// Returns the binary content of the certificate
+    #[cfg(feature = "fs")]
     pub async fn get_token_broker_cert_config(&self) -> Result<Option<Vec<u8>>> {
         match &self._config.attestation_token_broker {
             token::AttestationTokenConfig::Simple(cfg) => {

--- a/deps/eventlog/Cargo.toml
+++ b/deps/eventlog/Cargo.toml
@@ -24,4 +24,4 @@ tonic-build.workspace = true
 [dev-dependencies]
 assert-json-diff.workspace = true
 rstest.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }

--- a/deps/kms/Cargo.toml
+++ b/deps/kms/Cargo.toml
@@ -23,7 +23,7 @@ serde_json.workspace = true
 sha2.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
 tonic.workspace = true
 url = "2.5.4"
 yasna = "0.5.2"

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -159,4 +159,4 @@ tonic-build.workspace = true
 assert-json-diff.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -46,7 +46,7 @@ build:
 	cargo build --bin grpc-as --release --features grpc-bin --locked
 	cargo build --bin rvps --release
 	cargo build --bin rvps-tool --release
-	cargo build --bin attestation-challenge-client --release
+	cargo build --bin attestation-challenge-client --release --features attestation-challenge-client --locked
 	@echo "编译 trustee-gateway..."
 	@echo "编译完成"
 

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -90,7 +90,7 @@ strum.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time = { version = "0.3.23", features = ["std"] }
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true, optional = true }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 openssl.workspace = true

--- a/rvps/Cargo.toml
+++ b/rvps/Cargo.toml
@@ -48,7 +48,7 @@ shadow-rs = { workspace = true, optional = true }
 sled = "0.34.7"
 strum.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
 tonic = { workspace = true, optional = true }
 
 [build-dependencies]
@@ -59,5 +59,5 @@ tonic-build.workspace = true
 assert-json-diff.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
 walkdir = "2.3.2"

--- a/rvps/Cargo.toml
+++ b/rvps/Cargo.toml
@@ -4,9 +4,21 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = [ "bin", "reqwest", "sha2" ]
-# Used to build rvps binary
-bin = [ "clap", "config", "env_logger", "prost", "reqwest", "sha2", "shadow-rs", "tokio", "tonic" ]
+# The library core (the `Rvps` struct, storage, extractors, rekor/provenance
+# fetching) has no feature gates and compiles with `default-features = false`.
+# Consumers that only embed RVPS as a library (attestation-service, kbs) pull it
+# that way. The `bin` feature adds everything the `rvps` / `rvps-tool` binaries
+# need: the gRPC server/client, generated protos and CLI/config/logging.
+default = ["bin"]
+bin = [
+    "dep:clap",
+    "dep:config",
+    "dep:env_logger",
+    "dep:prost",
+    "dep:shadow-rs",
+    "dep:tonic",
+    "tokio/full",
+]
 
 # Support in-toto provenance (not ready)
 in-toto =[ "path-clean" ]
@@ -38,17 +50,17 @@ hex = { version = "0.4", optional = true }
 log.workspace = true
 path-clean = { version = "1.0.1", optional = true }
 prost = { workspace = true, optional = true }
-reqwest = { workspace = true, features = ["blocking"], optional = true }
+reqwest = { workspace = true, features = ["blocking"]}
 rpm = { version = "0.16", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml = { workspace = true, optional = true  }
-sha2 = { workspace = true, optional = true }
+sha2.workspace = true
 shadow-rs = { workspace = true, optional = true }
 sled = "0.34.7"
 strum.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full"], optional = true }
+tokio = { workspace = true, features = ["sync", "fs"] }
 tonic = { workspace = true, optional = true }
 
 [build-dependencies]

--- a/rvps/src/config.rs
+++ b/rvps/src/config.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-use anyhow::{Context, Result};
 use serde::Deserialize;
 
 use crate::storage::ReferenceValueStorageConfig;
@@ -13,7 +12,15 @@ pub struct Config {
     pub storage: ReferenceValueStorageConfig,
 }
 
+#[cfg(feature = "bin")]
+use anyhow::{Context, Result};
+
 impl Config {
+    /// Load config from a file. Only the `rvps` binary uses this; the library
+    /// core (and library consumers like attestation-service/kbs) construct
+    /// `Config` directly, so this is gated behind the `bin` feature to keep the
+    /// `config` crate out of the library's dependency closure.
+    #[cfg(feature = "bin")]
     pub fn from_file(config_path: &str) -> Result<Self> {
         let c = config::Config::builder()
             .add_source(config::File::with_name(config_path))

--- a/rvps/src/lib.rs
+++ b/rvps/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#[cfg(feature = "bin")]
 pub mod client;
 pub mod config;
 pub mod extractors;
@@ -11,7 +12,9 @@ mod provenance_source;
 pub mod reference_value;
 mod rekor;
 pub mod rv_list;
+#[cfg(feature = "bin")]
 pub mod rvps_api;
+#[cfg(feature = "bin")]
 pub mod server;
 pub mod storage;
 


### PR DESCRIPTION
## Purpose

Lay the build groundwork for running the trustee as a pure (fs-free, wasm-hostable) library. This PR does not change runtime behavior in the disk-backed path; it only introduces an `fs` feature and reorganizes dependencies so the *library* crates compile cleanly with filesystem access turned off. It is the base every subsequent PR in this series stacks on.

## Key changes reviewers should focus on

- **New `fs` feature** (attestation-service). Gates `AttestationService::new`, `get_cert_content`, and the `tokio::fs` / `std::io::Read` imports so the library builds without filesystem access.
- **Tokio retargeted to sync-only** at the library level: drop `tokio` "full" from the workspace and enable it per-package; retarget the AS library tokio usage to the sync feature set, and make tokio a core dependency of the library crate.
- **`uuid` gated behind wasm32** with the `js` feature so the crate resolves under wasm.
- **rvps library** made to compile without the bin feature; the bin stays gated.
- `.vscode` added to `.gitignore` (chore).
