### PR TITLE
attestation: verify SNP SVSM vTPM evidence

### DIFF
--- a/attestation-service/src/composite.rs
+++ b/attestation-service/src/composite.rs
@@ -291,4 +291,18 @@ mod tests {
         let snp = request(Tee::Snp, json!({}), json!({"nonce": "challenge"}));
         verify_composite_bindings(&[snp]).unwrap();
     }
+
+    #[test]
+    fn accepts_plain_snp_with_empty_additional_evidence() {
+        let snp = request(
+            Tee::Snp,
+            json!({}),
+            json!({
+                "nonce": "challenge",
+                (ADDITIONAL_EVIDENCE): "",
+            }),
+        );
+
+        verify_composite_bindings(&[snp]).unwrap();
+    }
 }

--- a/attestation-service/src/composite.rs
+++ b/attestation-service/src/composite.rs
@@ -1,0 +1,294 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Verification of relationships between otherwise independent TEE evidence.
+
+use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde_json::Value;
+use std::collections::HashMap;
+use verifier::VerifierError;
+
+use crate::{AttestationError, RuntimeData, Tee, VerificationRequest};
+
+const ADDITIONAL_EVIDENCE: &str = "additional-evidence";
+
+/// Verify bindings which span more than one [`VerificationRequest`].
+///
+/// A request list represents one TCB. For an SNP guest with an SVSM vTPM, the
+/// TPM evidence must therefore be the same evidence covered by the SNP runtime
+/// data, use the same base runtime data, and identify the EK carried in the
+/// VMPL0 SVSM manifest.
+pub(crate) fn verify_composite_bindings(requests: &[VerificationRequest]) -> Result<()> {
+    let snp = requests
+        .iter()
+        .enumerate()
+        .filter(|(_, request)| request.tee == Tee::Snp)
+        .collect::<Vec<_>>();
+    let tpm = requests
+        .iter()
+        .enumerate()
+        .filter(|(_, request)| request.tee == Tee::Tpm)
+        .collect::<Vec<_>>();
+
+    // Standalone SNP and standalone TPM evidence remain valid. The binding is
+    // required only when both are combined into one attestation result.
+    if snp.is_empty() || tpm.is_empty() {
+        return Ok(());
+    }
+
+    if snp.len() != 1 || tpm.len() != 1 {
+        return Err(invalid_request(
+            None,
+            "verification_requests",
+            "an SNP/SVSM vTPM attestation requires exactly one SNP and one TPM request",
+        ));
+    }
+
+    verify_snp_svsm_vtpm_binding(snp[0], tpm[0])
+}
+
+fn verify_snp_svsm_vtpm_binding(
+    (snp_index, snp): (usize, &VerificationRequest),
+    (tpm_index, tpm): (usize, &VerificationRequest),
+) -> Result<()> {
+    let primary_runtime = structured_runtime(snp_index, snp)?;
+    let additional_evidence = primary_runtime
+        .get(ADDITIONAL_EVIDENCE)
+        .and_then(Value::as_str)
+        .filter(|evidence| !evidence.is_empty())
+        .ok_or_else(|| {
+            invalid_request(
+                Some(snp_index),
+                "runtime_data",
+                "SNP runtime data does not contain TPM additional evidence",
+            )
+        })?;
+    let additional: HashMap<Tee, Value> =
+        serde_json::from_str(additional_evidence).map_err(|e| {
+            invalid_request(
+                Some(snp_index),
+                "runtime_data",
+                format!("cannot parse SNP additional evidence: {e}"),
+            )
+        })?;
+    let bound_tpm = additional.get(&Tee::Tpm).ok_or_else(|| {
+        invalid_request(
+            Some(snp_index),
+            "runtime_data",
+            "SNP runtime data does not contain TPM additional evidence",
+        )
+    })?;
+
+    if bound_tpm != &tpm.evidence {
+        return Err(binding_mismatch(
+            tpm_index,
+            Tee::Tpm,
+            "evidence",
+            "TPM evidence differs from the evidence bound by the SNP report",
+        ));
+    }
+
+    let mut base_runtime = primary_runtime.clone();
+    base_runtime.remove(ADDITIONAL_EVIDENCE);
+    if &base_runtime != structured_runtime(tpm_index, tpm)? {
+        return Err(invalid_request(
+            Some(tpm_index),
+            "runtime_data",
+            "SNP and TPM evidence do not use the same base runtime data",
+        ));
+    }
+
+    let manifest = evidence_string(snp_index, Tee::Snp, &snp.evidence, "svsm_manifest")?;
+    let ek_public = evidence_string(tpm_index, Tee::Tpm, &tpm.evidence, "ek_pubkey")?;
+    let manifest = decode_evidence(snp_index, Tee::Snp, "svsm_manifest", manifest)?;
+    let ek_public = decode_evidence(tpm_index, Tee::Tpm, "ek_pubkey", ek_public)?;
+
+    if manifest.is_empty() || manifest != ek_public {
+        return Err(binding_mismatch(
+            tpm_index,
+            Tee::Tpm,
+            "ek_pubkey",
+            "TPM EK public key does not match the vTPM manifest bound by the VMPL0 SNP report",
+        ));
+    }
+
+    Ok(())
+}
+
+fn structured_runtime(
+    index: usize,
+    request: &VerificationRequest,
+) -> Result<&serde_json::Map<String, Value>> {
+    match &request.runtime_data {
+        Some(RuntimeData::Structured(Value::Object(runtime))) => Ok(runtime),
+        _ => Err(invalid_request(
+            Some(index),
+            "runtime_data",
+            "SNP/SVSM vTPM composite evidence requires structured runtime data",
+        )),
+    }
+}
+
+fn evidence_string<'a>(
+    index: usize,
+    tee: Tee,
+    evidence: &'a Value,
+    field: &'static str,
+) -> Result<&'a str> {
+    evidence.get(field).and_then(Value::as_str).ok_or_else(|| {
+        verification_error(
+            index,
+            tee,
+            VerifierError::InvalidEvidenceFormat {
+                field,
+                source: anyhow!("required field is missing or is not a string"),
+            },
+        )
+    })
+}
+
+fn decode_evidence(index: usize, tee: Tee, field: &'static str, value: &str) -> Result<Vec<u8>> {
+    STANDARD.decode(value).map_err(|source| {
+        verification_error(
+            index,
+            tee,
+            VerifierError::InvalidEvidenceEncoding {
+                field,
+                source: source.into(),
+            },
+        )
+    })
+}
+
+fn invalid_request(
+    request_index: Option<usize>,
+    field: &'static str,
+    message: impl Into<String>,
+) -> anyhow::Error {
+    AttestationError::InvalidRequest {
+        request_index,
+        field,
+        source: anyhow!("{}", message.into()),
+    }
+    .into()
+}
+
+fn binding_mismatch(
+    request_index: usize,
+    tee: Tee,
+    field: &'static str,
+    message: impl Into<String>,
+) -> anyhow::Error {
+    verification_error(
+        request_index,
+        tee,
+        VerifierError::BindingMismatch {
+            field,
+            source: anyhow!("{}", message.into()),
+        },
+    )
+}
+
+fn verification_error(request_index: usize, tee: Tee, source: VerifierError) -> anyhow::Error {
+    AttestationError::Verification {
+        request_index,
+        tee,
+        source: source.into(),
+    }
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::HashAlgorithm;
+    use serde_json::json;
+
+    fn request(tee: Tee, evidence: Value, runtime_data: Value) -> VerificationRequest {
+        VerificationRequest {
+            tee,
+            evidence,
+            runtime_data: Some(RuntimeData::Structured(runtime_data)),
+            runtime_data_hash_algorithm: HashAlgorithm::Sha384,
+            init_data: None,
+            additional_data: None,
+        }
+    }
+
+    fn composite_requests(manifest: &[u8]) -> Vec<VerificationRequest> {
+        let ek = STANDARD.encode(manifest);
+        let tpm_evidence = json!({
+            "ek_pubkey": ek,
+            "ak_pubkey": "ak",
+            "quote": {"SHA256": "quote"}
+        });
+        let additional =
+            serde_json::to_string(&HashMap::from([(Tee::Tpm, tpm_evidence.clone())])).unwrap();
+        let base_runtime = json!({"nonce": "challenge", "tee-pubkey": "key"});
+        let primary_runtime = json!({
+            "nonce": "challenge",
+            "tee-pubkey": "key",
+            (ADDITIONAL_EVIDENCE): additional,
+        });
+
+        vec![
+            request(
+                Tee::Snp,
+                json!({"svsm_manifest": STANDARD.encode(manifest)}),
+                primary_runtime,
+            ),
+            request(Tee::Tpm, tpm_evidence, base_runtime),
+        ]
+    }
+
+    #[test]
+    fn accepts_bound_snp_svsm_vtpm_evidence() {
+        verify_composite_bindings(&composite_requests(b"ek-public")).unwrap();
+    }
+
+    #[test]
+    fn rejects_manifest_ek_mismatch() {
+        let mut requests = composite_requests(b"ek-public");
+        requests[0].evidence["svsm_manifest"] = json!(STANDARD.encode(b"another-ek"));
+
+        let error = verify_composite_bindings(&requests).unwrap_err();
+        assert!(format!("{error:#}").contains("TPM EK public key does not match"));
+    }
+
+    #[test]
+    fn rejects_tpm_evidence_splicing() {
+        let mut requests = composite_requests(b"ek-public");
+        requests[1].evidence["quote"] = json!({"SHA256": "another-quote"});
+
+        let error = verify_composite_bindings(&requests).unwrap_err();
+        assert!(format!("{error:#}").contains("TPM evidence differs"));
+    }
+
+    #[test]
+    fn rejects_snp_tpm_pair_without_svsm_manifest() {
+        let mut requests = composite_requests(b"ek-public");
+        requests[0].evidence = json!({});
+
+        let error = verify_composite_bindings(&requests).unwrap_err();
+        assert!(format!("{error:#}").contains("svsm_manifest"));
+    }
+
+    #[test]
+    fn rejects_different_runtime_data() {
+        let mut requests = composite_requests(b"ek-public");
+        requests[1].runtime_data = Some(RuntimeData::Structured(
+            json!({"nonce": "another-challenge", "tee-pubkey": "key"}),
+        ));
+
+        let error = verify_composite_bindings(&requests).unwrap_err();
+        assert!(format!("{error:#}").contains("same base runtime data"));
+    }
+
+    #[test]
+    fn leaves_independent_evidence_unchanged() {
+        let snp = request(Tee::Snp, json!({}), json!({"nonce": "challenge"}));
+        verify_composite_bindings(&[snp]).unwrap();
+    }
+}

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -9,6 +9,8 @@ pub mod policy_engine;
 pub mod rvps;
 pub mod token;
 
