### PR TITLE
verifier/tdx: make cache health age-based

### DIFF
--- a/attestation-service/docs/grpc-as.md
+++ b/attestation-service/docs/grpc-as.md
@@ -52,8 +52,10 @@ for the full configuration precedence, cache state machine, and alerting guide.
 
 Proactive refresh is asynchronous on native AS builds. If every PCCS endpoint
 is unavailable after the cache expiry, AS continues using the cached collateral
-until its signed TCB/QE `nextUpdate` is reached. Refresh failures are logged as
-`tdx_collateral_refresh_failed` and exposed through the generic status RPC:
+and leaves collateral freshness and validity decisions to quote verification.
+Refresh failures are logged as `tdx_collateral_refresh_failed` and exposed as
+`refresh_retrying` before cache expiry or `degraded` after cache expiry through
+the generic status RPC:
 
 ```shell
 grpcurl \

--- a/attestation-service/docs/pccs-resilience.md
+++ b/attestation-service/docs/pccs-resilience.md
@@ -41,25 +41,29 @@ through the cache.
 | Variable | Default | Meaning |
 |----------|---------|---------|
 | `VERIFY_COLLATERAL_CACHE_REFRESH_HOURS` | `72` | Schedule an asynchronous refresh after a successful cache fill. |
-| `VERIFY_COLLATERAL_CACHE_EXPIRE_HOURS` | `168` | Mark the local cache entry stale after this age. `0` disables caching. |
+| `VERIFY_COLLATERAL_CACHE_EXPIRE_HOURS` | `168` | Mark the local cache dependency degraded and make requests refresh synchronously after this age. `0` disables caching. |
 | `VERIFY_COLLATERAL_CACHE_REFRESH_RETRY_SECS` | `3600` | Minimum delay before another refresh after PCCS failure. |
 
 These numeric settings are read from the environment first, then from
 `/etc/sgx_default_qcnl.conf`. If the refresh age is not shorter than the cache
 expiry, AS clamps it to half of the expiry and emits a warning.
 
-The three time boundaries have different purposes:
+The cache policy has two local age boundaries:
 
 1. **Refresh age**: a native AS schedules a background timer as soon as it
    stores collateral. When the timer fires, verification continues with the
    current cache while one refresh runs for that cache key. A request that
    notices an overdue refresh also triggers it as a safety net.
 2. **Cache expiry**: after this local TTL, the next request attempts a blocking
-   refresh. If every PCCS is unavailable, AS falls back to the cached value.
-3. **Collateral validity**: stale fallback is allowed only while the earliest
-   signed TCB Info or QE Identity `nextUpdate` is still in the future. Intel
-   collateral is commonly issued with a validity window of about 30 days, but
-   AS uses the actual signed dates instead of assuming a fixed 30-day value.
+   refresh. If every PCCS is unavailable, AS still passes the cached value to
+   quote verification.
+
+The cache layer deliberately does not use TCB Info or QE Identity `nextUpdate`,
+CRL validity, or certificate validity to decide whether a cached value may be
+used. Those checks belong to quote verification and its policy. Consequently,
+cache expiry means operational degradation, not cryptographic collateral
+expiry, and extending the cache TTL does not change the verifier's security
+policy.
 
 Refreshes for the same key are coalesced. A slow PCCS for one FMSPC does not
 block refreshes for other cache keys. Stable log event names are available for
@@ -99,19 +103,18 @@ of these states:
 | Dependency state | Meaning |
 |------------------|---------|
 | `not_initialized` | This AS process has not verified TDX evidence yet. |
-| `ready` | Cache age is below the proactive refresh threshold. |
-| `refresh_due` | Collateral is usable and refresh is due or running. |
-| `degraded` | Refresh failed or local cache TTL elapsed, but signed collateral remains valid. |
-| `unhealthy` | Signed collateral has passed `nextUpdate`; PCCS recovery is required. |
+| `ready` | Cache age is below the proactive refresh threshold (less than 72 hours by default). |
+| `refresh_due` | Cache age is between refresh and expiry thresholds and proactive refresh is due or running. `refresh_in_progress` distinguishes an active fetch. |
+| `refresh_retrying` | Cache age is between refresh and expiry thresholds, the previous refresh failed, and AS is waiting to retry. |
+| `degraded` | The local cache age has reached the expiry threshold (168 hours by default). The cached value is still passed to quote verification if PCCS is unavailable. |
 
 Useful detail fields include `pccs_urls`, `last_successful_pccs`,
 `last_refresh_attempt_at`, `last_refresh_error`, `refresh_in_progress`,
-`cache_age_seconds`, `collateral_expires_at`, and
-`collateral_valid_for_seconds`. Timestamp fields are Unix seconds.
+`cache_age_seconds`, and `cached_at`. Timestamp fields are Unix seconds.
 
-For alerting, trigger an early operational warning when any dependency becomes
-`degraded` or `last_refresh_error` appears. Trigger a page when it becomes
-`unhealthy` or when `collateral_valid_for_seconds` approaches the team's repair
-SLO. With the defaults, a failed refresh is visible around day 3, the local
-cache TTL is day 7, and stale fallback remains bounded by the collateral's
-signed validity.
+For alerting, trigger an early operational warning when a dependency becomes
+`refresh_retrying` or `last_refresh_error` appears. Escalate when it becomes
+`degraded`. With the defaults, a failed refresh is visible around day 3 and the
+local cache dependency becomes degraded at day 7. Whether verification accepts
+the cached collateral is reported by the normal quote-verification path rather
+than this cache-health API.

--- a/attestation-service/docs/restful-as.md
+++ b/attestation-service/docs/restful-as.md
@@ -52,9 +52,11 @@ for the full configuration precedence, cache state machine, and alerting guide.
 
 Proactive refresh is asynchronous on native AS builds, so verification requests
 continue using the last successful collateral. If all PCCS endpoints are down
-after the cache expiry, the stale cache remains usable until the signed TCB/QE
-`nextUpdate` is reached. Refresh failures are logged with the stable event
-`tdx_collateral_refresh_failed` and exposed by the status API.
+after the cache expiry, the cache layer still passes the cached collateral to
+quote verification; collateral freshness and validity remain verifier-policy
+decisions. Refresh failures are logged with the stable event
+`tdx_collateral_refresh_failed` and exposed by the status API as
+`refresh_retrying` before cache expiry or `degraded` after cache expiry.
 
 `GET /status` returns AS and verifier dependency state without contacting PCCS:
 

--- a/deps/verifier/src/tdx/verify/native.rs
+++ b/deps/verifier/src/tdx/verify/native.rs
@@ -24,10 +24,11 @@
 //! Verification collateral is cached in process by PCCS set, FMSPC and CA type.
 //! `VERIFY_COLLATERAL_CACHE_REFRESH_HOURS` (72 hours by default) proactively
 //! refreshes an entry before `VERIFY_COLLATERAL_CACHE_EXPIRE_HOURS` (168 hours
-//! by default). Refresh failures retain the last successfully verified
-//! collateral. Even after the cache TTL, the old value remains usable while
-//! its signed TCB/QE `nextUpdate` has not passed. Concurrent refreshes are
-//! coalesced per cache key and failures are retried with a bounded backoff.
+//! by default). Refresh failures retain the last successfully fetched
+//! collateral, including after the cache TTL. Collateral freshness remains a
+//! quote-verification policy decision rather than a cache-availability
+//! decision. Concurrent refreshes are coalesced per cache key and failures are
+//! retried with a bounded backoff.
 //!
 //! Scope: the collateral fetch currently supports quotes whose certification
 //! data embeds the PCK certificate chain (PCK cert type 5), which is what cloud
@@ -343,7 +344,6 @@ struct CachedCollateral {
     collateral: QuoteCollateralV3,
     cached_at: Instant,
     cached_at_unix: u64,
-    collateral_expires_at: i64,
     last_successful_pccs: String,
     last_refresh_attempt_at: Option<u64>,
     last_refresh_error: Option<String>,
@@ -355,7 +355,6 @@ enum CacheEntryState {
     Fresh,
     RefreshDue,
     CacheExpired,
-    CollateralExpired,
 }
 
 /// Process-local collateral cache. Per-key refresh locks prevent a slow PCCS
@@ -384,7 +383,6 @@ impl CollateralCache {
         &self,
         key: CollateralCacheKey,
         mut collateral: QuoteCollateralV3,
-        collateral_expires_at: i64,
         successful_pccs: String,
     ) -> Instant {
         // The PCK chain belongs to the current quote and must never be shared
@@ -397,7 +395,6 @@ impl CollateralCache {
                 collateral,
                 cached_at: now,
                 cached_at_unix: unix_now(),
-                collateral_expires_at,
                 last_successful_pccs: successful_pccs,
                 last_refresh_attempt_at: Some(unix_now()),
                 last_refresh_error: None,
@@ -471,34 +468,33 @@ impl CollateralCache {
         }
 
         let now = Instant::now();
-        let now_unix = unix_now() as i64;
         let mut statuses = Vec::with_capacity(entries.len());
         for (key, entry) in entries {
-            let state = classify_cache_entry(&entry, policy, now, now_unix);
+            let state = classify_cache_entry(&entry, policy, now);
             let refresh_lock = self.refresh_lock(&key).await;
             let refresh_in_progress = refresh_lock.try_lock().is_err();
-            let (mut status, mut message) = match state {
+            let (status, message) = match state {
                 CacheEntryState::Fresh => (
                     "ready",
                     "cached collateral is within the proactive refresh interval",
                 ),
-                CacheEntryState::RefreshDue => (
-                    "refresh_due",
-                    "cached collateral is usable and due for proactive refresh",
-                ),
                 CacheEntryState::CacheExpired => (
                     "degraded",
-                    "cache TTL elapsed; signed collateral remains valid as fallback",
+                    "cache TTL elapsed; cached collateral is retained for verification",
                 ),
-                CacheEntryState::CollateralExpired => (
-                    "unhealthy",
-                    "cached collateral has passed its signed nextUpdate",
+                CacheEntryState::RefreshDue if refresh_in_progress => (
+                    "refresh_due",
+                    "cached collateral is usable while proactive refresh is running",
+                ),
+                CacheEntryState::RefreshDue if entry.last_refresh_error.is_some() => (
+                    "refresh_retrying",
+                    "the last PCCS refresh failed; cached collateral is available while waiting to retry",
+                ),
+                CacheEntryState::RefreshDue => (
+                    "refresh_due",
+                    "cached collateral is usable and proactive refresh is due",
                 ),
             };
-            if entry.last_refresh_error.is_some() && status != "unhealthy" {
-                status = "degraded";
-                message = "the last PCCS refresh failed; cached collateral remains available";
-            }
 
             let mut details = BTreeMap::new();
             details.insert("fmspc".into(), json!(key.fmspc));
@@ -509,14 +505,6 @@ impl CollateralCache {
                 json!(entry.cached_at.elapsed().as_secs()),
             );
             details.insert("cached_at".into(), json!(entry.cached_at_unix));
-            details.insert(
-                "collateral_expires_at".into(),
-                json!(entry.collateral_expires_at),
-            );
-            details.insert(
-                "collateral_valid_for_seconds".into(),
-                json!(entry.collateral_expires_at.saturating_sub(now_unix)),
-            );
             details.insert(
                 "last_successful_pccs".into(),
                 json!(entry.last_successful_pccs),
@@ -558,19 +546,14 @@ fn classify_cache_entry(
     entry: &CachedCollateral,
     policy: CollateralCachePolicy,
     now: Instant,
-    now_unix: i64,
 ) -> CacheEntryState {
-    if now_unix >= entry.collateral_expires_at {
-        CacheEntryState::CollateralExpired
+    let age = now.saturating_duration_since(entry.cached_at);
+    if age >= policy.expire_after {
+        CacheEntryState::CacheExpired
+    } else if age >= policy.refresh_after {
+        CacheEntryState::RefreshDue
     } else {
-        let age = now.saturating_duration_since(entry.cached_at);
-        if age >= policy.expire_after {
-            CacheEntryState::CacheExpired
-        } else if age >= policy.refresh_after {
-            CacheEntryState::RefreshDue
-        } else {
-            CacheEntryState::Fresh
-        }
+        CacheEntryState::Fresh
     }
 }
 
@@ -583,25 +566,14 @@ fn cached_collateral(entry: &CachedCollateral, pck_chain: String) -> QuoteCollat
     attach_pck_chain(entry.collateral.clone(), pck_chain)
 }
 
-fn collateral_is_still_valid(entry: &CachedCollateral, now_unix: i64) -> bool {
-    now_unix < entry.collateral_expires_at
-}
-
-fn collateral_expiration(collateral: &QuoteCollateralV3) -> Result<i64> {
-    CollateralDates::parse(collateral)
-        .map(|dates| dates.earliest_expiration_date)
-        .map_err(pccs_bad_response)
-}
-
 async fn fetch_and_store(
     key: &CollateralCacheKey,
     policy: CollateralCachePolicy,
 ) -> Result<QuoteCollateralV3> {
     let (collateral, successful_pccs) =
         fetch_collateral_with_fallback(&key.pccs_base_urls, &key.fmspc, &key.ca).await?;
-    let expires_at = collateral_expiration(&collateral)?;
     let cached_at = collateral_cache()
-        .store_success(key.clone(), collateral.clone(), expires_at, successful_pccs)
+        .store_success(key.clone(), collateral.clone(), successful_pccs)
         .await;
     schedule_refresh_after(key.clone(), policy, cached_at, policy.refresh_after);
     Ok(collateral)
@@ -686,9 +658,7 @@ async fn trigger_background_refresh(key: CollateralCacheKey, policy: CollateralC
         let Some(entry) = collateral_cache().lookup(&key).await else {
             return;
         };
-        if classify_cache_entry(&entry, policy, Instant::now(), unix_now() as i64)
-            == CacheEntryState::Fresh
-        {
+        if classify_cache_entry(&entry, policy, Instant::now()) == CacheEntryState::Fresh {
             return;
         }
 
@@ -725,13 +695,11 @@ async fn refresh_blocking_or_use_stale(
     let _refresh_guard = refresh_lock.lock().await;
 
     if let Some(entry) = collateral_cache().lookup(&key).await {
-        let state = classify_cache_entry(&entry, policy, Instant::now(), unix_now() as i64);
+        let state = classify_cache_entry(&entry, policy, Instant::now());
         if state == CacheEntryState::Fresh {
             return Ok(cached_collateral(&entry, pck_chain));
         }
-        if !collateral_cache().retry_allowed(&key).await
-            && state != CacheEntryState::CollateralExpired
-        {
+        if !collateral_cache().retry_allowed(&key).await {
             return Ok(cached_collateral(&entry, pck_chain));
         }
     }
@@ -744,16 +712,13 @@ async fn refresh_blocking_or_use_stale(
                 .record_refresh_failure(&key, &error, policy.retry_after)
                 .await;
             if let Some(entry) = collateral_cache().lookup(&key).await {
-                if collateral_is_still_valid(&entry, unix_now() as i64) {
-                    warn!(
-                        "event=tdx_collateral_stale_fallback fmspc={} ca={} cache_age_seconds={} collateral_valid_for_seconds={} error={error:#}",
-                        key.fmspc,
-                        key.ca,
-                        entry.cached_at.elapsed().as_secs(),
-                        entry.collateral_expires_at.saturating_sub(unix_now() as i64)
-                    );
-                    return Ok(cached_collateral(&entry, pck_chain));
-                }
+                warn!(
+                    "event=tdx_collateral_stale_fallback fmspc={} ca={} cache_age_seconds={} error={error:#}",
+                    key.fmspc,
+                    key.ca,
+                    entry.cached_at.elapsed().as_secs()
+                );
+                return Ok(cached_collateral(&entry, pck_chain));
             }
             Err(error)
         }
@@ -773,7 +738,7 @@ async fn get_collateral(
     }
 
     if let Some(entry) = collateral_cache().lookup(&key).await {
-        match classify_cache_entry(&entry, policy, Instant::now(), unix_now() as i64) {
+        match classify_cache_entry(&entry, policy, Instant::now()) {
             CacheEntryState::Fresh => {
                 debug!(
                     "dcap-qvl backend: collateral cache hit fmspc={} ca={}",
@@ -798,7 +763,7 @@ async fn get_collateral(
                 ))]
                 return refresh_blocking_or_use_stale(key, pck_chain, policy).await;
             }
-            CacheEntryState::CacheExpired | CacheEntryState::CollateralExpired => {}
+            CacheEntryState::CacheExpired => {}
         }
     }
 
@@ -1396,12 +1361,11 @@ fn rfind_sub(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::{
-        cached_collateral, classify_cache_entry, collateral_cache, collateral_is_still_valid,
-        fetch_collateral_with_fallback, normalize_pccs_base_url, parse_pccs_urls,
-        parse_qcnl_pccs_url, parse_qcnl_u64, refresh_blocking_or_use_stale, schedule_refresh_after,
-        unix_now, CacheEntryState, CachedCollateral, CollateralCache, CollateralCacheKey,
-        CollateralCachePolicy, QuoteCollateralV3, COLLATERAL_CACHE_EXPIRE_HOURS,
-        COLLATERAL_CACHE_REFRESH_HOURS,
+        cached_collateral, classify_cache_entry, collateral_cache, fetch_collateral_with_fallback,
+        normalize_pccs_base_url, parse_pccs_urls, parse_qcnl_pccs_url, parse_qcnl_u64,
+        refresh_blocking_or_use_stale, schedule_refresh_after, unix_now, CacheEntryState,
+        CachedCollateral, CollateralCache, CollateralCacheKey, CollateralCachePolicy,
+        QuoteCollateralV3, COLLATERAL_CACHE_EXPIRE_HOURS, COLLATERAL_CACHE_REFRESH_HOURS,
     };
     use std::sync::Arc;
     use std::time::{Duration, Instant};
@@ -1438,13 +1402,12 @@ mod tests {
         )
     }
 
-    fn cached(age: Duration, collateral_valid_for: i64) -> CachedCollateral {
+    fn cached(age: Duration) -> CachedCollateral {
         let now = Instant::now();
         CachedCollateral {
             collateral: collateral(),
             cached_at: now - age,
             cached_at_unix: unix_now().saturating_sub(age.as_secs()),
-            collateral_expires_at: unix_now() as i64 + collateral_valid_for,
             last_successful_pccs: "https://pccs.example.com".into(),
             last_refresh_attempt_at: Some(unix_now()),
             last_refresh_error: None,
@@ -1534,40 +1497,20 @@ mod tests {
     }
 
     #[test]
-    fn cache_state_has_separate_refresh_cache_and_collateral_deadlines() {
+    fn cache_state_depends_only_on_local_cache_age() {
         let now = Instant::now();
-        let now_unix = unix_now() as i64;
         assert_eq!(
-            classify_cache_entry(
-                &cached(Duration::from_secs(5), 3_600),
-                policy(),
-                now,
-                now_unix
-            ),
+            classify_cache_entry(&cached(Duration::from_secs(5)), policy(), now),
             CacheEntryState::Fresh
         );
         assert_eq!(
-            classify_cache_entry(
-                &cached(Duration::from_secs(15), 3_600),
-                policy(),
-                now,
-                now_unix
-            ),
+            classify_cache_entry(&cached(Duration::from_secs(15)), policy(), now),
             CacheEntryState::RefreshDue
         );
-        let cache_expired = cached(Duration::from_secs(25), 3_600);
         assert_eq!(
-            classify_cache_entry(&cache_expired, policy(), now, now_unix),
+            classify_cache_entry(&cached(Duration::from_secs(25)), policy(), now),
             CacheEntryState::CacheExpired
         );
-        assert!(collateral_is_still_valid(&cache_expired, now_unix));
-
-        let collateral_expired = cached(Duration::from_secs(5), -1);
-        assert_eq!(
-            classify_cache_entry(&collateral_expired, policy(), now, now_unix),
-            CacheEntryState::CollateralExpired
-        );
-        assert!(!collateral_is_still_valid(&collateral_expired, now_unix));
     }
 
     #[tokio::test]
@@ -1576,12 +1519,7 @@ mod tests {
         let mut fetched = collateral();
         fetched.pck_certificate_chain = Some("must-not-be-cached".into());
         cache
-            .store_success(
-                cache_key(),
-                fetched,
-                unix_now() as i64 + 3_600,
-                "https://pccs.example.com".into(),
-            )
+            .store_success(cache_key(), fetched, "https://pccs.example.com".into())
             .await;
 
         let entry = cache.lookup(&cache_key()).await.unwrap();
@@ -1613,7 +1551,7 @@ mod tests {
             .entries
             .lock()
             .await
-            .insert(key.clone(), cached(Duration::from_secs(25), 3_600));
+            .insert(key.clone(), cached(Duration::from_secs(15)));
         cache
             .record_refresh_failure(
                 &key,
@@ -1623,7 +1561,6 @@ mod tests {
             .await;
 
         let entry = cache.lookup(&key).await.unwrap();
-        assert!(collateral_is_still_valid(&entry, unix_now() as i64));
         assert!(entry
             .last_refresh_error
             .as_deref()
@@ -1635,8 +1572,45 @@ mod tests {
             .statuses(policy(), vec!["https://pccs.example.com".into()])
             .await;
         assert_eq!(statuses.len(), 1);
-        assert_eq!(statuses[0].status, "degraded");
+        assert_eq!(statuses[0].status, "refresh_retrying");
         assert!(statuses[0].details.contains_key("last_refresh_error"));
+        assert!(!statuses[0].details.contains_key("collateral_expires_at"));
+        assert!(!statuses[0]
+            .details
+            .contains_key("collateral_valid_for_seconds"));
+    }
+
+    #[tokio::test]
+    async fn status_reports_refresh_due_while_refresh_is_running_and_degraded_after_ttl() {
+        let cache = CollateralCache::default();
+        let key = cache_key();
+        cache
+            .entries
+            .lock()
+            .await
+            .insert(key.clone(), cached(Duration::from_secs(15)));
+
+        let refresh_lock = cache.refresh_lock(&key).await;
+        let refresh_guard = refresh_lock.lock().await;
+        let statuses = cache
+            .statuses(policy(), vec!["https://pccs.example.com".into()])
+            .await;
+        assert_eq!(statuses[0].status, "refresh_due");
+        assert_eq!(
+            statuses[0].details.get("refresh_in_progress"),
+            Some(&serde_json::json!(true))
+        );
+        drop(refresh_guard);
+
+        cache
+            .entries
+            .lock()
+            .await
+            .insert(key, cached(Duration::from_secs(25)));
+        let statuses = cache
+            .statuses(policy(), vec!["https://pccs.example.com".into()])
+            .await;
+        assert_eq!(statuses[0].status, "degraded");
     }
 
     #[tokio::test]
@@ -1646,7 +1620,7 @@ mod tests {
             fmspc: "TIMER00000001".into(),
             ca: "platform".into(),
         };
-        let entry = cached(Duration::ZERO, 3_600);
+        let entry = cached(Duration::ZERO);
         let cached_at = entry.cached_at;
         collateral_cache()
             .entries
@@ -1678,17 +1652,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hard_expired_cache_falls_back_while_collateral_is_valid() {
+    async fn hard_expired_cache_falls_back_without_parsing_collateral_validity() {
         let key = CollateralCacheKey {
             pccs_base_urls: vec!["http://127.0.0.1:1".into()],
             fmspc: "STALE0000001".into(),
             ca: "platform".into(),
         };
+        let mut entry = cached(Duration::from_secs(25));
+        entry.collateral.tcb_info =
+            r#"{"issueDate":"2019-01-01T00:00:00Z","nextUpdate":"2020-01-01T00:00:00Z"}"#.into();
+        entry.collateral.qe_identity =
+            r#"{"issueDate":"2019-01-01T00:00:00Z","nextUpdate":"2020-01-01T00:00:00Z"}"#.into();
         collateral_cache()
             .entries
             .lock()
             .await
-            .insert(key.clone(), cached(Duration::from_secs(25), 3_600));
+            .insert(key.clone(), entry);
 
         let result =
             refresh_blocking_or_use_stale(key.clone(), "current-pck-chain".into(), policy())
@@ -1704,27 +1683,6 @@ mod tests {
             .unwrap()
             .last_refresh_error
             .is_some());
-    }
-
-    #[tokio::test]
-    async fn expired_collateral_is_not_used_after_refresh_failure() {
-        let key = CollateralCacheKey {
-            pccs_base_urls: vec!["http://127.0.0.1:1".into()],
-            fmspc: "STALE0000002".into(),
-            ca: "platform".into(),
-        };
-        collateral_cache()
-            .entries
-            .lock()
-            .await
-            .insert(key.clone(), cached(Duration::from_secs(25), -1));
-
-        let error = refresh_blocking_or_use_stale(key, "current-pck-chain".into(), policy())
-            .await
-            .unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("configured PCCS endpoints failed"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- make TDX collateral cache availability depend only on local cache age
- remove cache-layer `nextUpdate` gating and the TDX cache `unhealthy` state
- add `refresh_retrying` for failed proactive refreshes that are waiting for backoff
- keep cached collateral available after the local TTL and leave freshness/validity decisions to quote verification
- update REST, gRPC, and PCCS resilience documentation

## Default state model

- `ready`: cache age is below 72 hours
- `refresh_due`: cache age is 72–168 hours and refresh is due or running
- `refresh_retrying`: cache age is 72–168 hours and a failed refresh is waiting to retry
- `degraded`: cache age is at least 168 hours

The status API no longer exposes `collateral_expires_at` or `collateral_valid_for_seconds` for this cache dependency.

## Rationale

Collateral freshness is already evaluated by the quote verifier and policy path. Using TCB Info / QE Identity `nextUpdate` again in the cache layer conflated cryptographic verification policy with PCCS/cache availability and could turn a PCCS outage into an early cache rejection.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p verifier --no-default-features --features tdx-dcap-rust tdx::verify::native::tests` — 15/15 passed
- `cargo clippy -p verifier --no-default-features --features tdx-dcap-rust -- -D warnings -A clippy::derive_partial_eq_without_eq`
- `cargo build -p attestation-service --bin restful-as --no-default-features --features restful-bin,all-verifier-rust,rvps-grpc`
- `cargo build --release --locked -p attestation-service --bin grpc-as --no-default-features --features grpc-bin,all-verifier-rust,rvps-grpc`

Real Alibaba Cloud TDX VM, with the patched gRPC AS pinned to CPU 0–1 and isolated test ports:

- fresh 23,858-byte TDX evidence verified successfully; default cache state became `ready`
- a delayed PCCS refresh returned `refresh_due` with `refresh_in_progress=true`; the attestation request still completed in 18 ms
- injected PCCS HTTP 503 returned `refresh_retrying`; cached attestation still completed in 19 ms
- the verifier token reported `collateral_expired=true`, confirming the cache no longer rejects on that field and the verifier owns the decision
- the scheduled retry succeeded after the configured 60-second backoff and cleared `last_refresh_error`
- the 168-hour `degraded` boundary and post-TTL fallback are covered deterministically by the focused unit tests
