### PR TITLE
feat(rvps): add InMemory storage and gate disk-backed storage behind fs for pure-lib

### DIFF
--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -10,7 +10,7 @@ default = [ "restful-bin", "rvps-grpc", "all-verifier", "fs" ]
 # rvps local_json/local_fs storage, nonce-key persistence, signer transparency
 # file, signer key/cert read by path. Turn off (`default-features = false`) for a
 # pure, fs-free library (e.g. wasm builds).
-fs = [ "tokio/fs" ]
+fs = [ "tokio/fs", "reference-value-provider-service/fs" ]
 all-verifier = [ "verifier/all-verifier" ]
 # Like `all-verifier`, but the TDX verifier uses the dcap-qvl backend and SGX is
 # dropped (it would still link the DCAP shared library). See

--- a/attestation-service/docs/config.md
+++ b/attestation-service/docs/config.md
@@ -75,9 +75,9 @@ If `type` is set to `BuiltIn`, the following extra properties can be set
 
 | Property       | Type                    | Description                                                           | Required | Default  |
 |----------------|-------------------------|-----------------------------------------------------------------------|----------|----------|
-| `storage`   | ReferenceValueStorageConfig | Configuration of storage for reference values (`LocalFs` or `LocalJson`)       | No       | `LocalFs`|
+| `storage`   | ReferenceValueStorageConfig | Configuration of storage for reference values (`LocalFs`, `LocalJson`, or `InMemory`)       | No       | `LocalFs`|
 
-`ReferenceValueStorageConfig` can contain either a `LocalFs` configuration or a `LocalJson` configuration.
+`ReferenceValueStorageConfig` can contain a `LocalFs`, `LocalJson`, or `InMemory` configuration.
 
 For `LocalFs`, the following properties can be set
 
@@ -90,6 +90,8 @@ For `LocalJson`, the following properties can be set
 | Property       | Type                    | Description                                              | Required | Default  |
 |----------------|-------------------------|----------------------------------------------------------|----------|----------|
 | `file_path`    | String                  | The path to the file that storing reference values       | No       | `/opt/confidential-containers/attestation-service/reference_values.json`|
+
+For `InMemory`, no additional properties can be set. Reference values are kept in memory without an on-disk database.
 
 ##### Remote RVPS
 

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -138,9 +138,9 @@ If `type` is set to `BuiltIn`, the following extra properties can be set
 
 | Property       | Type                    | Description                                                           | Required | Default  |
 |----------------|-------------------------|-----------------------------------------------------------------------|----------|----------|
-| `storage`   | ReferenceValueStorageConfig | Configuration of the storage for reference values (`LocalFs` or `LocalJson`) | No       | `LocalFs`|
+| `storage`   | ReferenceValueStorageConfig | Configuration of the storage for reference values (`LocalFs`, `LocalJson`, or `InMemory`) | No       | `LocalFs`|
 
-A `ReferenceValueStorageConfig` can either be of type `LocalFs` or `LocalJson`
+A `ReferenceValueStorageConfig` can be of type `LocalFs`, `LocalJson`, or `InMemory`
 
 For `LocalFs`, the following properties can be set
 
@@ -153,6 +153,8 @@ For `LocalJson`, the following properties can be set
 | Property       | Type                    | Description                                              | Required | Default  |
 |----------------|-------------------------|----------------------------------------------------------|----------|----------|
 | `file_path`    | String                  | The path to the file that storing reference values       | No       | `/opt/confidential-containers/attestation-service/reference_values.json`|
+
+For `InMemory`, no additional properties can be set. Reference values are kept in memory without an on-disk database.
 
 ##### Remote RVPS
 