+mod composite;
+
 use crate::token::AttestationTokenBroker;
 
 use anyhow::{anyhow, Context, Result};
@@ -305,6 +307,8 @@ impl AttestationService {
             }
             .into());
         }
+
+        composite::verify_composite_bindings(&verification_requests)?;
 
         for (request_index, verification_request) in verification_requests.into_iter().enumerate() {
             let verifier = verifier::to_verifier(&verification_request.tee).map_err(|source| {

--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -17,6 +17,7 @@ use openssl::{
 use serde_json::json;
 use sev::firmware::guest::AttestationReport;
 use sev::firmware::host::{CertTableEntry, CertType};
+use sha2::{Digest, Sha512};
 #[cfg(test)]
 use std::sync::OnceLock;
 use x509_parser::prelude::*;
@@ -25,6 +26,10 @@ use x509_parser::prelude::*;
 pub struct SnpEvidence {
     attestation_report: AttestationReport,
     cert_chain: Option<Vec<CertTableEntry>>,
+    /// Base64-encoded SVSM service manifest. When present, REPORT_DATA must
+    /// contain SHA-512(padded nonce || manifest), as defined by the SVSM ABI.
+    #[serde(default)]
+    svsm_manifest: Option<String>,
 }
 
 const HW_ID_OID: Oid<'static> = oid!(1.3.6 .1 .4 .1 .3704 .1 .4);
@@ -247,6 +252,7 @@ impl Verifier for Snp {
         let SnpEvidence {
             attestation_report: report,
             cert_chain,
+            svsm_manifest,
         } = serde_json::from_value(evidence).context("Deserialize Quote failed.")?;
 
         // Faithful raw bytes of the report; sev 4.x round-trips v2..=5 reports
@@ -282,8 +288,22 @@ impl Verifier for Snp {
 
         if let ReportData::Value(expected_report_data) = expected_report_data {
             debug!("Check the binding of REPORT_DATA.");
-            let expected_report_data =
-                regularize_data(expected_report_data, 64, "REPORT_DATA", "SNP");
+            let nonce = regularize_data(expected_report_data, 64, "REPORT_DATA", "SNP");
+            let expected_report_data = if let Some(encoded_manifest) = &svsm_manifest {
+                let manifest = base64::engine::general_purpose::STANDARD
+                    .decode(encoded_manifest)
+                    .context("Decode SVSM manifest")?;
+                if manifest.is_empty() {
+                    bail!("SVSM vTPM manifest is empty");
+                }
+
+                let mut hasher = Sha512::new();
+                hasher.update(&nonce);
+                hasher.update(&manifest);
+                hasher.finalize().to_vec()
+            } else {
+                nonce
+            };
 
             if expected_report_data != report.report_data {
                 warn!(
@@ -304,7 +324,14 @@ impl Verifier for Snp {
             }
         }
 
-        let claims_map = parse_tee_evidence(&report, &raw, proc_gen)?;
+        let mut claims_map = parse_tee_evidence(&report, &raw, proc_gen)?;
+        if let Some(manifest) = svsm_manifest {
+            let claims = claims_map
+                .as_object_mut()
+                .context("SNP claims must be a JSON object")?;
+            claims.insert("svsm_manifest".to_string(), json!(manifest));
+            claims.insert("svsm_attestation".to_string(), json!(true));
+        }
         let json = json!(claims_map);
         Ok((json, "cpu".to_string()))
     }

--- a/deps/verifier/src/tpm/mod.rs
+++ b/deps/verifier/src/tpm/mod.rs
@@ -4,6 +4,7 @@
 //
 
 use super::*;
+use ::eventlog::ccel::tcg_enum::{TcgAlgorithm, TcgEventType};
 use ::eventlog::CcEventLog;
 use async_trait::async_trait;
 use base64::Engine;
@@ -14,6 +15,8 @@ use openssl::pkey::PKey;
 use openssl::x509::X509;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use sha1::Sha1;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use tss_esapi::structures::{Attest, AttestInfo};
 use tss_esapi::traits::UnMarshall;
@@ -24,6 +27,9 @@ const TPM_REPORT_DATA_SIZE: usize = 32;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TpmEvidence {
+    // Base64 encoded TPMT_PUBLIC of the EK
+    #[serde(default)]
+    pub ek_pubkey: Option<String>,
     // PEM format of EK certificate
     pub ek_cert: Option<String>,
     // PEM format of AK public key
@@ -77,23 +83,54 @@ impl Verifier for TpmVerifier {
                     .ok_or_else(|| anyhow!(format!("Missing '{}' in registrar results", k)))
             };
             let ek_tpm_b64 = get_str("ek_tpm")?;
-            let ekcert_b64 = get_str("ekcert")?;
+            let ekcert_b64 = results.get("ekcert").and_then(Value::as_str);
             let aik_tpm_b64 = get_str("aik_tpm")?;
 
-            // Compare EK certificate (registrar DER vs evidence PEM)
-            let evidence_ek_pem = tpm_evidence.ek_cert.as_ref().ok_or_else(|| {
-                anyhow!("EK certificate missing in evidence while Keylime UUID is provided")
-            })?;
-            let evidence_ek_der = X509::from_pem(evidence_ek_pem.as_bytes())
-                .map_err(|e| anyhow!(format!("parse evidence EK cert (PEM): {}", e)))?
-                .to_der()
-                .map_err(|e| anyhow!(format!("encode evidence EK cert (DER): {}", e)))?;
             let engine = base64::engine::general_purpose::STANDARD;
-            let registrar_ek_der = engine
-                .decode(ekcert_b64)
-                .map_err(|e| anyhow!(format!("decode registrar EK cert (base64 DER): {}", e)))?;
-            if registrar_ek_der != evidence_ek_der {
-                bail!("EK certificate mismatch with keylime registrar");
+            let registrar_ek_raw = engine
+                .decode(ek_tpm_b64)
+                .map_err(|e| anyhow!(format!("decode registrar EK (TPM2B_PUBLIC): {}", e)))?;
+            if registrar_ek_raw.len() <= 2 {
+                bail!("Invalid registrar EK (TPM2B_PUBLIC) length (<= 2)");
+            }
+
+            // Prefer comparing the TPMT_PUBLIC directly. SVSM-backed vTPMs
+            // have an ephemeral EK and normally do not have a manufacturer EK
+            // certificate, while the Keylime registrar still records ek_tpm
+            // after credential activation.
+            let mut ek_bound = false;
+            if let Some(evidence_ek_b64) = &tpm_evidence.ek_pubkey {
+                let evidence_ek_raw = engine
+                    .decode(evidence_ek_b64)
+                    .map_err(|e| anyhow!(format!("decode evidence EK (TPMT_PUBLIC): {}", e)))?;
+                if registrar_ek_raw[2..] != evidence_ek_raw {
+                    bail!("EK public key mismatch with keylime registrar");
+                }
+                ek_bound = true;
+            }
+
+            // Preserve compatibility with physical TPM evidence that carries
+            // an EK certificate but predates the ek_pubkey field.
+            if let Some(evidence_ek_pem) = &tpm_evidence.ek_cert {
+                let evidence_ek_der = X509::from_pem(evidence_ek_pem.as_bytes())
+                    .map_err(|e| anyhow!(format!("parse evidence EK cert (PEM): {}", e)))?
+                    .to_der()
+                    .map_err(|e| anyhow!(format!("encode evidence EK cert (DER): {}", e)))?;
+                let registrar_ek_der = engine
+                    .decode(ekcert_b64.context(
+                        "Keylime registrar response is missing ekcert required by TPM evidence",
+                    )?)
+                    .map_err(|e| {
+                        anyhow!(format!("decode registrar EK cert (base64 DER): {}", e))
+                    })?;
+                if registrar_ek_der != evidence_ek_der {
+                    bail!("EK certificate mismatch with keylime registrar");
+                }
+                ek_bound = true;
+            }
+
+            if !ek_bound {
+                bail!("TPM evidence contains neither an EK public key nor an EK certificate");
             }
 
             // Compare AK public key (registrar TPM2B_PUBLIC vs evidence PEM)
@@ -111,9 +148,6 @@ impl Verifier for TpmVerifier {
             if registrar_ak.public_key_to_der()? != evidence_ak.public_key_to_der()? {
                 bail!("AK public key mismatch with keylime registrar");
             }
-
-            // Silence unused ek_tpm_b64 for now
-            let _ = ek_tpm_b64;
         }
 
         // Verify Quote and PCRs
@@ -125,12 +159,236 @@ impl Verifier for TpmVerifier {
             }
         }
 
-        // TODO: Verify integrity of Eventlogs
+        verify_eventlog_integrity(&tpm_evidence)?;
 
         // Parse Evidence
         let claims = parse_tpm_evidence(tpm_evidence)?;
         Ok((claims, "cpu".to_string()))
     }
+}
+
+#[derive(Clone, Copy)]
+enum PcrBank {
+    Sha1,
+    Sha256,
+}
+
+impl PcrBank {
+    fn quote_key(self) -> &'static str {
+        match self {
+            Self::Sha1 => "SHA1",
+            Self::Sha256 => "SHA256",
+        }
+    }
+
+    fn eventlog_name(self) -> &'static str {
+        match self {
+            Self::Sha1 => "TPM_ALG_SHA1",
+            Self::Sha256 => "TPM_ALG_SHA256",
+        }
+    }
+
+    fn digest_len(self) -> usize {
+        match self {
+            Self::Sha1 => 20,
+            Self::Sha256 => 32,
+        }
+    }
+
+    fn extend(self, current: &[u8], digest: &[u8]) -> Result<Vec<u8>> {
+        if current.len() != self.digest_len() || digest.len() != self.digest_len() {
+            bail!(
+                "Invalid {} PCR/digest length: {}/{}",
+                self.quote_key(),
+                current.len(),
+                digest.len()
+            );
+        }
+
+        Ok(match self {
+            Self::Sha1 => {
+                let mut hasher = Sha1::new();
+                hasher.update(current);
+                hasher.update(digest);
+                hasher.finalize().to_vec()
+            }
+            Self::Sha256 => {
+                let mut hasher = Sha256::new();
+                hasher.update(current);
+                hasher.update(digest);
+                hasher.finalize().to_vec()
+            }
+        })
+    }
+}
+
+type ReplayedPcrs = HashMap<u32, Vec<u8>>;
+
+fn extend_replayed_pcr(
+    pcrs: &mut ReplayedPcrs,
+    index: u32,
+    bank: PcrBank,
+    digest: &[u8],
+) -> Result<()> {
+    let current = pcrs
+        .entry(index)
+        .or_insert_with(|| vec![0; bank.digest_len()]);
+    *current = bank.extend(current, digest)?;
+    Ok(())
+}
+
+fn replay_tcg_eventlog(eventlog: &Eventlog, bank: PcrBank, pcrs: &mut ReplayedPcrs) -> Result<()> {
+    for event in &eventlog.log {
+        // Informational events are logged but are not extended into a PCR.
+        if event.event_type == "EV_NO_ACTION" {
+            continue;
+        }
+
+        if let Some(digest) = event
+            .digests
+            .iter()
+            .find(|digest| digest.algorithm == bank.eventlog_name())
+        {
+            extend_replayed_pcr(
+                pcrs,
+                event.target_measurement_registry,
+                bank,
+                &digest.digest,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn tcg_algorithm_for_bank(bank: PcrBank) -> TcgAlgorithm {
+    match bank {
+        PcrBank::Sha1 => TcgAlgorithm::Sha1,
+        PcrBank::Sha256 => TcgAlgorithm::Sha256,
+    }
+}
+
+/// Replay a crypto-agile TCG2 log. A TPM2 `StartupLocality` EV_NO_ACTION
+/// event changes the initial value of PCR 0 without being extended, so it must
+/// be handled explicitly before normal event replay.
+fn replay_cc_eventlog(
+    eventlog: &CcEventLog,
+    bank: PcrBank,
+    pcrs: &mut ReplayedPcrs,
+    honor_startup_locality: bool,
+) -> Result<()> {
+    const STARTUP_LOCALITY_SIGNATURE: &[u8] = b"StartupLocality\0";
+
+    for event in &eventlog.log {
+        if event.event_type == TcgEventType::EvNoAction {
+            if honor_startup_locality && event.index == 0 {
+                let event_data = base64::engine::general_purpose::STANDARD
+                    .decode(&event.event)
+                    .context("Decode EV_NO_ACTION event data")?;
+                if event_data.starts_with(STARTUP_LOCALITY_SIGNATURE)
+                    && event_data.len() == STARTUP_LOCALITY_SIGNATURE.len() + 1
+                {
+                    if pcrs.contains_key(&0) {
+                        bail!("TPM StartupLocality event appears after PCR 0 was extended");
+                    }
+                    let mut initial = vec![0; bank.digest_len()];
+                    let last = initial.len() - 1;
+                    initial[last] = event_data[STARTUP_LOCALITY_SIGNATURE.len()];
+                    pcrs.insert(0, initial);
+                }
+            }
+            continue;
+        }
+
+        if let Some(digest) = event
+            .digests
+            .iter()
+            .find(|digest| digest.alg == tcg_algorithm_for_bank(bank))
+        {
+            extend_replayed_pcr(pcrs, event.index, bank, &digest.digest)?;
+        }
+    }
+    Ok(())
+}
+
+fn replay_bios_eventlog(eventlog: &BiosEventlog, pcrs: &mut ReplayedPcrs) -> Result<()> {
+    for event in &eventlog.log {
+        if event.event_type == "EV_NO_ACTION" {
+            continue;
+        }
+        extend_replayed_pcr(pcrs, event.pcr_index, PcrBank::Sha1, &event.digest)?;
+    }
+    Ok(())
+}
+
+fn check_replayed_pcrs(
+    quote: &TpmQuote,
+    bank: PcrBank,
+    replayed_pcrs: &ReplayedPcrs,
+) -> Result<()> {
+    for (index, replayed) in replayed_pcrs {
+        let quoted = quote
+            .pcrs
+            .get(*index as usize)
+            .ok_or_else(|| anyhow!("{} quote is missing PCR {index}", bank.quote_key()))?;
+        let quoted = hex::decode(quoted)
+            .with_context(|| format!("Decode quoted {} PCR {index}", bank.quote_key()))?;
+        if quoted != *replayed {
+            bail!(
+                "{} eventlog replay mismatch for PCR {index}: replayed {}, quoted {}",
+                bank.quote_key(),
+                hex::encode(replayed),
+                hex::encode(quoted)
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Verify that every PCR represented by the supplied boot/AA event logs
+/// replays to the value protected by the TPM Quote. An event log that cannot be
+/// parsed is rejected instead of being treated as an informational claim.
+fn verify_eventlog_integrity(evidence: &TpmEvidence) -> Result<()> {
+    let engine = base64::engine::general_purpose::STANDARD;
+    let mut sha1_pcrs = ReplayedPcrs::new();
+    let mut sha256_pcrs = ReplayedPcrs::new();
+
+    if let Some(encoded) = &evidence.eventlog {
+        let raw = engine.decode(encoded).context("Decode TPM boot eventlog")?;
+        if let std::result::Result::Ok(eventlog) = CcEventLog::try_from(raw.clone()) {
+            replay_cc_eventlog(&eventlog, PcrBank::Sha1, &mut sha1_pcrs, true)?;
+            replay_cc_eventlog(&eventlog, PcrBank::Sha256, &mut sha256_pcrs, true)?;
+        } else if let std::result::Result::Ok(eventlog) = Eventlog::try_from(raw.clone()) {
+            replay_tcg_eventlog(&eventlog, PcrBank::Sha1, &mut sha1_pcrs)?;
+            replay_tcg_eventlog(&eventlog, PcrBank::Sha256, &mut sha256_pcrs)?;
+        } else if let std::result::Result::Ok(eventlog) = BiosEventlog::try_from(raw) {
+            replay_bios_eventlog(&eventlog, &mut sha1_pcrs)?;
+        } else {
+            bail!("Failed to parse TPM boot eventlog for integrity verification");
+        }
+    }
+
+    if let Some(encoded) = &evidence.aa_eventlog {
+        let raw = engine.decode(encoded).context("Decode AA eventlog")?;
+        let eventlog = CcEventLog::try_from(raw).context("Parse AA eventlog")?;
+        replay_cc_eventlog(&eventlog, PcrBank::Sha256, &mut sha256_pcrs, false)?;
+    }
+
+    if !sha1_pcrs.is_empty() {
+        let quote = evidence
+            .quote
+            .get(PcrBank::Sha1.quote_key())
+            .context("TPM evidence has a SHA1 eventlog but no SHA1 quote")?;
+        check_replayed_pcrs(quote, PcrBank::Sha1, &sha1_pcrs)?;
+    }
+    if !sha256_pcrs.is_empty() {
+        let quote = evidence
+            .quote
+            .get(PcrBank::Sha256.quote_key())
+            .context("TPM evidence has a SHA256 eventlog but no SHA256 quote")?;
+        check_replayed_pcrs(quote, PcrBank::Sha256, &sha256_pcrs)?;
+    }
+
+    Ok(())
 }
 
 #[allow(dead_code)]
@@ -173,6 +431,10 @@ fn parse_tpm_evidence(tpm_evidence: TpmEvidence) -> Result<TeeEvidenceParsedClai
     let mut parsed_claims = Map::new();
     let engine = base64::engine::general_purpose::STANDARD;
 
+    if let Some(ek_pubkey) = tpm_evidence.ek_pubkey {
+        parsed_claims.insert("ek_pubkey".to_string(), Value::String(ek_pubkey));
+    }
+
     // Parse EK certificate issuer
     if let Some(ek_cert) = tpm_evidence.ek_cert {
         let ek_cert_x509 = X509::from_pem(ek_cert.as_bytes())?;
@@ -213,22 +475,54 @@ fn parse_tpm_evidence(tpm_evidence: TpmEvidence) -> Result<TeeEvidenceParsedClai
             "report_data".to_string(),
             serde_json::Value::String(hex::encode(tpm_quote.extra_data().value())),
         );
+    }
 
-        // for (index, pcr_digest) in quote.pcrs.iter().enumerate() {
-        //     let key_name = format!("{algorithm}.pcr{index}");
-        //     let digest_string = hex::encode(pcr_digest.clone());
-        //     parsed_claims.insert(key_name, serde_json::Value::String(digest_string));
-        // }
+    for (algorithm, quote) in &tpm_evidence.quote {
+        for (index, pcr_digest) in quote.pcrs.iter().enumerate() {
+            parsed_claims.insert(
+                format!("pcrs.{algorithm}.{index}"),
+                Value::String(pcr_digest.clone()),
+            );
+        }
     }
 
     // Parse TCG Eventlogs
     if let Some(b64_eventlog) = tpm_evidence.eventlog {
         let eventlog_bytes = engine.decode(b64_eventlog)?;
 
-        if let Result::Ok(eventlog) = Eventlog::try_from(eventlog_bytes.clone()) {
+        if let Result::Ok(eventlog) = CcEventLog::try_from(eventlog_bytes.clone()) {
+            log::info!("TCG2 Eventlog parsed successfully");
+            for event in eventlog.log {
+                let event_type = serde_json::to_value(event.event_type)?
+                    .as_str()
+                    .context("TCG event type did not serialize as a string")?
+                    .to_string();
+                let event_desc = engine.decode(event.event)?;
+                let event_data = match String::from_utf8(event_desc.clone()) {
+                    Result::Ok(d) => d,
+                    Result::Err(_) => hex::encode(event_desc),
+                };
+                for digest in event.digests {
+                    let algorithm = serde_json::to_value(digest.alg)?
+                        .as_str()
+                        .context("TCG digest algorithm did not serialize as a string")?
+                        .to_string();
+                    parse_measurements_from_event(
+                        &mut parsed_claims,
+                        &event_type,
+                        &event_data,
+                        &algorithm,
+                        &digest.digest,
+                    )?;
+                }
+            }
+        } else if let Result::Ok(eventlog) = Eventlog::try_from(eventlog_bytes.clone()) {
             log::info!("TCG Eventlog parsed successfully");
             // Process TCG format event log
             for event in eventlog.log {
+                let Some(first_digest) = event.digests.first() else {
+                    continue;
+                };
                 let event_desc = &event.event_desc;
                 let event_data = match String::from_utf8(event_desc.clone()) {
                     Result::Ok(d) => d,
@@ -239,14 +533,14 @@ fn parse_tpm_evidence(tpm_evidence: TpmEvidence) -> Result<TeeEvidenceParsedClai
                 // - Replace underscores with hyphens
                 // - If there is no hyphen between letters and digits, insert one
                 //   Examples: "SHA256" -> "SHA-256", "SHA_384" -> "SHA-384", "SM3_256" -> "SM3-256"
-                let algo_clean = event.digests[0].algorithm.trim_start_matches("TPM_ALG_");
+                let algo_clean = first_digest.algorithm.trim_start_matches("TPM_ALG_");
                 let mut event_digest_algorithm = algo_clean.replace('_', "-");
                 if !event_digest_algorithm.contains('-') {
                     if let Some(idx) = event_digest_algorithm.find(|c: char| c.is_ascii_digit()) {
                         event_digest_algorithm.insert(idx, '-');
                     }
                 }
-                let event_digest = &event.digests[0].digest;
+                let event_digest = &first_digest.digest;
 
                 parse_measurements_from_event(
                     &mut parsed_claims,
@@ -288,6 +582,8 @@ fn parse_tpm_evidence(tpm_evidence: TpmEvidence) -> Result<TeeEvidenceParsedClai
         let aa_ccel_data = base64::engine::general_purpose::STANDARD.decode(aael)?;
         let aa_ccel = CcEventLog::try_from(aa_ccel_data)?;
         let result = serde_json::to_value(aa_ccel.clone().log)?;
+        // Preserve the existing claim key used by Trustee policies. The
+        // integrity check above has already replayed these AA runtime events.
         parsed_claims.insert("uefi_event_logs".to_string(), result);
     }
 
@@ -441,8 +737,6 @@ impl TpmQuote {
     }
 
     fn check_pcrs(&self, pcr_algorithm: &str) -> Result<()> {
-        use sha2::{Digest, Sha256};
-
         let attest = Attest::unmarshall(
             &base64::engine::general_purpose::STANDARD.decode(self.attest_body.clone())?,
         )?;
@@ -516,5 +810,56 @@ fn pkey_from_tpm2b_public(tpm2b_public: &[u8]) -> Result<PKey<openssl::pkey::Pub
             Ok(PKey::from_ec_key(ec_key)?)
         }
         _ => bail!("Unsupported or invalid TPM public key"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replayed_pcr_is_checked_against_quote() {
+        let event_digest = Sha256::digest(b"runtime event").to_vec();
+        let mut replayed = ReplayedPcrs::new();
+        extend_replayed_pcr(&mut replayed, 17, PcrBank::Sha256, &event_digest).unwrap();
+
+        let mut quoted_pcrs = vec!["00".repeat(32); 24];
+        quoted_pcrs[17] = hex::encode(replayed.get(&17).unwrap());
+        let quote = TpmQuote {
+            attest_body: String::new(),
+            attest_sig: String::new(),
+            pcrs: quoted_pcrs,
+        };
+
+        check_replayed_pcrs(&quote, PcrBank::Sha256, &replayed).unwrap();
+
+        let mut tampered = replayed;
+        tampered.get_mut(&17).unwrap()[0] ^= 1;
+        let err = check_replayed_pcrs(&quote, PcrBank::Sha256, &tampered).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("eventlog replay mismatch for PCR 17"));
+    }
+
+    #[test]
+    fn startup_locality_initializes_pcr_zero() {
+        let mut event_data = b"StartupLocality\0".to_vec();
+        event_data.push(3);
+        let eventlog = CcEventLog {
+            log: vec![::eventlog::EventlogEntry {
+                details: ::eventlog::EventDetails::empty(),
+                digests: vec![],
+                event: base64::engine::general_purpose::STANDARD.encode(event_data),
+                index: 0,
+                event_type: TcgEventType::EvNoAction,
+            }],
+        };
+        let mut replayed = ReplayedPcrs::new();
+
+        replay_cc_eventlog(&eventlog, PcrBank::Sha256, &mut replayed, true).unwrap();
+
+        let mut expected = vec![0; 32];
+        expected[31] = 3;
+        assert_eq!(replayed.get(&0), Some(&expected));
     }
 }

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -93,6 +93,11 @@ OpenAnolis提供了一个简单易用的工具[cryptpilot](https://github.com/op
 
 当 SNP guest 使用 Coconut SVSM vTPM，且 guest 内核提供 `tpm_svsm` 与 TSM SVSM attestation ABI 时，Attestation Agent 会把 SNP 作为主证据、TPM Quote 作为附加设备证据，并把 AA 动态事件扩展到 vTPM PCR。
 
+同一版本也兼容不带 SVSM 的纯 SEV-SNP guest：AA 只提交普通 SNP
+evidence，Trustee 按既有 SNP verifier 校验证书链、报告签名、VMPL、TCB 与
+`REPORT_DATA`。此时不会要求 `svsm_manifest`、TPM Quote 或 event log；只有同一
+次 evaluation 同时出现 SNP 与 TPM evidence 时，才启用下面的组合绑定规则。
+
 Trustee 在 Attestation Service 核心层验证这组组合证据，因此经 KBS、
 直接访问 RESTful AS 或直接访问 gRPC AS 都遵循相同的安全语义：
 

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -93,11 +93,21 @@ OpenAnolis提供了一个简单易用的工具[cryptpilot](https://github.com/op
 
 当 SNP guest 使用 Coconut SVSM vTPM，且 guest 内核提供 `tpm_svsm` 与 TSM SVSM attestation ABI 时，Attestation Agent 会把 SNP 作为主证据、TPM Quote 作为附加设备证据，并把 AA 动态事件扩展到 vTPM PCR。
 
-Trustee 按以下顺序验证这组组合证据：
+Trustee 在 Attestation Service 核心层验证这组组合证据，因此经 KBS、
+直接访问 RESTful AS 或直接访问 gRPC AS 都遵循相同的安全语义：
 
 1. 验证 VMPL0 SNP report 的签名、证书链和 challenge 绑定；其中 `REPORT_DATA = SHA-512(nonce || vTPM manifest)`。
-2. 验证 manifest 中的 EK `TPMT_PUBLIC` 与 TPM evidence 携带的 EK 完全一致，阻止宿主注入 swtpm 或跨 guest 拼接证据。
-3. 验证 TPM Quote 的签名、nonce、PCR digest，并回放 UEFI 启动日志和 AA 动态事件日志，逐项比对 Quote 中的 PCR。
+2. 验证 SNP runtime data 覆盖的 TPM evidence 与本次提交给 AS 的 TPM evidence 完全一致，并确认两者使用相同的基础 runtime data，阻止替换或跨 guest 拼接证据。
+3. 验证 manifest 中的 EK `TPMT_PUBLIC` 与 TPM evidence 携带的 EK 完全一致。
+4. 验证 TPM Quote 的签名、nonce、PCR digest，并回放 UEFI 启动日志和 AA 动态事件日志，逐项比对 Quote 中的 PCR。
+
+直连 RESTful AS 或 gRPC AS 时，应在同一个请求中提交 SNP、TPM 两条
+`verification_requests`。SNP 的 structured runtime data 使用
+`additional-evidence` 携带序列化后的 TPM evidence；TPM 的 structured runtime
+data 则是去掉 `additional-evidence` 后的同一组基础字段。单独提交 SNP 或 TPM
+证据的既有用法不受影响；只有同一次 evaluation 同时包含二者时才强制上述组合绑定。
+生产环境应先通过 AS challenge API 获取签名 challenge，并把其中的 JWT 作为
+`challenge_token` 放入这组基础 runtime data，使 AS 同时校验 challenge 的签名和有效期。
 
 Keylime 是可选增强：没有 `keylime_agent_uuid` 时，上述主链路仍会完整执行；只有 evidence 提供 UUID 时，TPM verifier 才查询 registrar，并额外验证已激活 AK 与 EK 的绑定关系。SVSM vTPM 的 EK 通常没有厂商证书，因此该路径优先比较 registrar 的 `ek_tpm` 与 evidence 的 EK 公钥；物理 TPM 仍兼容 EK 证书比较。
 

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -89,6 +89,18 @@ OpenAnolis提供了一个简单易用的工具[cryptpilot](https://github.com/op
 
 如果本地不存在可复用的 AK，`Hygon TPM attester` 会回退为临时生成新的 SM2 AK，仅完成主链路 quote 证明，不执行 registrar 绑定校验。
 
+### SEV-SNP + SVSM vTPM 动态度量
+
+当 SNP guest 使用 Coconut SVSM vTPM，且 guest 内核提供 `tpm_svsm` 与 TSM SVSM attestation ABI 时，Attestation Agent 会把 SNP 作为主证据、TPM Quote 作为附加设备证据，并把 AA 动态事件扩展到 vTPM PCR。
+
+Trustee 按以下顺序验证这组组合证据：
+
+1. 验证 VMPL0 SNP report 的签名、证书链和 challenge 绑定；其中 `REPORT_DATA = SHA-512(nonce || vTPM manifest)`。
+2. 验证 manifest 中的 EK `TPMT_PUBLIC` 与 TPM evidence 携带的 EK 完全一致，阻止宿主注入 swtpm 或跨 guest 拼接证据。
+3. 验证 TPM Quote 的签名、nonce、PCR digest，并回放 UEFI 启动日志和 AA 动态事件日志，逐项比对 Quote 中的 PCR。
+
+Keylime 是可选增强：没有 `keylime_agent_uuid` 时，上述主链路仍会完整执行；只有 evidence 提供 UUID 时，TPM verifier 才查询 registrar，并额外验证已激活 AK 与 EK 的绑定关系。SVSM vTPM 的 EK 通常没有厂商证书，因此该路径优先比较 registrar 的 `ek_tpm` 与 evidence 的 EK 公钥；物理 TPM 仍兼容 EK 证书比较。
+
 ### 平台特定
 
 平台特定的证据字段内容已经在Trustee内部验证硬件证书和硬件签名时做过了一轮验证，确保其真实可信，如果想要在远程证明策略中对关注的字段再次做一次自定义的验证，就需要设置对应的参考值。

--- a/kbs/src/attestation/backend.rs
+++ b/kbs/src/attestation/backend.rs
@@ -57,45 +57,6 @@ pub struct CompositeEvidence {
     additional_evidence: String,
 }
 
-/// Bind an SNP guest's additional TPM evidence to the vTPM service manifest
-/// covered by its VMPL0 SVSM report. This rejects host-injected swtpm evidence
-/// and cross-guest evidence splicing before the individual verifiers run.
-fn verify_snp_svsm_vtpm_binding(
-    primary_tee: Tee,
-    primary_evidence: &TeeEvidence,
-    additional_evidence: &str,
-) -> anyhow::Result<()> {
-    if primary_tee != Tee::Snp || additional_evidence.is_empty() {
-        return Ok(());
-    }
-
-    let additional: HashMap<Tee, TeeEvidence> = serde_json::from_str(additional_evidence)
-        .context("parse additional evidence for SNP/SVSM binding")?;
-    let Some(tpm_evidence) = additional.get(&Tee::Tpm) else {
-        return Ok(());
-    };
-
-    let manifest = primary_evidence
-        .get("svsm_manifest")
-        .and_then(serde_json::Value::as_str)
-        .context("SNP evidence contains TPM evidence without an SVSM vTPM manifest")?;
-    let ek_public = tpm_evidence
-        .get("ek_pubkey")
-        .and_then(serde_json::Value::as_str)
-        .context("TPM evidence is missing the EK public key")?;
-    let manifest = STANDARD
-        .decode(manifest)
-        .context("decode SVSM vTPM manifest")?;
-    let ek_public = STANDARD
-        .decode(ek_public)
-        .context("decode TPM EK public key")?;
-    if manifest.is_empty() || manifest != ek_public {
-        bail!("TPM EK public key does not match the vTPM manifest bound by the VMPL0 SNP report");
-    }
-
-    Ok(())
-}
-
 #[derive(Deserialize)]
 pub struct RuntimeData {
     pub nonce: String,
@@ -433,11 +394,6 @@ impl AttestationService {
         let composite_evidence: CompositeEvidence =
             serde_json::from_value(attestation.tee_evidence)
                 .context("failed to parse composite evidence")?;
-        verify_snp_svsm_vtpm_binding(
-            tee,
-            &composite_evidence.primary_evidence,
-            &composite_evidence.additional_evidence,
-        )?;
         let mut evidence_to_verify: Vec<IndependentEvidence> = vec![];
 
         let runtime_data: RuntimeData = serde_json::from_value(attestation.runtime_data)
@@ -549,36 +505,6 @@ impl AttestationService {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn snp_svsm_manifest_binds_tpm_ek() {
-        let ek = STANDARD.encode(b"marshalled-ek-public");
-        let primary = json!({ "svsm_manifest": ek.clone() });
-        let additional =
-            serde_json::to_string(&HashMap::from([(Tee::Tpm, json!({ "ek_pubkey": ek }))]))
-                .unwrap();
-
-        verify_snp_svsm_vtpm_binding(Tee::Snp, &primary, &additional).unwrap();
-
-        let wrong = STANDARD.encode(b"another-ek");
-        let additional =
-            serde_json::to_string(&HashMap::from([(Tee::Tpm, json!({ "ek_pubkey": wrong }))]))
-                .unwrap();
-        assert!(verify_snp_svsm_vtpm_binding(Tee::Snp, &primary, &additional).is_err());
-    }
-
-    #[test]
-    fn snp_rejects_tpm_without_svsm_manifest() {
-        let additional = serde_json::to_string(&HashMap::from([(
-            Tee::Tpm,
-            json!({
-                "ek_pubkey": STANDARD.encode(b"ek"),
-                "keylime_agent_uuid": "agent-1"
-            }),
-        )]))
-        .unwrap();
-        assert!(verify_snp_svsm_vtpm_binding(Tee::Snp, &json!({}), &additional).is_err());
-    }
 
     #[tokio::test]
     async fn test_make_nonce() {

--- a/kbs/src/attestation/backend.rs
+++ b/kbs/src/attestation/backend.rs
@@ -57,6 +57,45 @@ pub struct CompositeEvidence {
     additional_evidence: String,
 }
 
+/// Bind an SNP guest's additional TPM evidence to the vTPM service manifest
+/// covered by its VMPL0 SVSM report. This rejects host-injected swtpm evidence
+/// and cross-guest evidence splicing before the individual verifiers run.
+fn verify_snp_svsm_vtpm_binding(
+    primary_tee: Tee,
+    primary_evidence: &TeeEvidence,
+    additional_evidence: &str,
+) -> anyhow::Result<()> {
+    if primary_tee != Tee::Snp || additional_evidence.is_empty() {
+        return Ok(());
+    }
+
+    let additional: HashMap<Tee, TeeEvidence> = serde_json::from_str(additional_evidence)
+        .context("parse additional evidence for SNP/SVSM binding")?;
+    let Some(tpm_evidence) = additional.get(&Tee::Tpm) else {
+        return Ok(());
+    };
+
+    let manifest = primary_evidence
+        .get("svsm_manifest")
+        .and_then(serde_json::Value::as_str)
+        .context("SNP evidence contains TPM evidence without an SVSM vTPM manifest")?;
+    let ek_public = tpm_evidence
+        .get("ek_pubkey")
+        .and_then(serde_json::Value::as_str)
+        .context("TPM evidence is missing the EK public key")?;
+    let manifest = STANDARD
+        .decode(manifest)
+        .context("decode SVSM vTPM manifest")?;
+    let ek_public = STANDARD
+        .decode(ek_public)
+        .context("decode TPM EK public key")?;
+    if manifest.is_empty() || manifest != ek_public {
+        bail!("TPM EK public key does not match the vTPM manifest bound by the VMPL0 SNP report");
+    }
+
+    Ok(())
+}
+
 #[derive(Deserialize)]
 pub struct RuntimeData {
     pub nonce: String,
@@ -394,6 +433,11 @@ impl AttestationService {
         let composite_evidence: CompositeEvidence =
             serde_json::from_value(attestation.tee_evidence)
                 .context("failed to parse composite evidence")?;
+        verify_snp_svsm_vtpm_binding(
+            tee,
+            &composite_evidence.primary_evidence,
+            &composite_evidence.additional_evidence,
+        )?;
         let mut evidence_to_verify: Vec<IndependentEvidence> = vec![];
 
         let runtime_data: RuntimeData = serde_json::from_value(attestation.runtime_data)
@@ -505,6 +549,36 @@ impl AttestationService {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn snp_svsm_manifest_binds_tpm_ek() {
+        let ek = STANDARD.encode(b"marshalled-ek-public");
+        let primary = json!({ "svsm_manifest": ek.clone() });
+        let additional =
+            serde_json::to_string(&HashMap::from([(Tee::Tpm, json!({ "ek_pubkey": ek }))]))
+                .unwrap();
+
+        verify_snp_svsm_vtpm_binding(Tee::Snp, &primary, &additional).unwrap();
+
+        let wrong = STANDARD.encode(b"another-ek");
+        let additional =
+            serde_json::to_string(&HashMap::from([(Tee::Tpm, json!({ "ek_pubkey": wrong }))]))
+                .unwrap();
+        assert!(verify_snp_svsm_vtpm_binding(Tee::Snp, &primary, &additional).is_err());
+    }
+
+    #[test]
+    fn snp_rejects_tpm_without_svsm_manifest() {
+        let additional = serde_json::to_string(&HashMap::from([(
+            Tee::Tpm,
+            json!({
+                "ek_pubkey": STANDARD.encode(b"ek"),
+                "keylime_agent_uuid": "agent-1"
+            }),
+        )]))
+        .unwrap();
+        assert!(verify_snp_svsm_vtpm_binding(Tee::Snp, &json!({}), &additional).is_err());
+    }
 
     #[tokio::test]
     async fn test_make_nonce() {


### PR DESCRIPTION
## Summary

- verify the SVSM VMPL0 report binding as `REPORT_DATA = SHA-512(nonce || service manifest)`
- enforce SNP/SVSM vTPM composite bindings once in the Attestation Service core, so KBS, RESTful AS, and gRPC AS share the same behavior
- require the top-level TPM evidence to exactly match the TPM evidence covered by the SNP runtime data, and require both requests to use the same base runtime data
- bind the TPM EK to the vTPM service manifest and reject host-injected TPM or cross-guest evidence splicing
- verify TPM quote signatures, nonces, PCR digests, and replay the firmware event log followed by the AA runtime event log
- keep standalone SNP/TPM evidence compatible and keep Keylime AK/EK validation optional unless `keylime_agent_uuid` is present
- expose verified PCR and SVSM claims for policy evaluation

Companion attester change: https://github.com/inclavare-containers/guest-components/pull/103

## Validation

Local:

- `cargo test -p attestation-service -p verifier`: AS 31 passed; REST 5 passed; RVPS E2E 2 passed; verifier 57 passed, 3 ignored
- `cargo test -p kbs`: 47 passed
- composite-binding suite: 7 passed, including a regression for plain SNP with empty additional evidence
- `cargo clippy -p attestation-service -p verifier -- -D warnings -A clippy::derive_partial_eq_without_eq`: passed
- `cargo clippy -p kbs -- -D warnings`: passed

Real AMD EPYC Turin SEV-SNP E2E with Coconut SVSM and Fedora 44 (`6.19.10-300.fc44.x86_64`):

- guest ran at VMPL2 and exposed `/dev/sev-guest`, `/dev/tpm0`, `/dev/tpmrm0`, `sev_guest`, `tsm_report`, and `tpm_svsm`
- an AA runtime event extended PCR10 from zero to `02f713ae04900eeb2a9b569538fe8cf5536d25934979cf01316e81676dac0d35`
- KBS accepted the signed SNP + TPM composite evidence and logged both verifier passes
- direct RESTful AS and gRPC AS accepted the same real evidence with a fresh signed AS challenge; both tokens contained the AAEL event and updated PCR10
- changing the SVSM manifest, replacing the top-level TPM evidence, or changing the TPM base runtime data was rejected before token issuance; REST returned stable binding/invalid-request errors and gRPC returned `Aborted`
- Keylime was intentionally left unset, validating the complete non-Keylime core path

Real plain SEV-SNP compatibility E2E on the same Turin host, without SVSM or TPM:

- current guest-components PR #103 head emitted a version-5 VMPL0 SNP report with no `svsm_manifest` or additional TPM evidence
- KBS built from this PR head accepted the evidence and issued a 1702-byte EAR token
- annotated evidence contained only `snp` claims (measurement, policy, platform and Turin TCB); no `svsm_attestation` or TPM claim was added
- the EAR policy status remained `contraindicated` because the test policy had no allowlisted measurement/TCB values; token issuance and annotated SNP claims confirm cryptographic verification succeeded

The stock Alibaba Cloud Linux 4.0.4 guest was evaluated first. With the recent OVMF required by Coconut, its boot path page-faulted in `\EFI\BOOT\fbx64.efi` before entering Linux, so Fedora 44 was used for the complete guest validation.
