### PR TITLE
Split OPA PolicyEngine into fs  and in-memory implaments

### DIFF
--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = [ "restful-bin", "rvps-grpc", "all-verifier", "fs" ]
+default = [ "restful-bin", "rvps-grpc", "all-verifier", "fs", "policy-rvps" ]
 
 # Filesystem-backed implementations: config-from-file, on-disk OPA policy engine,
 # rvps local_json/local_fs storage, nonce-key persistence, signer transparency
 # file, signer key/cert read by path. Turn off (`default-features = false`) for a
 # pure, fs-free library (e.g. wasm builds).
-fs = [ "policy-rvps", "tokio/fs", "reference-value-provider-service/fs" ]
+fs = [ "tokio/fs", "reference-value-provider-service/fs" ]
 # Runtime bridge used by synchronous Regorus extensions to make bounded
 # asynchronous RVPS queries. Normal AS binaries enable this through `fs`.
 policy-rvps = [ "tokio/rt", "tokio/time" ]
@@ -38,13 +38,13 @@ tpm-verifier = [ "verifier/tpm-verifier" ]
 rvps-grpc = [ "prost", "tonic", "tokio/sync" ]
 
 # For building gRPC CoCo-AS binary
-grpc-bin = [ "clap", "env_logger", "prost", "tonic", "tokio/full", "fs" ]
+grpc-bin = [ "clap", "env_logger", "prost", "tonic", "tokio/full", "fs", "policy-rvps" ]
 
 # For restful CoCo-AS binary
-restful-bin = [ "actix-cors", "actix-web/openssl", "clap", "env_logger", "openssl", "tokio/full", "fs" ]
+restful-bin = [ "actix-cors", "actix-web/openssl", "clap", "env_logger", "openssl", "tokio/full", "fs", "policy-rvps" ]
 
 # For attestation-challenge-client binary
-attestation-challenge-client = [ "tokio/full", "fs" ]
+attestation-challenge-client = [ "tokio/full", "fs", "policy-rvps" ]
 
 [[bin]]
 name = "grpc-as"

--- a/attestation-service/src/policy_engine/mod.rs
+++ b/attestation-service/src/policy_engine/mod.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::io;
+#[cfg(feature = "fs")]
 use std::path::Path;
 use std::sync::Arc;
 use strum::EnumString;