--- a/rvps/Cargo.toml
+++ b/rvps/Cargo.toml
@@ -25,13 +25,15 @@ bin = [
 # reads. Pulls `dep:sled` and `tokio/fs`. Library consumers that embed RVPS as
 # a pure library (attestation-service with `--no-default-features`, wasm) turn
 # this off so the lib core has zero fs/sled references.
-fs = ["dep:sled", "tokio/fs"]
+fs = ["dep:sled", "tokio/fs", "dep:tempfile"]
 
-# Support in-toto provenance (not ready)
-in-toto =[ "path-clean" ]
+# Support in-toto provenance (not ready). Uses `tempfile` at runtime, so the
+# extractor pulls it in when enabled without `fs`.
+in-toto = [ "path-clean", "dep:tempfile" ]
 
-# Enable reproducible build feature
-reproducible-build = [ "rpm", "serde_yaml", "hex", "git2" ]
+# Enable reproducible build feature. Uses `tempfile` at runtime, so the
+# extractor pulls it in when enabled without `fs`.
+reproducible-build = [ "rpm", "serde_yaml", "hex", "git2", "dep:tempfile" ]
 
 rebuild-grpc-protos = []
 
@@ -66,7 +68,7 @@ sha2.workspace = true
 shadow-rs = { workspace = true, optional = true }
 sled = { version = "0.34.7", optional = true }
 strum.workspace = true
-tempfile.workspace = true
+tempfile = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync"] }
 tonic = { workspace = true, optional = true }
 

--- a/rvps/Cargo.toml
+++ b/rvps/Cargo.toml
@@ -17,8 +17,15 @@ bin = [
     "dep:prost",
     "dep:shadow-rs",
     "dep:tonic",
+    "fs",
     "tokio/full",
 ]
+
+# Filesystem-backed storage (LocalFs / LocalJson) and `file://` provenance
+# reads. Pulls `dep:sled` and `tokio/fs`. Library consumers that embed RVPS as
+# a pure library (attestation-service with `--no-default-features`, wasm) turn
+# this off so the lib core has zero fs/sled references.
+fs = ["dep:sled", "tokio/fs"]
 
 # Support in-toto provenance (not ready)
 in-toto =[ "path-clean" ]
@@ -57,10 +64,10 @@ serde_json.workspace = true
 serde_yaml = { workspace = true, optional = true  }
 sha2.workspace = true
 shadow-rs = { workspace = true, optional = true }
-sled = "0.34.7"
+sled = { version = "0.34.7", optional = true }
 strum.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["sync", "fs"] }
+tokio = { workspace = true, features = ["sync"] }
 tonic = { workspace = true, optional = true }
 
 [build-dependencies]

