### PR TITLE
attestation-service: add default SNP appraisal

### DIFF
--- a/attestation-service/README.md
+++ b/attestation-service/README.md
@@ -146,6 +146,8 @@ The results of every policy that is evaluated are included in the attestation to
 **Note**: Please refer to the [Policy Language](https://www.openpolicyagent.org/docs/latest/policy-language/) documentation for more information about Rego.
 
 If the policy is not updated, the AS will use the [default policy](src/token/ear_default_policy_cpu.rego).
+For AMD SEV-SNP, see the required launch-measurement and platform-TCB
+[reference values](docs/amd-snp-appraisal.md).
 
 Concrete policy usages please refer to [this guide](docs/policy.md).
 

--- a/attestation-service/docs/amd-snp-appraisal.md
+++ b/attestation-service/docs/amd-snp-appraisal.md
@@ -1,0 +1,59 @@
+# AMD SEV-SNP appraisal
+
+Trustee verifies the SNP report signature, endorsement chain, VCEK TCB
+extensions, VMPL, and `REPORT_DATA` before evaluating an attestation policy.
+The default EAR and OIDC policies also require Debug and Migration Agent to be
+disabled. Deployment-specific launch-measurement and platform-TCB allow-lists
+are included as commented examples and are disabled by default, matching the
+customization model used by the other platform branches.
+
+## Reference values
+
+When the relying party needs stricter appraisal, uncomment the corresponding
+checks in the default policy (or, preferably, install a deployment-owned policy)
+and register arrays of accepted string values under these RVPS keys:
+
+| Key | SNP claim |
+| --- | --- |
+| `snp.measurement` | Initial guest launch measurement (Base64) |
+| `snp.reported_tcb_bootloader` | Bootloader security patch level |
+| `snp.reported_tcb_tee` | TEE security patch level |
+| `snp.reported_tcb_snp` | SNP firmware security patch level |
+| `snp.reported_tcb_microcode` | CPU microcode security patch level |
+| `snp.reported_tcb_fmc` | Turin+ FMC security patch level |
+
+Enable the FMC check only for Turin and later evidence that contains the claim.
+Once a check is enabled, a missing or mismatched reference value prevents an
+affirming EAR appraisal (producing `warning` or `contraindicated`, depending on
+the failed trust claim) and causes an OIDC policy rejection.
+
+A sample RVPS message is:
+
+```json
+{
+  "version": "0.1.0",
+  "type": "sample",
+  "payload": "<base64-of-reference-value-json>"
+}
+```
+
+The decoded payload has this shape:
+
+```json
+{
+  "snp.measurement": ["<base64-launch-measurement>"],
+  "snp.reported_tcb_bootloader": ["0"],
+  "snp.reported_tcb_tee": ["0"],
+  "snp.reported_tcb_snp": ["0"],
+  "snp.reported_tcb_microcode": ["37"],
+  "snp.reported_tcb_fmc": ["0"]
+}
+```
+
+## Scope
+
+The SNP launch measurement authenticates initial guest state; it is not a
+dynamic runtime or filesystem measurement. For plain SNP evidence, the default
+EAR policy therefore reports no filesystem claim. Use SVSM/vTPM or another
+measured-boot mechanism when the relying party requires boot-event or runtime
+filesystem appraisal.

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -577,6 +577,54 @@ mod tests {
         ear.validate().unwrap();
     }
 
+    async fn issue_snp_ear(debug_allowed: &str) -> Value {
+        let policy_dir = tempfile::tempdir().unwrap();
+        let config = Configuration {
+            policy_dir: policy_dir.path().to_string_lossy().into_owned(),
+            ..Configuration::default()
+        };
+        let broker = EarAttestationTokenBroker::new(config).unwrap();
+        let token = broker
+            .issue(
+                vec![TeeClaims {
+                    tee: Tee::Snp,
+                    tee_class: "cpu".to_string(),
+                    claims: json!({
+                        "measurement": "test-snp-launch-measurement",
+                        "policy_debug_allowed": debug_allowed,
+                        "policy_migrate_ma": "0",
+                        "reported_tcb_bootloader": "0",
+                        "reported_tcb_tee": "0",
+                        "reported_tcb_snp": "0",
+                        "reported_tcb_microcode": "37",
+                        "reported_tcb_fmc": "0",
+                    }),
+                    runtime_data_claims: Value::Null,
+                    init_data_claims: Value::Null,
+                    additional_data: None,
+                }],
+                vec!["default".into()],
+                crate::rvps::empty_test_resolver(),
+            )
+            .await
+            .unwrap();
+
+        let payload = token.split('.').nth(1).unwrap();
+        serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload).unwrap()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_snp_default_policy_affirms_without_reference_values() {
+        let ear = issue_snp_ear("0").await;
+        assert_eq!(ear["submods"]["cpu0"]["ear.status"], "affirming");
+    }
+
+    #[tokio::test]
+    async fn test_snp_default_policy_rejects_debug_guest() {
+        let ear = issue_snp_ear("1").await;
+        assert_eq!(ear["submods"]["cpu0"]["ear.status"], "warning");
+    }
+
     #[test]
     fn test_transform_claims() {
         let json = json!({

--- a/attestation-service/src/token/ear_default_policy_cpu.rego
+++ b/attestation-service/src/token/ear_default_policy_cpu.rego
@@ -224,6 +224,41 @@ validate_aael_model_measurements(uefi_event_logs) if {
 	}
 }
 
+##### AMD SEV-SNP
+
+# Signature, endorsement-chain, TCB-extension, VMPL, and REPORT_DATA checks are
+# completed by the SNP verifier before policy evaluation. Reference-value
+# checks are deployment-specific, so keep them disabled in the default policy
+# and uncomment the checks needed by the relying party.
+executables := 3 if {
+	input.snp
+	# Check the initial guest launch measurement.
+	# input.snp.measurement in query_reference_value("snp.measurement")
+}
+
+hardware := 2 if {
+	input.snp
+	# Check minimum or explicitly approved platform TCB values.
+	# input.snp.reported_tcb_bootloader in query_reference_value("snp.reported_tcb_bootloader")
+	# input.snp.reported_tcb_tee in query_reference_value("snp.reported_tcb_tee")
+	# input.snp.reported_tcb_snp in query_reference_value("snp.reported_tcb_snp")
+	# input.snp.reported_tcb_microcode in query_reference_value("snp.reported_tcb_microcode")
+	# Turin and later only:
+	# input.snp.reported_tcb_fmc in query_reference_value("snp.reported_tcb_fmc")
+}
+
+configuration := 2 if {
+	input.snp.policy_debug_allowed == "0"
+	input.snp.policy_migrate_ma == "0"
+}
+
+# AR4SI value 0 means "no claim". Base SNP attestation has no authenticated
+# runtime filesystem measurement; SVSM/vTPM or another measured-boot mechanism
+# must provide that evidence separately.
+file_system := 0 if {
+	input.snp
+}
+
 ##### TDX
 
 executables := 3 if {

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -541,6 +541,42 @@ mod tests {
             .unwrap();
     }
 
+    #[tokio::test]
+    async fn test_snp_default_policy_accepts_without_reference_values() {
+        let policy_dir = tempfile::tempdir().unwrap();
+        let config = Configuration {
+            policy_dir: policy_dir.path().to_string_lossy().into_owned(),
+            ..Configuration::default()
+        };
+        let broker = OIDCAttestationTokenBroker::new(config).unwrap();
+        let claims = TeeClaims {
+            tee: Tee::Snp,
+            tee_class: "cpu".to_string(),
+            claims: json!({
+                "measurement": "test-snp-launch-measurement",
+                "policy_debug_allowed": "0",
+                "policy_migrate_ma": "0",
+                "reported_tcb_bootloader": "0",
+                "reported_tcb_tee": "0",
+                "reported_tcb_snp": "0",
+                "reported_tcb_microcode": "37",
+                "reported_tcb_fmc": "0",
+            }),
+            runtime_data_claims: serde_json::Value::Null,
+            init_data_claims: serde_json::Value::Null,
+            additional_data: None,
+        };
+        let token = broker
+            .issue(
+                vec![claims],
+                vec!["default".into()],
+                crate::rvps::empty_test_resolver(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(token.split('.').count(), 3);
+    }
+
     // A pre-generated RSA-2048 PKCS#8 private key (PEM). Used together with
     // `TEST_CERT_CHAIN_PEM` to exercise the `signer = Some(...)` branch of
     // `OIDCAttestationTokenBroker::new`, which parses the PEM cert chain via

--- a/attestation-service/src/token/oidc_default_policy.rego
+++ b/attestation-service/src/token/oidc_default_policy.rego
@@ -160,6 +160,35 @@ validate_aael_file_measurements(uefi_event_logs) if {
 	}
 }
 
+##### AMD SEV-SNP
+
+# Reference-value checks are deployment-specific. Uncomment the checks needed
+# by the relying party after provisioning the corresponding RVPS values.
+executables := 3 if {
+	input.snp
+	# input.snp.measurement in query_reference_value("snp.measurement")
+}
+
+hardware := 2 if {
+	input.snp
+	# input.snp.reported_tcb_bootloader in query_reference_value("snp.reported_tcb_bootloader")
+	# input.snp.reported_tcb_tee in query_reference_value("snp.reported_tcb_tee")
+	# input.snp.reported_tcb_snp in query_reference_value("snp.reported_tcb_snp")
+	# input.snp.reported_tcb_microcode in query_reference_value("snp.reported_tcb_microcode")
+	# Turin and later only:
+	# input.snp.reported_tcb_fmc in query_reference_value("snp.reported_tcb_fmc")
+}
+
+configuration := 2 if {
+	input.snp.policy_debug_allowed == "0"
+	input.snp.policy_migrate_ma == "0"
+}
+
+# Base SNP evidence does not authenticate runtime filesystem state.
+file_system := 0 if {
+	input.snp
+}
+
 ##### TDX
 
 executables := 3 if {

--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -602,7 +602,7 @@ pub(crate) fn parse_tee_evidence(
 ) -> Result<TeeEvidenceParsedClaim> {
     // generation-aware reported_tcb (see read_reported_tcb)
     let tcb = read_reported_tcb(raw, proc_gen)?;
-    let claims_map = json!({
+    let mut claims_map = json!({
         // policy fields
         "policy_abi_major": format!("{}",report.policy.abi_major()),
         "policy_abi_minor": format!("{}", report.policy.abi_minor()),
@@ -624,6 +624,13 @@ pub(crate) fn parse_tee_evidence(
         // measurement
         "measurement": format!("{}", base64::engine::general_purpose::STANDARD.encode(report.measurement)),
     });
+
+    if let Some(fmc) = tcb.fmc {
+        claims_map
+            .as_object_mut()
+            .context("SNP claims must be a JSON object")?
+            .insert("reported_tcb_fmc".to_string(), json!(fmc.to_string()));
+    }
 
     Ok(claims_map as TeeEvidenceParsedClaim)
 }
@@ -866,6 +873,9 @@ mod tests {
             (3, 2, 5, 97)
         );
         assert_eq!(tcb.fmc, Some(1));
+
+        let claims = parse_tee_evidence(&report, &raw, ProcessorGeneration::Turin).unwrap();
+        assert_eq!(claims["reported_tcb_fmc"], "1");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- add AMD SEV-SNP branches to the default EAR and OIDC appraisal policies
- keep deployment-specific RVPS checks for the launch measurement and reported TCB as commented examples, consistent with the other platform branches
- require Debug and Migration Agent to be disabled
- expose the Turin+ FMC TCB value in parsed SNP claims
- explicitly emit no filesystem claim for base SNP evidence, because it is not a dynamic runtime measurement
- document optional SNP reference-value hardening and add positive and negative policy tests

## Why

The SNP verifier already validated the report signature, endorsement chain, VCEK TCB extensions, VMPL, and `REPORT_DATA`, but the default token policies did not recognize SNP. Consequently, valid SNP evidence still produced a contraindicated EAR appraisal. The default policies now recognize successfully verified SNP evidence and reject unsafe Debug or Migration Agent policy bits. Relying parties can uncomment the documented measurement and TCB checks after provisioning their deployment-owned RVPS values.

## Validation

- `cargo test -p attestation-service --no-default-features --features fs,snp-verifier --lib` (34 passed)
- `cargo test -p verifier --no-default-features --features snp-verifier snp::tests --lib` (20 passed)
- `cargo clippy -p attestation-service --no-default-features --features fs,snp-verifier --lib -- -D warnings`
- `cargo clippy -p verifier --no-default-features --features snp-verifier --lib -- -D warnings`
- `cargo check -p kbs --no-default-features --features coco-as-builtin-no-verifier,attestation-service/snp-verifier,attestation-service/fs`
- real Alibaba Cloud Linux 4 SEV-SNP guest evidence:
  - fresh empty RVPS work directories were used for the updated default policy; neither run queried an `snp.*` reference value
  - online AMD KDS path returned an EAR with `ear.status=affirming`
  - offline path removed all proxy variables, loaded the TCB-specific VCEK cache, made no KDS request, and also returned `ear.status=affirming`
- end-to-end guest AA to Trustee KBS, including a rebuild from this PR head with an empty in-memory RVPS:
  - online AMD KDS path: `attestation-agent-client get-token --token-type kbs` returned an EAR with `ear.status=affirming`
  - offline path with all proxy variables removed: the TCB-specific VCEK cache was used, no KDS request was made, and the EAR was also `affirming`
  - both runs validated `REPORT_DATA`, performed no `snp.*` RVPS query, and returned HTTP 200 from `/auth` and `/attest`

Signed-off-by: Jiale Zhang <zhangjiale@linux.alibaba.com>