@@ -55,10 +56,12 @@ pub enum PolicyError {
 #[derive(Debug, EnumString, Deserialize)]
 #[strum(ascii_case_insensitive)]
 pub enum PolicyEngineType {
+    #[cfg(feature = "fs")]
     OPA,
 }
 
 impl PolicyEngineType {
+    #[cfg(feature = "fs")]
     pub fn to_policy_engine(
         &self,
         work_dir: &Path,

--- a/attestation-service/src/policy_engine/opa/fs.rs
+++ b/attestation-service/src/policy_engine/opa/fs.rs
@@ -1,0 +1,454 @@
+// Copyright (c) 2024 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::rvps::ReferenceValueResolver;
+use anyhow::Result;
+use async_trait::async_trait;
+use base64::Engine;
+use log::warn;
+use sha2::{Digest, Sha384};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::policy_engine::{EvaluationResult, PolicyDigest, PolicyEngine, PolicyError};
+
+#[derive(Debug, Clone)]
+pub struct OPA {
+    policy_dir_path: PathBuf,
+}
+
+impl OPA {
+    pub fn new(
+        work_dir: PathBuf,
+        default_policy: &str,
+        default_policy_id: &str,
+    ) -> Result<Self, PolicyError> {
+        let mut policy_dir_path = work_dir;
+
+        policy_dir_path.push("opa");
+        if !policy_dir_path.as_path().exists() {
+            std::fs::create_dir_all(&policy_dir_path)
+                .map_err(PolicyError::CreatePolicyDirFailed)?;
+        }
+
+        let mut default_policy_path = PathBuf::from(
+            &policy_dir_path
+                .to_str()
+                .ok_or_else(|| PolicyError::PolicyDirPathToStringFailed)?,
+        );
+        default_policy_path.push(default_policy_id);
+        if !default_policy_path.as_path().exists() {
+            std::fs::write(&default_policy_path, default_policy)
+                .map_err(PolicyError::WriteDefaultPolicyFailed)?;
+        } else {
+            warn!("Default policy file is already populated. Existing policy file will be used.");
+        }
+
+        Ok(Self { policy_dir_path })
+    }
+}
+
+#[async_trait]
+impl PolicyEngine for OPA {
+    async fn evaluate(
+        &self,
+        input: &str,
+        policy_id: &str,
+        evaluation_rules: Vec<String>,
+        reference_value_resolver: Arc<ReferenceValueResolver>,
+    ) -> Result<EvaluationResult, PolicyError> {
+        let policy_dir_path = self
+            .policy_dir_path
+            .to_str()
+            .ok_or_else(|| PolicyError::PolicyDirPathToStringFailed)?;
+
+        let policy_file_path = format!("{policy_dir_path}/{policy_id}.rego");
+
+        let policy =
+            std::fs::read_to_string(policy_file_path).map_err(PolicyError::ReadPolicyFileFailed)?;
+
+        super::common_evaluate(
+            policy,
+            input.to_string(),
+            policy_id.to_string(),
+            evaluation_rules,
+            reference_value_resolver,
+        )
+        .await
+    }
+
+    async fn set_policy(&self, policy_id: String, policy: String) -> Result<(), PolicyError> {
+        let policy_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(policy)?;
+
+        if !super::is_valid_policy_id(&policy_id) {
+            return Err(PolicyError::InvalidPolicyId);
+        }
+
+        // Check if the policy is valid
+        {
+            let policy_content = String::from_utf8(policy_bytes.clone())
+                .map_err(|e| PolicyError::InvalidPolicy(e.into()))?;
+            let mut engine = regorus::Engine::new();
+            engine
+                .add_policy(policy_id.clone(), policy_content)
+                .map_err(PolicyError::InvalidPolicy)?;
+        }
+
+        let mut policy_file_path = PathBuf::from(
+            &self
+                .policy_dir_path
+                .to_str()
+                .ok_or_else(|| PolicyError::PolicyDirPathToStringFailed)?,
+        );
+
+        policy_file_path.push(format!("{}.rego", policy_id));
+
+        std::fs::write(&policy_file_path, policy_bytes).map_err(PolicyError::WritePolicyFileFailed)
+    }
+
+    async fn list_policies(&self) -> Result<HashMap<String, PolicyDigest>, PolicyError> {
+        let mut policy_ids = Vec::new();
+        let entries = std::fs::read_dir(&self.policy_dir_path)?;
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(std::ffi::OsStr::to_str) == Some("rego") {
+                if let Some(filename) = path.file_stem() {
+                    if let Some(filename_str) = filename.to_str() {
+                        policy_ids.push(filename_str.to_owned());
+                    }
+                }
+            }
+        }
+
+        let mut policy_list = HashMap::new();
+
+        for id in policy_ids.iter() {
+            let policy_file_path = self.policy_dir_path.join(format!("{id}.rego"));
+            let policy =
+                std::fs::read(policy_file_path).map_err(PolicyError::ReadPolicyFileFailed)?;
+
+            let mut hasher = Sha384::new();
+            hasher.update(policy);
+            let digest = hasher.finalize().to_vec();
+            policy_list.insert(
+                id.to_string(),
+                base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest),
+            );
+        }
+
+        Ok(policy_list)
+    }
+
+    async fn get_policy(&self, policy_id: String) -> Result<String, PolicyError> {
+        let policy_file_path = self.policy_dir_path.join(format!("{policy_id}.rego"));
+        let policy = std::fs::read(policy_file_path).map_err(PolicyError::ReadPolicyFileFailed)?;
+        let base64_policy = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(policy);
+        Ok(base64_policy)
+    }
+
+    async fn delete_policy(&self, policy_id: String) -> Result<(), PolicyError> {
+        if !super::is_valid_policy_id(&policy_id) {
+            return Err(PolicyError::InvalidPolicyId);
+        }
+
+        // Prevent deletion of default policy
+        if policy_id == "default" {
+            return Err(PolicyError::CannotDeleteDefaultPolicy);
+        }
+
+        let policy_file_path = self.policy_dir_path.join(format!("{policy_id}.rego"));
+
+        if !policy_file_path.exists() {
+            return Err(PolicyError::ReadPolicyFileFailed(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("Policy {} not found", policy_id),
+            )));
+        }
+
+        std::fs::remove_file(policy_file_path).map_err(PolicyError::IOError)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rvps::{RvpsApi, RvpsError};
+    use anyhow::anyhow;
+    use ear::TrustVector;
+    use rstest::rstest;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    fn dummy_reference(svn: u64, launch_digest: String) -> Arc<ReferenceValueResolver> {
+        crate::rvps::test_resolver(HashMap::from([
+            ("svn".to_string(), json!([svn.to_string()])),
+            ("launch_digest".to_string(), json!([launch_digest])),
+        ]))
+    }
+
+    fn dummy_input(svn: u64, launch_digest: String) -> String {
+        json!({
+            "sample": {
+                "svn": svn.to_string(),
+                "launch_digest": launch_digest
+            }
+        })
+        .to_string()
+    }
+
+    #[rstest]
+    // #[case(1,1,"aac43bb3".to_string(),"aac43bb3".to_string(),3,2)]
+    //#[case(2,1,"aac43bb3".to_string(),"aac43bb3".to_string(),3,97)]
+    //#[case(1,1,"aac43bb4".to_string(),"aac43bb3".to_string(),33,2)]
+    #[case(2,1,"aac43bb4".to_string(),"aac43bb3".to_string(),33,97)]
+    #[tokio::test]
+    async fn test_evaluate(
+        #[case] svn_a: u64,
+        #[case] svn_b: u64,
+        #[case] digest_a: String,
+        #[case] digest_b: String,
+        #[case] ex_exp: i8,
+        #[case] hw_exp: i8,
+    ) {
+        let opa = OPA {
+            policy_dir_path: PathBuf::from("./src/token/"),
+        };
+        let default_policy_id = "ear_default_policy_cpu".to_string();
+
+        let ear_rules = TrustVector::new()
+            .into_iter()
+            .map(|c| c.tag().to_string().replace("-", "_"))
+            .collect();
+
+        let output = opa
+            .evaluate(
+                &dummy_input(svn_b, digest_b),
+                &default_policy_id,
+                ear_rules,
+                dummy_reference(svn_a, digest_a),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            hw_exp,
+            output
+                .rules_result
+                .get("hardware")
+                .unwrap()
+                .as_i64()
+                .unwrap() as i8
+        );
+        assert_eq!(
+            ex_exp,
+            output
+                .rules_result
+                .get("executables")
+                .unwrap()
+                .as_i64()
+                .unwrap() as i8
+        );
+    }
+
+    #[tokio::test]
+    async fn test_policy_management() {
+        let opa = OPA::new(PathBuf::from("tests/tmp"), "default", "default.rego").unwrap();
+        let policy = "package policy
+default allow = true"
+            .to_string();
+
+        let get_policy_output = "cGFja2FnZSBwb2xpY3kKZGVmYXVsdCBhbGxvdyA9IHRydWU".to_string();
+
+        assert!(opa
+            .set_policy(
+                "test".to_string(),
+                base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(policy)
+            )
+            .await
+            .is_ok());
+        let policy_list = opa.list_policies().await.unwrap();
+        assert_eq!(policy_list.len(), 2);
+        let test_policy = opa.get_policy("test".to_string()).await.unwrap();
+        assert_eq!(test_policy, get_policy_output);
+        assert!(opa.list_policies().await.is_ok());
+    }
+
+    #[cfg(feature = "policy-rvps")]
+    struct CountingRvps {
+        keyed_queries: AtomicUsize,
+        bulk_queries: AtomicUsize,
+    }
+
+    #[cfg(feature = "policy-rvps")]
+    #[async_trait::async_trait]
+    impl RvpsApi for CountingRvps {
+        async fn verify_and_extract(&self, _message: &str) -> std::result::Result<(), RvpsError> {
+            unreachable!()
+        }
+
+        async fn set_reference_value_list(
+            &self,
+            _payload: &str,
+        ) -> std::result::Result<(), RvpsError> {
+            unreachable!()
+        }
+
+        async fn query_reference_value(
+            &self,
+            reference_value_id: &str,
+        ) -> std::result::Result<Option<serde_json::Value>, RvpsError> {
+            self.keyed_queries.fetch_add(1, Ordering::SeqCst);
+            Ok(match reference_value_id {
+                "svn" => Some(json!([7])),
+                "minimum" => Some(json!(3)),
+                _ => None,
+            })
+        }
+
+        async fn get_reference_values(
+            &self,
+        ) -> std::result::Result<HashMap<String, serde_json::Value>, RvpsError> {
+            self.bulk_queries.fetch_add(1, Ordering::SeqCst);
+            Ok(HashMap::new())
+        }
+
+        async fn delete_reference_value(
+            &self,
+            _name: &str,
+        ) -> std::result::Result<bool, RvpsError> {
+            unreachable!()
+        }
+    }
+
+    #[cfg(feature = "policy-rvps")]
+    #[tokio::test]
+    async fn query_extension_is_keyed_cached_and_returns_null_for_missing() {
+        let policy = r#"package policy
+default allow = false
+allow {
+    query_reference_value("svn") == [7]
+    query_reference_value("missing") == null
+}
+minimum = query_reference_value("minimum")
+svn_again = query_reference_value("svn")
+"#;
+        let tmp = tempfile::tempdir().unwrap();
+        let opa = OPA::new(tmp.path().to_path_buf(), policy, "query.rego").unwrap();
+        let rvps = Arc::new(CountingRvps {
+            keyed_queries: AtomicUsize::new(0),
+            bulk_queries: AtomicUsize::new(0),
+        });
+        let resolver = Arc::new(ReferenceValueResolver::new(
+            Arc::clone(&rvps) as Arc<dyn RvpsApi>
+        ));
+
+        let result = opa
+            .evaluate(
+                "{}",
+                "query",
+                vec![
+                    "allow".to_string(),
+                    "minimum".to_string(),
+                    "svn_again".to_string(),
+                ],
+                resolver,
+            )
+            .await
+            .unwrap();
+
+        assert!(result.rules_result.get("allow").unwrap().as_bool().unwrap());
+        assert_eq!(
+            result
+                .rules_result
+                .get("minimum")
+                .unwrap()
+                .as_i64()
+                .unwrap(),
+            3
+        );
+        assert_eq!(result.rules_result.get("svn_again").unwrap(), &json!([7]));
+        assert_eq!(rvps.keyed_queries.load(Ordering::SeqCst), 3);
+        assert_eq!(rvps.bulk_queries.load(Ordering::SeqCst), 0);
+    }
+
+    #[cfg(feature = "policy-rvps")]
+    struct UnavailableRvps {
+        timeout: bool,
+    }
+
+    #[cfg(feature = "policy-rvps")]
+    #[async_trait::async_trait]
+    impl RvpsApi for UnavailableRvps {
+        async fn verify_and_extract(&self, _message: &str) -> std::result::Result<(), RvpsError> {
+            unreachable!()
+        }
+
+        async fn set_reference_value_list(
+            &self,
+            _payload: &str,
+        ) -> std::result::Result<(), RvpsError> {
+            unreachable!()
+        }
+
+        async fn query_reference_value(
+            &self,
+            _reference_value_id: &str,
+        ) -> std::result::Result<Option<serde_json::Value>, RvpsError> {
+            if self.timeout {
+                std::future::pending::<()>().await;
+                unreachable!()
+            }
+            Err(RvpsError::Anyhow(anyhow!("RVPS backend unavailable")))
+        }
+
+        async fn get_reference_values(
+            &self,
+        ) -> std::result::Result<HashMap<String, serde_json::Value>, RvpsError> {
+            unreachable!()
+        }
+
+        async fn delete_reference_value(
+            &self,
+            _name: &str,
+        ) -> std::result::Result<bool, RvpsError> {
+            unreachable!()
+        }
+    }
+
+    #[cfg(feature = "policy-rvps")]
+    async fn evaluate_unavailable_rvps(timeout: bool) -> String {
+        let policy = r#"package policy
+allow = query_reference_value("svn") == [7]
+"#;
+        let tmp = tempfile::tempdir().unwrap();
+        let opa = OPA::new(tmp.path().to_path_buf(), policy, "query.rego").unwrap();
+        let resolver = Arc::new(ReferenceValueResolver::new(Arc::new(UnavailableRvps {
+            timeout,
+        })));
+
+        opa.evaluate("{}", "query", vec!["allow".to_string()], resolver)
+            .await
+            .unwrap_err()
+            .to_string()
+    }
+
+    #[cfg(feature = "policy-rvps")]
+    #[tokio::test]
+    async fn query_extension_preserves_backend_errors() {
+        let error = evaluate_unavailable_rvps(false).await;
+        assert!(error.contains("RVPS backend unavailable"), "{error}");
+    }
+
+    #[cfg(feature = "policy-rvps")]
+    #[tokio::test]
+    async fn query_extension_times_out() {
+        let error = evaluate_unavailable_rvps(true).await;
+        assert!(error.contains("timed out"), "{error}");
+    }
+}

--- a/attestation-service/src/policy_engine/opa/in_memory.rs
+++ b/attestation-service/src/policy_engine/opa/in_memory.rs
@@ -1,0 +1,184 @@
+//! fs-free `PolicyEngine`: holds rego policy sources in memory and evaluates
+//! them with Regorus, mirroring `opa::OPA`'s engine usage but without any
+//! filesystem access. Selected by `PolicyEngineType::InMemory`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use sha2::{Digest, Sha384};
+use tokio::sync::RwLock;
+
+use crate::{
+    policy_engine::{EvaluationResult, PolicyDigest, PolicyEngine, PolicyError},
+    rvps::ReferenceValueResolver,
+};
+
+/// In-memory policy store: `policy_id` -> raw rego source (decoded from the
+/// base64url wire format `set_policy` receives, matching `opa::OPA`).
+pub struct OPAInMemory {
+    policies: RwLock<HashMap<String, Vec<u8>>>,
+}
+
+impl OPAInMemory {
+    /// Build an engine with a default policy preloaded, mirroring `opa::OPA::new`
+    /// which writes the default policy to `{dir}/{default_policy_id}` on disk.
+    /// The policy is stored under the stem of `default_policy_id` (`.rego`
+    /// stripped), matching how `opa::OPA::evaluate` looks up `{policy_id}.rego`.
+    /// This lets a broker's default policy flow (`evaluate(..., "default", ...)`)
+    /// succeed without any filesystem access.
+    pub fn with_raw_default_policy(raw_default_policy: &str, default_policy_id: &str) -> Self {
+        let stem = default_policy_id.trim_end_matches(".rego");
+        let mut policies = HashMap::new();
+        policies.insert(stem.to_string(), raw_default_policy.as_bytes().to_vec());
+        Self {
+            policies: RwLock::new(policies),
+        }
+    }
+
+    fn is_valid_policy_id(policy_id: &str) -> bool {
+        policy_id
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+    }
+}
+
+#[async_trait]
+impl PolicyEngine for OPAInMemory {
+    async fn evaluate(
+        &self,
+        input: &str,
+        policy_id: &str,
+        evaluation_rules: Vec<String>,
+        reference_value_resolver: Arc<ReferenceValueResolver>,
+    ) -> Result<EvaluationResult, PolicyError> {
+        let policies = self.policies.read().await;
+        let policy = policies
+            .get(policy_id)
+            .map(|b| b.as_slice())
+            .ok_or_else(|| {
+                PolicyError::ReadPolicyFileFailed(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("policy {policy_id} not found"),
+                ))
+            })?;
+        let policy =
+            std::str::from_utf8(policy).map_err(|e| PolicyError::InvalidPolicy(e.into()))?;
+
+        super::common_evaluate(
+            policy.to_string(),
+            input.to_string(),
+            policy_id.to_string(),
+            evaluation_rules,
+            reference_value_resolver,
+        )
+        .await
+    }
+
+    async fn set_policy(&self, policy_id: String, policy: String) -> Result<(), PolicyError> {
+        if !Self::is_valid_policy_id(&policy_id) {
+            return Err(PolicyError::InvalidPolicyId);
+        }
+        let bytes = URL_SAFE_NO_PAD.decode(policy)?;
+        // validate it compiles as rego
+        {
+            let src =
+                std::str::from_utf8(&bytes).map_err(|e| PolicyError::InvalidPolicy(e.into()))?;
+            let mut engine = regorus::Engine::new();
+            engine
+                .add_policy(policy_id.clone(), src.to_string())
+                .map_err(PolicyError::InvalidPolicy)?;
+        }
+        let mut policies = self.policies.write().await;
+        policies.insert(policy_id, bytes);
+        Ok(())
+    }
+
+    async fn list_policies(&self) -> Result<HashMap<String, PolicyDigest>, PolicyError> {
+        let policies = self.policies.read().await;
+        let mut out = HashMap::new();
+        for (id, bytes) in policies.iter() {
+            let mut h = Sha384::new();
+            h.update(bytes);
+            out.insert(id.clone(), URL_SAFE_NO_PAD.encode(h.finalize()));
+        }
+        Ok(out)
+    }
+
+    async fn get_policy(&self, policy_id: String) -> Result<String, PolicyError> {
+        let policies = self.policies.read().await;
+        let bytes = policies.get(&policy_id).ok_or_else(|| {
+            PolicyError::ReadPolicyFileFailed(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("policy {policy_id} not found"),
+            ))
+        })?;
+        Ok(URL_SAFE_NO_PAD.encode(bytes))
+    }
+
+    async fn delete_policy(&self, policy_id: String) -> Result<(), PolicyError> {
+        if !Self::is_valid_policy_id(&policy_id) {
+            return Err(PolicyError::InvalidPolicyId);
+        }
+        if policy_id == "default" {
+            return Err(PolicyError::CannotDeleteDefaultPolicy);
+        }
+        let mut policies = self.policies.write().await;
+        policies.remove(&policy_id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RAW_ALLOW_POLICY: &str = "package policy\ndefault allow = true";
+    fn allow_policy() -> String {
+        URL_SAFE_NO_PAD.encode(RAW_ALLOW_POLICY)
+    }
+
+    #[tokio::test]
+    async fn set_get_list_delete_roundtrip() {
+        let eng = OPAInMemory::with_raw_default_policy(RAW_ALLOW_POLICY, "test");
+        assert_eq!(eng.list_policies().await.unwrap().len(), 1);
+        assert_eq!(eng.get_policy("test".into()).await.unwrap(), allow_policy());
+        eng.delete_policy("test".into()).await.unwrap();
+        assert!(eng.list_policies().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn set_policy_then_get_roundtrip() {
+        // Covers the set_policy -> get_policy path (the roundtrip above only
+        // exercises with_default_policy). Verifies raw rego in == raw rego out.
+        let eng = OPAInMemory::with_raw_default_policy(RAW_ALLOW_POLICY, "default");
+        eng.set_policy("test".into(), allow_policy().into())
+            .await
+            .unwrap();
+        let got = eng.get_policy("test".into()).await.unwrap();
+        assert_eq!(got, allow_policy());
+        // setting again overwrites cleanly
+        eng.set_policy("test".into(), allow_policy().into())
+            .await
+            .unwrap();
+        assert_eq!(eng.get_policy("test".into()).await.unwrap(), allow_policy());
+    }
+
+    #[tokio::test]
+    async fn evaluate_uses_in_memory_policy() {
+        let eng = OPAInMemory::with_raw_default_policy(RAW_ALLOW_POLICY, "test");
+        eng.set_policy("p".into(), allow_policy()).await.unwrap();
+        let res = eng
+            .evaluate(
+                "{}",
+                "test",
+                vec!["allow".into()],
+                crate::rvps::test_resolver(HashMap::from([])),
+            )
+            .await
+            .unwrap();
+        assert!(res.rules_result.contains_key("allow"));
+    }
+}

--- a/attestation-service/src/policy_engine/opa/mod.rs
+++ b/attestation-service/src/policy_engine/opa/mod.rs
@@ -1,669 +1,249 @@
-// Copyright (c) 2024 by Alibaba.
+// Copyright (c) 2026 by Alibaba.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::rvps::ReferenceValueResolver;
 #[cfg(feature = "policy-rvps")]
 use anyhow::{anyhow, bail};
 use anyhow::{Context, Result};
-use async_trait::async_trait;
-use base64::Engine;
-use log::{debug, warn};
+use log::debug;
+#[cfg(feature = "policy-rvps")]
+use log::warn;
 use regorus::Extension;
-use sha2::{Digest, Sha384};
+use sha2::Digest;
 use std::collections::HashMap;
-use std::fs;
-use std::path::PathBuf;
 use std::sync::Arc;
 #[cfg(feature = "policy-rvps")]
 use std::time::Duration;
 
-use super::{EvaluationResult, PolicyDigest, PolicyEngine, PolicyError};
+use crate::rvps::ReferenceValueResolver;
+
+use super::{EvaluationResult, PolicyError};
+
+#[cfg(feature = "fs")]
+mod fs;
+mod in_memory;
+
+#[cfg(feature = "fs")]
+pub use fs::OPA;
+pub use in_memory::OPAInMemory;
 
 #[cfg(all(feature = "policy-rvps", not(test)))]
 const REFERENCE_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 #[cfg(all(feature = "policy-rvps", test))]
 const REFERENCE_QUERY_TIMEOUT: Duration = Duration::from_millis(100);
 
-#[derive(Debug, Clone)]
-pub struct OPA {
-    policy_dir_path: PathBuf,
+fn is_valid_policy_id(policy_id: &str) -> bool {
+    policy_id
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
 }
 
-impl OPA {
-    pub fn new(
-        work_dir: PathBuf,
-        default_policy: &str,
-        default_policy_id: &str,
-    ) -> Result<Self, PolicyError> {
-        let mut policy_dir_path = work_dir;
+fn policy_uses_legacy_reference(policy: &str) -> Result<bool, PolicyError> {
+    use regorus::unstable::{Lexer, Source, TokenKind};
 
-        policy_dir_path.push("opa");
-        if !policy_dir_path.as_path().exists() {
-            fs::create_dir_all(&policy_dir_path).map_err(PolicyError::CreatePolicyDirFailed)?;
+    let source = Source::from_contents("policy.rego".to_string(), policy.to_string())
+        .map_err(PolicyError::LoadPolicyFailed)?;
+    let mut lexer = Lexer::new(&source);
+    let mut tokens = Vec::new();
+
+    loop {
+        let token = lexer.next_token().map_err(PolicyError::LoadPolicyFailed)?;
+        if token.0 == TokenKind::Eof {
+            break;
         }
-
-        let mut default_policy_path = PathBuf::from(
-            &policy_dir_path
-                .to_str()
-                .ok_or_else(|| PolicyError::PolicyDirPathToStringFailed)?,
-        );
-        default_policy_path.push(default_policy_id);
-        if !default_policy_path.as_path().exists() {
-            fs::write(&default_policy_path, default_policy)
-                .map_err(PolicyError::WriteDefaultPolicyFailed)?;
-        } else {
-            warn!("Default policy file is already populated. Existing policy file will be used.");
-        }
-
-        Ok(Self { policy_dir_path })
+        tokens.push((token.0, token.1.text().to_string()));
     }
 
-    fn is_valid_policy_id(policy_id: &str) -> bool {
-        policy_id
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
-    }
+    let dotted = tokens.windows(3).any(|tokens| {
+        tokens[0].0 == TokenKind::Ident
+            && tokens[0].1 == "data"
+            && tokens[1].0 == TokenKind::Symbol
+            && tokens[1].1 == "."
+            && tokens[2].0 == TokenKind::Ident
+            && tokens[2].1 == "reference"
+    });
+    let indexed = tokens.windows(4).any(|tokens| {
+        tokens[0].0 == TokenKind::Ident
+            && tokens[0].1 == "data"
+            && tokens[1].0 == TokenKind::Symbol
+            && tokens[1].1 == "["
+            && matches!(tokens[2].0, TokenKind::String | TokenKind::RawString)
+            && tokens[2].1 == "reference"
+            && tokens[3].0 == TokenKind::Symbol
+            && tokens[3].1 == "]"
+    });
 
-    fn policy_uses_legacy_reference(policy: &str) -> Result<bool, PolicyError> {
-        use regorus::unstable::{Lexer, Source, TokenKind};
+    Ok(dotted || indexed)
+}
 
-        let source = Source::from_contents("policy.rego".to_string(), policy.to_string())
-            .map_err(PolicyError::LoadPolicyFailed)?;
-        let mut lexer = Lexer::new(&source);
-        let mut tokens = Vec::new();
+#[cfg(feature = "policy-rvps")]
+fn query_reference_value_extension(
+    reference_value_resolver: Arc<ReferenceValueResolver>,
+    runtime_handle: tokio::runtime::Handle,
+) -> Box<dyn Extension> {
+    Box::new(move |params: Vec<regorus::Value>| {
+        if params.len() != 1 {
+            bail!("query_reference_value requires exactly one parameter");
+        }
+        let reference_value_id = params[0]
+            .as_string()
+            .context("query_reference_value parameter must be a string")?
+            .to_string();
+        debug!("query reference value from RVPS: {reference_value_id}");
 
-        loop {
-            let token = lexer.next_token().map_err(PolicyError::LoadPolicyFailed)?;
-            if token.0 == TokenKind::Eof {
-                break;
+        let value = runtime_handle
+            .block_on(async {
+                tokio::time::timeout(
+                    REFERENCE_QUERY_TIMEOUT,
+                    reference_value_resolver.query_reference_value(&reference_value_id),
+                )
+                .await
+                .map_err(|_| {
+                    anyhow!(
+                        "query_reference_value({reference_value_id:?}) timed out after {:?}",
+                        REFERENCE_QUERY_TIMEOUT
+                    )
+                })?
+            })
+            .map_err(|e| anyhow!("query_reference_value({reference_value_id:?}) failed: {e}"))?;
+
+        match value {
+            Some(value) => Ok(regorus::Value::from(value)),
+            None => {
+                warn!("No reference value found for id {reference_value_id:?}; returning null");
+                Ok(regorus::Value::Null)
             }
-            tokens.push((token.0, token.1.text().to_string()));
         }
+    })
+}
 
-        let dotted = tokens.windows(3).any(|tokens| {
-            tokens[0].0 == TokenKind::Ident
-                && tokens[0].1 == "data"
-                && tokens[1].0 == TokenKind::Symbol
-                && tokens[1].1 == "."
-                && tokens[2].0 == TokenKind::Ident
-                && tokens[2].1 == "reference"
-        });
-        let indexed = tokens.windows(4).any(|tokens| {
-            tokens[0].0 == TokenKind::Ident
-                && tokens[0].1 == "data"
-                && tokens[1].0 == TokenKind::Symbol
-                && tokens[1].1 == "["
-                && matches!(tokens[2].0, TokenKind::String | TokenKind::RawString)
-                && tokens[2].1 == "reference"
-                && tokens[3].0 == TokenKind::Symbol
-                && tokens[3].1 == "]"
-        });
-
-        Ok(dotted || indexed)
-    }
+async fn common_evaluate(
+    policy: String,
+    input: String,
+    policy_id: String,
+    evaluation_rules: Vec<String>,
+    reference_value_resolver: Arc<ReferenceValueResolver>,
+) -> Result<EvaluationResult, PolicyError> {
+    let data = if policy_uses_legacy_reference(&policy)? {
+        let reference_values = reference_value_resolver
+            .get_reference_values()
+            .await
+            .map_err(|e| PolicyError::LoadReferenceDataFailed(e.into()))?;
+        serde_json::json!({ "reference": reference_values }).to_string()
+    } else {
+        "{}".to_string()
+    };
 
     #[cfg(feature = "policy-rvps")]
-    fn query_reference_value_extension(
-        reference_value_resolver: Arc<ReferenceValueResolver>,
-        runtime_handle: tokio::runtime::Handle,
-    ) -> Box<dyn Extension> {
-        Box::new(move |params: Vec<regorus::Value>| {
-            if params.len() != 1 {
-                bail!("query_reference_value requires exactly one parameter");
-            }
-            let reference_value_id = params[0]
-                .as_string()
-                .context("query_reference_value parameter must be a string")?
-                .to_string();
-            debug!("query reference value from RVPS: {reference_value_id}");
-
-            let value = runtime_handle
-                .block_on(async {
-                    tokio::time::timeout(
-                        REFERENCE_QUERY_TIMEOUT,
-                        reference_value_resolver.query_reference_value(&reference_value_id),
-                    )
-                    .await
-                    .map_err(|_| {
-                        anyhow!(
-                            "query_reference_value({reference_value_id:?}) timed out after {:?}",
-                            REFERENCE_QUERY_TIMEOUT
-                        )
-                    })?
-                })
-                .map_err(|e| {
-                    anyhow!("query_reference_value({reference_value_id:?}) failed: {e}")
-                })?;
-
-            match value {
-                Some(value) => Ok(regorus::Value::from(value)),
-                None => {
-                    warn!("No reference value found for id {reference_value_id:?}; returning null");
-                    Ok(regorus::Value::Null)
-                }
-            }
+    {
+        let runtime_handle = tokio::runtime::Handle::current();
+        let query_extension = Some(query_reference_value_extension(
+            reference_value_resolver,
+            runtime_handle,
+        ));
+        tokio::task::spawn_blocking(move || {
+            evaluate_sync(
+                policy,
+                input,
+                policy_id,
+                evaluation_rules,
+                data,
+                query_extension,
+            )
         })
+        .await
+        .map_err(|e| {
+            PolicyError::EvalPolicyFailed(anyhow!("Regorus blocking evaluation task failed: {e}"))
+        })?
     }
 
-    fn evaluate_sync(
-        policy: String,
-        input: String,
-        policy_id: String,
-        evaluation_rules: Vec<String>,
-        data: String,
-        query_extension: Option<Box<dyn Extension>>,
-    ) -> Result<EvaluationResult, PolicyError> {
-        let mut engine = regorus::Engine::new();
-
-        let policy_hash = {
-            let mut hasher = sha2::Sha384::new();
-            hasher.update(&policy);
-            hex::encode(hasher.finalize())
-        };
-
-        engine
-            .add_policy(policy_id.clone(), policy)
-            .map_err(PolicyError::LoadPolicyFailed)?;
-
-        let data =
-            regorus::Value::from_json_str(&data).map_err(PolicyError::JsonSerializationFailed)?;
-        engine
-            .add_data(data)
-            .map_err(PolicyError::LoadReferenceDataFailed)?;
-
-        engine
-            .set_input_json(&input)
-            .context("set input")
-            .map_err(PolicyError::SetInputDataFailed)?;
-
-        if let Some(query_extension) = query_extension {
-            engine
-                .add_extension("query_reference_value".to_string(), 1, query_extension)
-                .map_err(PolicyError::EvalPolicyFailed)?;
-        }
-
-        let mut rules_result = HashMap::new();
-        for rule in evaluation_rules {
-            let whole_rule = format!("data.policy.{rule}");
-            let claim_value = match engine.eval_rule(whole_rule) {
-                Ok(value) => value,
-                Err(error) if error.to_string().contains("not a valid rule path") => {
-                    debug!("Policy `{policy_id}` does not check {rule}");
-                    continue;
-                }
-                Err(error) => return Err(PolicyError::EvalPolicyFailed(error)),
-            };
-
-            let claim_value = claim_value
-                .to_json_str()
-                .map_err(PolicyError::JsonSerializationFailed)?;
-            let claim_value =
-                serde_json::from_str(&claim_value).map_err(PolicyError::SerdeJsonError)?;
-            rules_result.insert(rule, claim_value);
-        }
-
-        Ok(EvaluationResult {
-            rules_result,
-            policy_hash,
-        })
-    }
+    #[cfg(not(feature = "policy-rvps"))]
+    evaluate_sync(policy, input, policy_id, evaluation_rules, data, None)
 }
 
-#[async_trait]
-impl PolicyEngine for OPA {
-    async fn evaluate(
-        &self,
-        input: &str,
-        policy_id: &str,
-        evaluation_rules: Vec<String>,
-        reference_value_resolver: Arc<ReferenceValueResolver>,
-    ) -> Result<EvaluationResult, PolicyError> {
-        let policy_dir_path = self
-            .policy_dir_path
-            .to_str()
-            .ok_or_else(|| PolicyError::PolicyDirPathToStringFailed)?;
+fn evaluate_sync(
+    policy: String,
+    input: String,
+    policy_id: String,
+    evaluation_rules: Vec<String>,
+    data: String,
+    query_extension: Option<Box<dyn Extension>>,
+) -> Result<EvaluationResult, PolicyError> {
+    let mut engine = regorus::Engine::new();
 
-        let policy_file_path = format!("{policy_dir_path}/{policy_id}.rego");
+    let policy_hash = {
+        let mut hasher = sha2::Sha384::new();
+        hasher.update(&policy);
+        hex::encode(hasher.finalize())
+    };
 
-        let policy =
-            fs::read_to_string(policy_file_path).map_err(PolicyError::ReadPolicyFileFailed)?;
+    engine
+        .add_policy(policy_id.clone(), policy)
+        .map_err(PolicyError::LoadPolicyFailed)?;
 
-        let data = if Self::policy_uses_legacy_reference(&policy)? {
-            let reference_values = reference_value_resolver
-                .get_reference_values()
-                .await
-                .map_err(|e| PolicyError::LoadReferenceDataFailed(e.into()))?;
-            serde_json::json!({ "reference": reference_values }).to_string()
-        } else {
-            "{}".to_string()
+    let data =
+        regorus::Value::from_json_str(&data).map_err(PolicyError::JsonSerializationFailed)?;
+    engine
+        .add_data(data)
+        .map_err(PolicyError::LoadReferenceDataFailed)?;
+
+    engine
+        .set_input_json(&input)
+        .context("set input")
+        .map_err(PolicyError::SetInputDataFailed)?;
+
+    if let Some(query_extension) = query_extension {
+        engine
+            .add_extension("query_reference_value".to_string(), 1, query_extension)
+            .map_err(PolicyError::EvalPolicyFailed)?;
+    }
+
+    let mut rules_result = HashMap::new();
+    for rule in evaluation_rules {
+        let whole_rule = format!("data.policy.{rule}");
+        let claim_value = match engine.eval_rule(whole_rule) {
+            Ok(value) => value,
+            Err(error) if error.to_string().contains("not a valid rule path") => {
+                debug!("Policy `{policy_id}` does not check {rule}");
+                continue;
+            }
+            Err(error) => return Err(PolicyError::EvalPolicyFailed(error)),
         };
 
-        #[cfg(feature = "policy-rvps")]
-        {
-            let runtime_handle = tokio::runtime::Handle::current();
-            let query_extension = Some(Self::query_reference_value_extension(
-                reference_value_resolver,
-                runtime_handle,
-            ));
-            let policy_id = policy_id.to_string();
-            let input = input.to_string();
-            return tokio::task::spawn_blocking(move || {
-                Self::evaluate_sync(
-                    policy,
-                    input,
-                    policy_id,
-                    evaluation_rules,
-                    data,
-                    query_extension,
-                )
-            })
-            .await
-            .map_err(|e| {
-                PolicyError::EvalPolicyFailed(anyhow!(
-                    "Regorus blocking evaluation task failed: {e}"
-                ))
-            })?;
-        }
-
-        #[cfg(not(feature = "policy-rvps"))]
-        Self::evaluate_sync(
-            policy,
-            input.to_string(),
-            policy_id.to_string(),
-            evaluation_rules,
-            data,
-            None,
-        )
+        let claim_value = claim_value
+            .to_json_str()
+            .map_err(PolicyError::JsonSerializationFailed)?;
+        let claim_value =
+            serde_json::from_str(&claim_value).map_err(PolicyError::SerdeJsonError)?;
+        rules_result.insert(rule, claim_value);
     }
 
-    async fn set_policy(&self, policy_id: String, policy: String) -> Result<(), PolicyError> {
-        let policy_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(policy)?;
-
-        if !Self::is_valid_policy_id(&policy_id) {
-            return Err(PolicyError::InvalidPolicyId);
-        }
-
-        // Check if the policy is valid
-        {
-            let policy_content = String::from_utf8(policy_bytes.clone())
-                .map_err(|e| PolicyError::InvalidPolicy(e.into()))?;
-            let mut engine = regorus::Engine::new();
-            engine
-                .add_policy(policy_id.clone(), policy_content)
-                .map_err(PolicyError::InvalidPolicy)?;
-        }
-
-        let mut policy_file_path = PathBuf::from(
-            &self
-                .policy_dir_path
-                .to_str()
-                .ok_or_else(|| PolicyError::PolicyDirPathToStringFailed)?,
-        );
-
-        policy_file_path.push(format!("{}.rego", policy_id));
-
-        fs::write(&policy_file_path, policy_bytes).map_err(PolicyError::WritePolicyFileFailed)
-    }
-
-    async fn list_policies(&self) -> Result<HashMap<String, PolicyDigest>, PolicyError> {
-        let mut policy_ids = Vec::new();
-        let entries = fs::read_dir(&self.policy_dir_path)?;
-        for entry in entries {
-            let entry = entry?;
-            let path = entry.path();
-            if path.extension().and_then(std::ffi::OsStr::to_str) == Some("rego") {
-                if let Some(filename) = path.file_stem() {
-                    if let Some(filename_str) = filename.to_str() {
-                        policy_ids.push(filename_str.to_owned());
-                    }
-                }
-            }
-        }
-
-        let mut policy_list = HashMap::new();
-
-        for id in policy_ids.iter() {
-            let policy_file_path = self.policy_dir_path.join(format!("{id}.rego"));
-            let policy = fs::read(policy_file_path).map_err(PolicyError::ReadPolicyFileFailed)?;
-
-            let mut hasher = Sha384::new();
-            hasher.update(policy);
-            let digest = hasher.finalize().to_vec();
-            policy_list.insert(
-                id.to_string(),
-                base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest),
-            );
-        }
-
-        Ok(policy_list)
-    }
-
-    async fn get_policy(&self, policy_id: String) -> Result<String, PolicyError> {
-        let policy_file_path = self.policy_dir_path.join(format!("{policy_id}.rego"));
-        let policy = fs::read(policy_file_path).map_err(PolicyError::ReadPolicyFileFailed)?;
-        let base64_policy = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(policy);
-        Ok(base64_policy)
-    }
-
-    async fn delete_policy(&self, policy_id: String) -> Result<(), PolicyError> {
-        if !Self::is_valid_policy_id(&policy_id) {
-            return Err(PolicyError::InvalidPolicyId);
-        }
-
-        // Prevent deletion of default policy
-        if policy_id == "default" {
-            return Err(PolicyError::CannotDeleteDefaultPolicy);
-        }
-
-        let policy_file_path = self.policy_dir_path.join(format!("{policy_id}.rego"));
-
-        if !policy_file_path.exists() {
-            return Err(PolicyError::ReadPolicyFileFailed(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("Policy {} not found", policy_id),
-            )));
-        }
-
-        fs::remove_file(policy_file_path).map_err(PolicyError::IOError)?;
-
-        Ok(())
-    }
+    Ok(EvaluationResult {
+        rules_result,
+        policy_hash,
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::rvps::{RvpsApi, RvpsError};
-    use ear::TrustVector;
-    use rstest::rstest;
-    use serde_json::json;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
     use super::*;
-
-    fn dummy_reference(svn: u64, launch_digest: String) -> Arc<ReferenceValueResolver> {
-        crate::rvps::test_resolver(HashMap::from([
-            ("svn".to_string(), json!([svn.to_string()])),
-            ("launch_digest".to_string(), json!([launch_digest])),
-        ]))
-    }
-
-    fn dummy_input(svn: u64, launch_digest: String) -> String {
-        json!({
-            "sample": {
-                "svn": svn.to_string(),
-                "launch_digest": launch_digest
-            }
-        })
-        .to_string()
-    }
-
-    #[rstest]
-    // #[case(1,1,"aac43bb3".to_string(),"aac43bb3".to_string(),3,2)]
-    //#[case(2,1,"aac43bb3".to_string(),"aac43bb3".to_string(),3,97)]
-    //#[case(1,1,"aac43bb4".to_string(),"aac43bb3".to_string(),33,2)]
-    #[case(2,1,"aac43bb4".to_string(),"aac43bb3".to_string(),33,97)]
-    #[tokio::test]
-    async fn test_evaluate(
-        #[case] svn_a: u64,
-        #[case] svn_b: u64,
-        #[case] digest_a: String,
-        #[case] digest_b: String,
-        #[case] ex_exp: i8,
-        #[case] hw_exp: i8,
-    ) {
-        let opa = OPA {
-            policy_dir_path: PathBuf::from("./src/token/"),
-        };
-        let default_policy_id = "ear_default_policy_cpu".to_string();
-
-        let ear_rules = TrustVector::new()
-            .into_iter()
-            .map(|c| c.tag().to_string().replace("-", "_"))
-            .collect();
-
-        let output = opa
-            .evaluate(
-                &dummy_input(svn_b, digest_b),
-                &default_policy_id,
-                ear_rules,
-                dummy_reference(svn_a, digest_a),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(
-            hw_exp,
-            output
-                .rules_result
-                .get("hardware")
-                .unwrap()
-                .as_i64()
-                .unwrap() as i8
-        );
-        assert_eq!(
-            ex_exp,
-            output
-                .rules_result
-                .get("executables")
-                .unwrap()
-                .as_i64()
-                .unwrap() as i8
-        );
-    }
-
-    #[tokio::test]
-    async fn test_policy_management() {
-        let opa = OPA::new(PathBuf::from("tests/tmp"), "default", "default.rego").unwrap();
-        let policy = "package policy
-default allow = true"
-            .to_string();
-
-        let get_policy_output = "cGFja2FnZSBwb2xpY3kKZGVmYXVsdCBhbGxvdyA9IHRydWU".to_string();
-
-        assert!(opa
-            .set_policy(
-                "test".to_string(),
-                base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(policy)
-            )
-            .await
-            .is_ok());
-        let policy_list = opa.list_policies().await.unwrap();
-        assert_eq!(policy_list.len(), 2);
-        let test_policy = opa.get_policy("test".to_string()).await.unwrap();
-        assert_eq!(test_policy, get_policy_output);
-        assert!(opa.list_policies().await.is_ok());
-    }
 
     #[test]
     fn detects_legacy_reference_without_comment_or_string_false_positives() {
-        assert!(OPA::policy_uses_legacy_reference(
+        assert!(policy_uses_legacy_reference(
             "package policy\nallow { input.svn in data.reference.svn }"
         )
         .unwrap());
-        assert!(OPA::policy_uses_legacy_reference(
+        assert!(policy_uses_legacy_reference(
             "package policy\nallow { input.svn in data[\"reference\"].svn }"
         )
         .unwrap());
-        assert!(!OPA::policy_uses_legacy_reference(
+        assert!(!policy_uses_legacy_reference(
             r#"package policy
                # data.reference.comment_only
                message := "data.reference.string_only"
                allow := true"#
         )
         .unwrap());
-    }
-
-    #[cfg(feature = "policy-rvps")]
-    struct CountingRvps {
-        keyed_queries: AtomicUsize,
-        bulk_queries: AtomicUsize,
-    }
-
-    #[cfg(feature = "policy-rvps")]
-    #[async_trait::async_trait]
-    impl RvpsApi for CountingRvps {
-        async fn verify_and_extract(&self, _message: &str) -> std::result::Result<(), RvpsError> {
-            unreachable!()
-        }
-
-        async fn set_reference_value_list(
-            &self,
-            _payload: &str,
-        ) -> std::result::Result<(), RvpsError> {
-            unreachable!()
-        }
-
-        async fn query_reference_value(
-            &self,
-            reference_value_id: &str,
-        ) -> std::result::Result<Option<serde_json::Value>, RvpsError> {
-            self.keyed_queries.fetch_add(1, Ordering::SeqCst);
-            Ok(match reference_value_id {
-                "svn" => Some(json!([7])),
-                "minimum" => Some(json!(3)),
-                _ => None,
-            })
-        }
-
-        async fn get_reference_values(
-            &self,
-        ) -> std::result::Result<HashMap<String, serde_json::Value>, RvpsError> {
-            self.bulk_queries.fetch_add(1, Ordering::SeqCst);
-            Ok(HashMap::new())
-        }
-
-        async fn delete_reference_value(
-            &self,
-            _name: &str,
-        ) -> std::result::Result<bool, RvpsError> {
-            unreachable!()
-        }
-    }
-
-    #[cfg(feature = "policy-rvps")]
-    #[tokio::test]
-    async fn query_extension_is_keyed_cached_and_returns_null_for_missing() {
-        let policy = r#"package policy
-default allow = false
-allow {
-    query_reference_value("svn") == [7]
-    query_reference_value("missing") == null
-}
-minimum = query_reference_value("minimum")
-svn_again = query_reference_value("svn")
-"#;
-        let tmp = tempfile::tempdir().unwrap();
-        let opa = OPA::new(tmp.path().to_path_buf(), policy, "query.rego").unwrap();
-        let rvps = Arc::new(CountingRvps {
-            keyed_queries: AtomicUsize::new(0),
-            bulk_queries: AtomicUsize::new(0),
-        });
-        let resolver = Arc::new(ReferenceValueResolver::new(
-            Arc::clone(&rvps) as Arc<dyn RvpsApi>
-        ));
-
-        let result = opa
-            .evaluate(
-                "{}",
-                "query",
-                vec![
-                    "allow".to_string(),
-                    "minimum".to_string(),
-                    "svn_again".to_string(),
-                ],
-                resolver,
-            )
-            .await
-            .unwrap();
-
-        assert!(result.rules_result.get("allow").unwrap().as_bool().unwrap());
-        assert_eq!(
-            result
-                .rules_result
-                .get("minimum")
-                .unwrap()
-                .as_i64()
-                .unwrap(),
-            3
-        );
-        assert_eq!(result.rules_result.get("svn_again").unwrap(), &json!([7]));
-        assert_eq!(rvps.keyed_queries.load(Ordering::SeqCst), 3);
-        assert_eq!(rvps.bulk_queries.load(Ordering::SeqCst), 0);
-    }
-
-    #[cfg(feature = "policy-rvps")]
-    struct UnavailableRvps {
-        timeout: bool,
-    }
-
-    #[cfg(feature = "policy-rvps")]
-    #[async_trait::async_trait]
-    impl RvpsApi for UnavailableRvps {
-        async fn verify_and_extract(&self, _message: &str) -> std::result::Result<(), RvpsError> {
-            unreachable!()
-        }
-
-        async fn set_reference_value_list(
-            &self,
-            _payload: &str,
-        ) -> std::result::Result<(), RvpsError> {
-            unreachable!()
-        }
-
-        async fn query_reference_value(
-            &self,
-            _reference_value_id: &str,
-        ) -> std::result::Result<Option<serde_json::Value>, RvpsError> {
-            if self.timeout {
-                std::future::pending::<()>().await;
-                unreachable!()
-            }
-            Err(RvpsError::Anyhow(anyhow!("RVPS backend unavailable")))
-        }
-
-        async fn get_reference_values(
-            &self,
-        ) -> std::result::Result<HashMap<String, serde_json::Value>, RvpsError> {
-            unreachable!()
-        }
-
-        async fn delete_reference_value(
-            &self,
-            _name: &str,
-        ) -> std::result::Result<bool, RvpsError> {
-            unreachable!()
-        }
-    }
-
-    #[cfg(feature = "policy-rvps")]
-    async fn evaluate_unavailable_rvps(timeout: bool) -> String {
-        let policy = r#"package policy
-allow = query_reference_value("svn") == [7]
-"#;
-        let tmp = tempfile::tempdir().unwrap();
-        let opa = OPA::new(tmp.path().to_path_buf(), policy, "query.rego").unwrap();
-        let resolver = Arc::new(ReferenceValueResolver::new(Arc::new(UnavailableRvps {
-            timeout,
-        })));
-
-        opa.evaluate("{}", "query", vec!["allow".to_string()], resolver)
-            .await
-            .unwrap_err()
-            .to_string()
-    }
-
-    #[cfg(feature = "policy-rvps")]
-    #[tokio::test]
-    async fn query_extension_preserves_backend_errors() {
-        let error = evaluate_unavailable_rvps(false).await;
-        assert!(error.contains("RVPS backend unavailable"), "{error}");
-    }
-
-    #[cfg(feature = "policy-rvps")]
-    #[tokio::test]
-    async fn query_extension_times_out() {
-        let error = evaluate_unavailable_rvps(true).await;
-        assert!(error.contains("timed out"), "{error}");
     }
 }


### PR DESCRIPTION
This commit extracts the shared parts of the existing `struct OPA` implementation and adds a new `struct OPAInMemory`. Both implement the `trait PolicyEngine`, intended for scenarios that do not depend on an external storage filesystem. However, since the current consumer of policy engine, the token broker, still hardcodes its dependency on `struct OPA`, and reworking that is relatively involved, it is not included in this PR. Although `struct OPAInMemory` has no consumers in the current project, we have still achieved a degree of decoupling. In the next PR, we will rework the token broker so that crate integrators can choose between `struct OPA` and `struct OPAInMemory` in code.