--- a/rvps/README.md
+++ b/rvps/README.md
@@ -103,8 +103,8 @@ RVPS can be launched with a specified configuration file by `-c` flag. A configu
     }
 }
 ```
-- `storage.type`: backend storage type to store reference values. Currently `LocalFs` and `LocalJson` are supported.
-- `storage.*`: Each different type of storage has its own associated configuration parameters. This is also a JSON map object.
+- `storage.type`: backend storage type to store reference values. Currently `InMemory`, `LocalFs`, and `LocalJson` are supported.
+- `storage.*`: Each different type of storage has its own associated configuration parameters. This is also a JSON map object. `InMemory` takes no extra parameters.
 
 ## Integrate RVPS into the Attestation Service
 

--- a/rvps/src/extractors/extractor_modules/mod.rs
+++ b/rvps/src/extractors/extractor_modules/mod.rs
@@ -15,6 +15,7 @@ pub mod in_toto;
 #[cfg(feature = "reproducible-build")]
 pub mod reproducible_build;
 pub mod sample;
+#[cfg(feature = "fs")]
 pub mod slsa;
 
 /// Extractor is a standard interface that all provenance extractors
@@ -43,6 +44,7 @@ impl Default for ExtractorModuleList {
             mod_list.insert("sample".to_string(), instantiate_func);
         }
 
+        #[cfg(feature = "fs")]
         {
             let instantiate_func: ExtractorInstantiateFunc =
                 Box::new(|| -> ExtractorInstance { Box::new(slsa::SlsaExtractor) });

--- a/rvps/src/lib.rs
+++ b/rvps/src/lib.rs
@@ -350,6 +350,7 @@ async fn fetch_provenance_material(
                 .await
                 .with_context(|| format!("fetch provenance from OCI `{}`", src.uri))
         }
+        #[cfg(feature = "fs")]
         "file" => {
             let path = source.uri.strip_prefix("file://").unwrap_or(&source.uri);
             let raw_bytes = std::fs::read(path)
@@ -559,6 +560,7 @@ fn unique_docs(docs: Vec<String>) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "fs")]
     use crate::storage::{local_json, ReferenceValueStorageConfig};
 
     #[test]
@@ -580,6 +582,7 @@ mod tests {
         assert!(docs[0].contains("predicateType"));
     }
 
+    #[cfg(feature = "fs")]
     #[tokio::test]
     async fn set_reference_value_list_from_release_manifest_file() {
         let tmp = tempfile::tempdir().unwrap();

--- a/rvps/src/provenance_source.rs
+++ b/rvps/src/provenance_source.rs
@@ -19,8 +19,16 @@ pub struct FetchedProvenanceMaterial {
     pub raw_bytes: Vec<u8>,
 }
 
-#[async_trait]
-pub trait ProvenanceFetcher: Send + Sync {
+#[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), async_trait(?Send))]
+#[cfg_attr(
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )),
+    async_trait
+)]
+pub trait ProvenanceFetcher {
     async fn fetch(&self, source: &ProvenanceSource) -> Result<FetchedProvenanceMaterial>;
 }
 
@@ -65,7 +73,15 @@ struct BearerTokenResponse {
     access_token: Option<String>,
 }
 
-#[async_trait]
+#[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), async_trait(?Send))]
+#[cfg_attr(
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )),
+    async_trait
+)]
 impl ProvenanceFetcher for OciProvenanceFetcher {
     async fn fetch(&self, source: &ProvenanceSource) -> Result<FetchedProvenanceMaterial> {
         let reference = parse_oci_reference(&source.uri)?;
@@ -248,12 +264,18 @@ fn parse_oci_reference(uri: &str) -> Result<OciReference> {
 }
 
 fn infer_registry_scheme(registry: &str) -> String {
-    if registry.starts_with("127.0.0.1")
-        || registry.starts_with("localhost")
-        || std::env::var("TRUSTEE_OCI_INSECURE")
+    let insecure = registry.starts_with("127.0.0.1") || registry.starts_with("localhost");
+    #[cfg(not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )))]
+    let insecure = insecure
+        | std::env::var("TRUSTEE_OCI_INSECURE")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
-    {
+            .unwrap_or(false);
+
+    if insecure {
         "http".to_string()
     } else {
         "https".to_string()

--- a/rvps/src/storage/in_memory/mod.rs
+++ b/rvps/src/storage/in_memory/mod.rs
@@ -1,0 +1,89 @@
+// Copyright (c) 2022 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! fs-free `ReferenceValueStorage`: keeps reference values in a `HashMap`
+//! behind a `tokio::sync::RwLock`. For pure-lib / wasm consumers that preload
+//! reference values in-process (no on-disk DB).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
+use tokio::sync::RwLock;
+
+use super::ReferenceValueStorage;
+use crate::ReferenceValue;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Config {}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+pub struct InMemory {
+    map: Arc<RwLock<HashMap<String, ReferenceValue>>>,
+}
+
+impl InMemory {
+    pub fn new(_config: Config) -> Result<Self> {
+        Ok(Self {
+            map: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+}
+
+#[async_trait]
+impl ReferenceValueStorage for InMemory {
+    async fn set(&self, name: String, rv: ReferenceValue) -> Result<Option<ReferenceValue>> {
+        let mut m = self.map.write().await;
+        Ok(m.insert(name, rv))
+    }
+
+    async fn get(&self, name: &str) -> Result<Option<ReferenceValue>> {
+        let m = self.map.read().await;
+        Ok(m.get(name).cloned())
+    }
+
+    async fn get_values(&self) -> Result<Vec<ReferenceValue>> {
+        let m = self.map.read().await;
+        Ok(m.values().cloned().collect())
+    }
+
+    async fn delete(&self, name: &str) -> Result<Option<ReferenceValue>> {
+        let mut m = self.map.write().await;
+        Ok(m.remove(name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn dummy_rv(name: &str) -> ReferenceValue {
+        ReferenceValue {
+            version: "0.1.0".to_string(),
+            name: name.to_string(),
+            expiration: chrono::Utc.with_ymd_and_hms(2099, 1, 1, 0, 0, 0).unwrap(),
+            hash_value: vec![],
+            audit_proof: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn set_get_delete() {
+        let s = InMemory::new(Config {}).unwrap();
+        s.set("a".into(), dummy_rv("a")).await.unwrap();
+        assert!(s.get("a").await.unwrap().is_some());
+        assert_eq!(s.get_values().await.unwrap().len(), 1);
+        s.delete("a").await.unwrap();
+        assert!(s.get("a").await.unwrap().is_none());
+    }
+}

--- a/rvps/src/storage/in_memory/mod.rs
+++ b/rvps/src/storage/in_memory/mod.rs
@@ -18,14 +18,8 @@ use tokio::sync::RwLock;
 use super::ReferenceValueStorage;
 use crate::ReferenceValue;
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 pub struct Config {}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {}
-    }
-}
 
 pub struct InMemory {
     map: Arc<RwLock<HashMap<String, ReferenceValue>>>,

--- a/rvps/src/storage/mod.rs
+++ b/rvps/src/storage/mod.rs
@@ -10,32 +10,53 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use strum::Display;
 
+#[cfg(feature = "fs")]
 use self::local_fs::LocalFs;
+#[cfg(feature = "fs")]
 use self::local_json::LocalJson;
 
 use super::ReferenceValue;
 
+pub mod in_memory;
+#[cfg(feature = "fs")]
 pub mod local_fs;
+#[cfg(feature = "fs")]
 pub mod local_json;
 
 #[derive(Clone, Debug, Deserialize, Display, PartialEq)]
 #[serde(tag = "type")]
 pub enum ReferenceValueStorageConfig {
+    InMemory(in_memory::Config),
+    #[cfg(feature = "fs")]
     LocalFs(local_fs::Config),
+    #[cfg(feature = "fs")]
     LocalJson(local_json::Config),
 }
 
 impl Default for ReferenceValueStorageConfig {
     fn default() -> Self {
-        ReferenceValueStorageConfig::LocalFs(local_fs::Config::default())
+        #[cfg(feature = "fs")]
+        {
+            ReferenceValueStorageConfig::LocalFs(local_fs::Config::default())
+        }
+        #[cfg(not(feature = "fs"))]
+        {
+            ReferenceValueStorageConfig::InMemory(in_memory::Config::default())
+        }
     }
 }
 
 impl ReferenceValueStorageConfig {
     pub fn to_storage(&self) -> Result<Box<dyn ReferenceValueStorage + Send + Sync>> {
         match self {
+            ReferenceValueStorageConfig::InMemory(cfg) => {
+                Ok(Box::new(in_memory::InMemory::new(cfg.clone())?)
+                    as Box<dyn ReferenceValueStorage + Send + Sync>)
+            }
+            #[cfg(feature = "fs")]
             ReferenceValueStorageConfig::LocalFs(cfg) => Ok(Box::new(LocalFs::new(cfg.clone())?)
                 as Box<dyn ReferenceValueStorage + Send + Sync>),
+            #[cfg(feature = "fs")]
             ReferenceValueStorageConfig::LocalJson(cfg) => {
                 Ok(Box::new(LocalJson::new(cfg.clone())?)
                     as Box<dyn ReferenceValueStorage + Send + Sync>)


### PR DESCRIPTION
Make RVPS usable as an fs-free library for the upcoming wasm/pure-lib attestation-service builds: add a tokio::sync::RwLock HashMap-backed InMemory storage so reference values can be preloaded in-process, and move sled, tokio/fs, and tempfile behind a new `fs` feature, gating LocalFs, LocalJson, and the `file://` provenance reads on it so the lib core has zero fs/sled references when `fs` is off. attestation-service wires its own `fs` feature through to `reference-value-provider-service/fs`, so existing binary builds keep their disk storage unchanged.

Key changes worth reviewing:
- rvps/Cargo.toml: new `fs = ["dep:sled", "tokio/fs", "dep:tempfile"]`; `sled` and `tempfile` become `optional`; `tokio` drops its `fs` feature by default (only `sync`), so tokio/fs no longer leaks into downstream no-fs builds; `in-toto` and `reproducible-build` now pull `tempfile` directly so their extractors still work without `fs`; the `bin` feature enables `fs`.
- rvps/src/storage/in_memory/mod.rs: new InMemory storage (RwLock<HashMap>).
- rvps/src/storage/mod.rs: InMemory is the no-fs default; LocalFs/LocalJson gated behind `#[cfg(feature = "fs")]`; storage config falls back to InMemory when `fs` is off.
- rvps/src/provenance_source.rs: `file://` reads gated behind `fs` (non-fs path returns the fetch error instead of touching disk); OCI provenance fetch uses `cfg_attr` so it builds on wasm32 (async_trait(?Send) and the non-wasm fetch path guarded accordingly).
- rvps/src/extractors/extractor_modules/mod.rs: SLSA extractor gated behind `fs`.
- attestation-service/Cargo.toml: `fs` now propagates `reference-value-provider-service/fs`.
