### PR TITLE
fix(as): remove synthetic request ID

### DIFF
--- a/attestation-service/docs/error-codes.md
+++ b/attestation-service/docs/error-codes.md
@@ -5,9 +5,10 @@ with the media type `application/problem+json`. Successful responses are
 unchanged.
 
 Clients should branch on `code` and use the HTTP status as a fallback. The
-human-readable `detail` can change and must not be parsed. `request_id` is also
-returned in the `x-request-id` response header and can be used to correlate the
-response with the full server-side error chain.
+human-readable `detail` can change and must not be parsed. The full source error
+chain is logged by RESTful AS and is not returned to clients. RESTful AS does
+not synthesize a request or correlation identifier; clients should use their
+own tracing context when one is required.
 
 ```json
 {
@@ -17,8 +18,7 @@ response with the full server-side error chain.
   "code": "AS.EVIDENCE.INVALID_ENCODING",
   "detail": "An evidence field uses an invalid encoding.",
   "retryable": false,
-  "field": "verification_requests[0].evidence.quote",
-  "request_id": "b08e8f11-0000-4000-8000-000000000000"
+  "field": "verification_requests[0].evidence.quote"
 }
 ```
 

--- a/attestation-service/src/bin/restful-as.rs
+++ b/attestation-service/src/bin/restful-as.rs
@@ -104,7 +104,6 @@ fn configure_cors(allowed_origin: &[String]) -> Cors {
     let mut cors = Cors::default()
         .allowed_methods(vec!["POST", "GET", "OPTIONS"])
         .allowed_headers(vec![header::CONTENT_TYPE, header::AUTHORIZATION])
-        .expose_headers(vec![header::HeaderName::from_static("x-request-id")])
         .max_age(86400);
 
     // Parse origin

--- a/attestation-service/src/bin/restful/mod.rs
+++ b/attestation-service/src/bin/restful/mod.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use thiserror::Error;
 use tokio::sync::RwLock;
-use uuid::Uuid;
 
 const ERROR_TYPE_PREFIX: &str =
     "https://github.com/confidential-containers/attestation-service/errors";
@@ -87,7 +86,6 @@ struct ProblemDetails {
     retryable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     field: Option<String>,
-    request_id: String,
 }
 
 impl Error {
@@ -296,10 +294,8 @@ impl ResponseError for Error {
 
     fn error_response(&self) -> HttpResponse {
         let status = self.status_code();
-        let request_id = Uuid::new_v4().to_string();
         error!(
-            "request_id={} code={} status={} error={:#}",
-            request_id,
+            "code={} status={} error={:#}",
             self.code,
             status.as_u16(),
             self.source
@@ -313,11 +309,9 @@ impl ResponseError for Error {
             detail: self.detail.clone(),
             retryable: self.retryable,
             field: self.field.clone(),
-            request_id: request_id.clone(),
         };
 
         HttpResponse::build(status)
-            .insert_header(("x-request-id", request_id))
             .content_type("application/problem+json")
             .json(problem)
     }
@@ -790,8 +784,11 @@ mod tests {
         let response = error.error_response();
         let status = response.status();
         let headers = response.headers().clone();
+        assert!(headers.get("x-request-id").is_none());
         let body = to_bytes(response.into_body()).await.unwrap();
-        let problem: ProblemDetails = serde_json::from_slice(&body).unwrap();
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert!(body.get("request_id").is_none());
+        let problem: ProblemDetails = serde_json::from_value(body).unwrap();
         let mut response = HttpResponse::build(status).finish();
         *response.headers_mut() = headers;
         (response, problem)
@@ -829,15 +826,6 @@ mod tests {
         );
         assert!(!problem.retryable);
         assert!(!problem.detail.contains(source_detail));
-        assert_eq!(
-            response
-                .headers()
-                .get("x-request-id")
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            problem.request_id
-        );
     }
 
     #[actix_web::test]
@@ -883,16 +871,11 @@ mod tests {
         let response = test::call_service(&app, request).await;
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let request_id = response
-            .headers()
-            .get("x-request-id")
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string();
-        let problem: ProblemDetails = test::read_body_json(response).await;
+        assert!(response.headers().get("x-request-id").is_none());
+        let body: Value = test::read_body_json(response).await;
+        assert!(body.get("request_id").is_none());
+        let problem: ProblemDetails = serde_json::from_value(body).unwrap();
         assert_eq!(problem.code, "AS.REQUEST.INVALID_JSON");
         assert_eq!(problem.field.as_deref(), Some("body"));
-        assert_eq!(problem.request_id, request_id);
     }
 }


### PR DESCRIPTION
## Summary

Remove the synthetic request identifier added to RESTful AS error responses in #210.

The identifier was created only when Actix serialized an error response. It was not propagated from the request ingress and did not correlate earlier verifier or service logs, so exposing it as `request_id` / `x-request-id` could be mistaken for an end-to-end request or trace identifier.

## Changes

- remove `request_id` from the `application/problem+json` body;
- stop emitting the `x-request-id` response header and remove its CORS exposure;
- keep the full source error chain in server logs, keyed by stable error code and HTTP status;
- add regression assertions that both the body field and response header are absent;
- update the RESTful AS error contract to state that AS does not synthesize a correlation identifier.

The stable `AS.*` error codes, HTTP mappings, `retryable`, `field`, safe client detail, and successful responses are unchanged.

## Validation

- `cargo test -p attestation-service` (24 library tests, 5 RESTful-AS tests, 2 RVPS integration tests)
- `cargo clippy -p attestation-service -- -D warnings -A clippy::derive_partial_eq_without_eq`
- `cargo check -p attestation-service --no-default-features --features restful-bin,rvps-grpc,all-verifier-rust,fs`
- `cargo fmt --all -- --check`
- `git diff --check`
