### PR TITLE
refactor(token-broker): introduce SignKeyProvider trait

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -250,7 +250,5 @@ jobs:
         run: |
           RUSTUP_TOOLCHAIN=nightly-2025-07-07 cargo check -p eventlog --target wasm32-unknown-unknown
           RUSTUP_TOOLCHAIN=nightly-2025-07-07 cargo check -p reference-value-provider-service --target wasm32-unknown-unknown --no-default-features  # no "fs" feature in wasm
-          # The only OPA policy engine still hard-depends on tokio::fs, which is
-          # unavailable on wasm32, so the attestation-service check is disabled for now.
-          # RUSTUP_TOOLCHAIN=nightly-2025-07-07 cargo check -p attestation-service --target wasm32-unknown-unknown --no-default-features --features tdx-dcap-rust
+          RUSTUP_TOOLCHAIN=nightly-2025-07-07 cargo check -p attestation-service --target wasm32-unknown-unknown --no-default-features --features tdx-dcap-rust
           RUSTUP_TOOLCHAIN=nightly-2025-07-07 cargo check -p verifier --target wasm32-unknown-unknown --no-default-features --features tdx-dcap-rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,7 @@ dependencies = [
  "reqwest 0.12.12",
  "rsa",
  "rstest",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_variant",

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -105,11 +105,7 @@ toml.workspace = true
 tonic = { workspace = true, optional = true }
 verifier = { path = "../deps/verifier", default-features = false }
 const_format.workspace = true
-# x509-cert is used by `token/simple.rs` for PEM/DER certificate-chain parsing
-# (JWK `x5c`). Pulled in as a direct dep so `simple.rs` can call
-# `Certificate::from_pem` / `to_der`. The `pem` feature enables
-# `der::DecodePem` (used by `from_pem`); `std` is part of the default set.
-x509-cert = { version = "0.2.5", default-features = false, features = ["pem", "std"] }
+rustls-pki-types.workspace = true
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies]
 uuid = { version = "1.1.2", features = ["v4"] }
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies]
@@ -130,3 +126,4 @@ serial_test.workspace = true
 sha2.workspace = true
 testing_logger = "0.1.1"
 tokio = { workspace = true, features = ["full"] }
+x509-cert = { version = "0.2.5", default-features = false, features = ["pem", "std"] }

--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -92,7 +92,7 @@ mod tests {
     use crate::rvps::RvpsCrateConfig;
     use crate::{
         rvps::RvpsConfig,
-        token::{ear_broker, simple, AttestationTokenConfig},
+        token::{ear_broker, oidc, simple, AttestationTokenConfig},
     };
     use reference_value_provider_service::storage::{local_fs, ReferenceValueStorageConfig};
 
@@ -171,9 +171,141 @@ mod tests {
         }),
         challenge_key_path: None,
     })]
+    #[case("./tests/configs/example5.json", Config {
+        work_dir: PathBuf::from("/var/lib/attestation-service/"),
+        rvps_config: RvpsConfig::BuiltIn(RvpsCrateConfig {
+            storage: ReferenceValueStorageConfig::LocalFs(local_fs::Config::default()),
+        }),
+        attestation_token_broker: AttestationTokenConfig::OIDC(oidc::Configuration {
+            settings: oidc::TokenBrokerSettings {
+                duration_min: 5,
+                issuer_name: "test".into(),
+                oid_config: Some(oidc::OpenIDConfig {
+                    issuer: "https://example.com".into(),
+                    jwks_uri: "https://example.com/jwks".into(),
+                    id_token_signing_alg_values_supported: vec!["RS256".into()],
+                    audience: "sigstore".into(),
+                    sub_claims: Some(vec!["sub1".into()]),
+                    additional_claims: Some(vec!["extra1".into()]),
+                }),
+            },
+            signer: Some(oidc::SignerConfig {
+                key_path: "/etc/key".into(),
+                cert_url: Some("https://example.io".into()),
+                cert_path: Some("/etc/cert.pem".into()),
+            }),
+            policy_dir: "/var/lib/attestation-service/policies".into(),
+        }),
+        challenge_key_path: None,
+    })]
     fn read_config(#[case] config: &str, #[case] expected: Config) {
         let config = std::fs::read_to_string(config).unwrap();
         let config: Config = serde_json::from_str(&config).unwrap();
         assert_eq!(config, expected);
+    }
+
+    // Backward compatibility: the refactor moved `duration_min` / `issuer_name`
+    // (and ear's `developer_name` / `build_name` / `profile_name`, oidc's
+    // `oid_config`) into a nested `settings: TokenBrokerSettings` sub-struct.
+    // `#[serde(flatten)]` on `settings` must keep the *pre-refactor* flat
+    // JSON/TOML config format working. These inline cases assert that a flat
+    // broker config still deserializes into the nested struct for every broker
+    // variant, without relying on the on-disk example fixtures.
+    #[test]
+    fn backward_compat_flat_broker_json_deserializes_into_nested_settings() {
+        // Simple: flat `duration_min` / `issuer_name` → `settings.*`.
+        let json = r#"{
+            "type": "Simple",
+            "duration_min": 9,
+            "issuer_name": "flat-issuer",
+            "policy_dir": "/p"
+        }"#;
+        let cfg: AttestationTokenConfig = serde_json::from_str(json).unwrap();
+        let simple::Configuration {
+            settings,
+            signer,
+            policy_dir,
+        } = match cfg {
+            AttestationTokenConfig::Simple(c) => c,
+            _ => unreachable!(),
+        };
+        assert_eq!(settings.duration_min, 9);
+        assert_eq!(settings.issuer_name, "flat-issuer");
+        assert_eq!(policy_dir, "/p");
+        assert!(signer.is_none());
+
+        // Ear: flat `developer_name` / `build_name` / `profile_name` → `settings.*`.
+        let json = r#"{
+            "type": "Ear",
+            "duration_min": 9,
+            "issuer_name": "flat-issuer",
+            "developer_name": "dev",
+            "build_name": "build",
+            "profile_name": "prof",
+            "policy_dir": "/p"
+        }"#;
+        let cfg: AttestationTokenConfig = serde_json::from_str(json).unwrap();
+        let ear_broker::Configuration {
+            settings,
+            signer,
+            policy_dir,
+        } = match cfg {
+            AttestationTokenConfig::Ear(c) => c,
+            _ => unreachable!(),
+        };
+        assert_eq!(settings.developer_name, "dev");
+        assert_eq!(settings.build_name, "build");
+        assert_eq!(settings.profile_name, "prof");
+        assert_eq!(policy_dir, "/p");
+        assert!(signer.is_none());
+
+        // OIDC: flat `oid_config` → `settings.oid_config`.
+        let json = r#"{
+            "type": "OIDC",
+            "duration_min": 9,
+            "issuer_name": "flat-issuer",
+            "policy_dir": "/p",
+            "oid_config": {
+                "issuer": "https://example.com",
+                "jwks_uri": "https://example.com/jwks"
+            }
+        }"#;
+        let cfg: AttestationTokenConfig = serde_json::from_str(json).unwrap();
+        let oidc::Configuration {
+            settings,
+            signer,
+            policy_dir,
+        } = match cfg {
+            AttestationTokenConfig::OIDC(c) => c,
+            _ => unreachable!(),
+        };
+        let oid = settings.oid_config.expect("oid_config deserialized");
+        assert_eq!(oid.issuer, "https://example.com");
+        assert_eq!(oid.jwks_uri, "https://example.com/jwks");
+        assert_eq!(policy_dir, "/p");
+        assert!(signer.is_none());
+    }
+
+    // Backward-compat / relaxation: the shared `SignerConfig` makes `cert_url`
+    // and `cert_path` `#[serde(default)]` (absent → `None`). The pre-refactor
+    // simple/oidc `TokenSignerConfig` rejected a signer missing `cert_url`; the
+    // new shared config must accept a minimal `{key_path}` signer for every
+    // broker.
+    #[test]
+    fn signer_config_accepts_minimal_key_path_only() {
+        let json = r#"{
+            "type": "Simple",
+            "signer": { "key_path": "/etc/key" },
+            "policy_dir": "/p"
+        }"#;
+        let cfg: AttestationTokenConfig = serde_json::from_str(json).unwrap();
+        let simple::Configuration { signer, .. } = match cfg {
+            AttestationTokenConfig::Simple(c) => c,
+            _ => unreachable!(),
+        };
+        let signer = signer.expect("signer present");
+        assert_eq!(signer.key_path, "/etc/key");
+        assert!(signer.cert_url.is_none());
+        assert!(signer.cert_path.is_none());
     }
 }

--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -103,8 +103,10 @@ mod tests {
             storage: ReferenceValueStorageConfig::LocalFs(local_fs::Config::default()),
         }),
         attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration {
-            duration_min: 5,
-            issuer_name: "test".into(),
+            settings: simple::TokenBrokerSettings {
+                duration_min: 5,
+                issuer_name: "test".into(),
+            },
             signer: None,
             policy_dir: "/var/lib/attestation-service/policies".into(),
         }),
@@ -116,14 +118,16 @@ mod tests {
             storage: ReferenceValueStorageConfig::LocalFs(local_fs::Config::default()),
         }),
         attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration {
-            duration_min: 5,
-            issuer_name: "test".into(),
+            settings: simple::TokenBrokerSettings {
+                duration_min: 5,
+                issuer_name: "test".into(),
+            },
             policy_dir: "/var/lib/attestation-service/policies".into(),
-            signer: Some(simple::TokenSignerConfig {
+            signer: Some(simple::SignerConfig {
                 key_path: "/etc/key".into(),
                 cert_url: Some("https://example.io".into()),
                 cert_path: Some("/etc/cert.pem".into())
-            })
+            }),
         }),
         challenge_key_path: None,
     })]
@@ -133,13 +137,15 @@ mod tests {
             storage: ReferenceValueStorageConfig::LocalFs(local_fs::Config::default()),
         }),
         attestation_token_broker: AttestationTokenConfig::Ear(ear_broker::Configuration {
-            duration_min: 5,
-            issuer_name: "test".into(),
+            settings: ear_broker::TokenBrokerSettings {
+                duration_min: 5,
+                issuer_name: "test".into(),
+                developer_name: "someone".into(),
+                build_name: "0.1.0".into(),
+                profile_name: "tag:github.com,2024:confidential-containers/Trustee".into(),
+            },
             signer: None,
             policy_dir: "/var/lib/attestation-service/policies".into(),
-            developer_name: "someone".into(),
-            build_name: "0.1.0".into(),
-            profile_name: "tag:github.com,2024:confidential-containers/Trustee".into()
         }),
         challenge_key_path: None,
     })]
@@ -149,17 +155,19 @@ mod tests {
             storage: ReferenceValueStorageConfig::LocalFs(local_fs::Config::default()),
         }),
         attestation_token_broker: AttestationTokenConfig::Ear(ear_broker::Configuration {
-            duration_min: 5,
-            issuer_name: "test".into(),
+            settings: ear_broker::TokenBrokerSettings {
+                duration_min: 5,
+                issuer_name: "test".into(),
+                developer_name: "someone".into(),
+                build_name: "0.1.0".into(),
+                profile_name: "tag:github.com,2024:confidential-containers/Trustee".into(),
+            },
             policy_dir: "/var/lib/attestation-service/policies".into(),
-            developer_name: "someone".into(),
-            build_name: "0.1.0".into(),
-            profile_name: "tag:github.com,2024:confidential-containers/Trustee".into(),
-            signer: Some(ear_broker::TokenSignerConfig {
+            signer: Some(ear_broker::SignerConfig {
                 key_path: "/etc/key".into(),
                 cert_url: Some("https://example.io".into()),
                 cert_path: Some("/etc/cert.pem".into())
-            })
+            }),
         }),
         challenge_key_path: None,
     })]

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -11,31 +11,21 @@ pub mod token;
 
 mod composite;
 
-use crate::token::AttestationTokenBroker;
+use crate::{rvps::ReferenceValueResolver, token::AttestationTokenBroker};
 
 use anyhow::{anyhow, Context, Result};
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use base64::Engine;
 use canon_json::CanonicalFormatter;
 use config::Config;
 pub use kbs_types::{Attestation, Tee};
 use log::info;
 #[cfg(feature = "fs")]
 use reqwest::Client;
-use rsa::pkcs1::DecodeRsaPrivateKey;
-use rsa::pkcs8::DecodePrivateKey;
-use rsa::traits::PublicKeyParts;
-use rsa::RsaPrivateKey;
-use rvps::{ReferenceValueResolver, RvpsApi, RvpsError};
+use rvps::{RvpsApi, RvpsError};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 pub use serde_json::Value;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use sm3::Sm3;
-use std::collections::HashMap;
-#[cfg(feature = "fs")]
-use std::io::Read;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use strum::{AsRefStr, Display, EnumString};
 use thiserror::Error;
 #[cfg(feature = "fs")]
@@ -235,13 +225,6 @@ pub struct ServiceStatus {
     pub service: String,
     pub status: String,
     pub dependencies: Vec<verifier::DependencyStatus>,
-}
-
-#[derive(serde::Serialize, Debug, Clone)]
-struct Jwk {
-    kty: String,
-    n: String,
-    e: String,
 }
 
 impl AttestationService {
@@ -492,131 +475,60 @@ impl AttestationService {
         }
     }
 
-    /// Get token broker certificate content
-    /// Returns the binary content of the certificate
-    #[cfg(feature = "fs")]
+    /// Get token broker signer certificate content.
+    ///
+    /// The broker self-reports the local cert it loaded at construction (from
+    /// an inline `cert_pem` or a `cert_path`); if it has none, the service
+    /// HTTP-fetches the broker's published `cert_url`. Returns the binary PEM
+    /// bytes, or `None` when no cert is available.
     pub async fn get_token_broker_cert_config(&self) -> Result<Option<Vec<u8>>> {
-        match &self._config.attestation_token_broker {
-            token::AttestationTokenConfig::Simple(cfg) => {
-                if let Some(signer) = &cfg.signer {
-                    self.get_cert_content(signer.cert_path.as_deref(), signer.cert_url.as_deref())
-                        .await
-                } else {
-                    Ok(None)
-                }
-            }
-            token::AttestationTokenConfig::Ear(cfg) => {
-                if let Some(signer) = &cfg.signer {
-                    self.get_cert_content(signer.cert_path.as_deref(), signer.cert_url.as_deref())
-                        .await
-                } else {
-                    Ok(None)
-                }
-            }
-            token::AttestationTokenConfig::OIDC(cfg) => {
-                if let Some(signer) = &cfg.signer {
-                    self.get_cert_content(signer.cert_path.as_deref(), signer.cert_url.as_deref())
-                        .await
-                } else {
-                    Ok(None)
-                }
-            }
+        if let Some(content) = self.token_broker.signer_cert_content().await? {
+            return Ok(Some(content));
+        }
+        match self.token_broker.signer_cert_url() {
+            Some(url) => self.fetch_cert_url(url).await,
+            None => Ok(None),
         }
     }
 
-    /// Get certificate content from file path or URL
-    #[cfg(feature = "fs")]
-    async fn get_cert_content(
-        &self,
-        cert_path: Option<&str>,
-        cert_url: Option<&str>,
-    ) -> Result<Option<Vec<u8>>> {
-        if let Some(path) = cert_path {
-            // Read certificate from file
-            let mut file = std::fs::File::open(path)
-                .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
-            let mut content = Vec::new();
-            file.read_to_end(&mut content)
-                .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
-            Ok(Some(content))
-        } else if let Some(url) = cert_url {
-            // Get certificate from URL
-            let client = Client::new();
-            let response = client
-                .get(url)
-                .send()
-                .await
-                .map_err(|e| anyhow!("Failed to fetch certificate from URL: {}", e))?;
+    /// Fetch certificate content from a URL (the broker's published x5u).
+    /// Inherent async (not behind the `Send`-bound broker trait), so it stays
+    /// wasm-compatible — reqwest-wasm futures need not be `Send` here.
+    async fn fetch_cert_url(&self, url: &str) -> Result<Option<Vec<u8>>> {
+        let client = Client::new();
+        let response = client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| anyhow!("Failed to fetch certificate from URL: {}", e))?;
 
-            if !response.status().is_success() {
-                return Err(anyhow!(
-                    "Failed to fetch certificate: HTTP {}",
-                    response.status()
-                ));
-            }
-
-            let content = response
-                .bytes()
-                .await
-                .map_err(|e| anyhow!("Failed to read certificate content: {}", e))?;
-
-            Ok(Some(content.to_vec()))
-        } else {
-            Ok(None)
+        if !response.status().is_success() {
+            return Err(anyhow!(
+                "Failed to fetch certificate: HTTP {}",
+                response.status()
+            ));
         }
+
+        let content = response
+            .bytes()
+            .await
+            .map_err(|e| anyhow!("Failed to read certificate content: {}", e))?;
+
+        Ok(Some(content.to_vec()))
     }
 
+    /// Get the token broker's public key set (JWKS JSON). Delegates to the
+    /// broker; only brokers that publish a public key (e.g. OIDC with a
+    /// configured signer) return `Some`.
     pub async fn get_token_broker_public_key(&self) -> Result<Option<String>> {
-        match &self._config.attestation_token_broker {
-            token::AttestationTokenConfig::Simple(_) => Ok(None),
-            token::AttestationTokenConfig::Ear(_) => Ok(None),
-            token::AttestationTokenConfig::OIDC(cfg) => {
-                if let Some(signer) = &cfg.signer {
-                    let pem_data = std::fs::read(&signer.key_path)
-                        .context("Read Token Signer private key failed")?;
-                    let pem_str =
-                        std::str::from_utf8(&pem_data).context("Token Signer key not UTF-8")?;
-                    let private_key = RsaPrivateKey::from_pkcs8_pem(pem_str)
-                        .or_else(|_| RsaPrivateKey::from_pkcs1_pem(pem_str))?;
-                    let n = private_key.n().to_bytes_be();
-                    let e = private_key.e().to_bytes_be();
-
-                    let jwk = Jwk {
-                        kty: "RSA".to_string(),
-                        n: URL_SAFE_NO_PAD.encode(n),
-                        e: URL_SAFE_NO_PAD.encode(e),
-                    };
-
-                    let jwks = json!({
-                        "keys": vec![jwk],
-                    });
-
-                    Ok(Some(serde_json::to_string(&jwks)?))
-                } else {
-                    Ok(None)
-                }
-            }
-        }
+        self.token_broker.public_jwks().await
     }
 
+    /// Get the token broker's OIDC discovery configuration (JSON). Delegates to
+    /// the broker; only the OIDC broker with a configured `oid_config` returns
+    /// `Some`.
     pub async fn get_token_broker_oid_config(&self) -> Result<Option<String>> {
-        match &self._config.attestation_token_broker {
-            token::AttestationTokenConfig::Simple(_) => Ok(None),
-            token::AttestationTokenConfig::Ear(_) => Ok(None),
-            token::AttestationTokenConfig::OIDC(cfg) => {
-                if let Some(oid_config) = &cfg.settings.oid_config {
-                    let oid_info = json!({
-                        "issuer": oid_config.issuer,
-                        "jwks_uri": oid_config.jwks_uri,
-                        "id_token_signing_alg_values_supported": oid_config.id_token_signing_alg_values_supported
-                    });
-
-                    Ok(Some(serde_json::to_string(&oid_info)?))
-                } else {
-                    Ok(None)
-                }
-            }
-        }
+        self.token_broker.oid_config_json().await
     }
 }
 

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -604,7 +604,7 @@ impl AttestationService {
             token::AttestationTokenConfig::Simple(_) => Ok(None),
             token::AttestationTokenConfig::Ear(_) => Ok(None),
             token::AttestationTokenConfig::OIDC(cfg) => {
-                if let Some(oid_config) = &cfg.oid_config {
+                if let Some(oid_config) = &cfg.settings.oid_config {
                     let oid_info = json!({
                         "issuer": oid_config.issuer,
                         "jwks_uri": oid_config.jwks_uri,

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -482,8 +482,8 @@ impl AttestationService {
     /// HTTP-fetches the broker's published `cert_url`. Returns the binary PEM
     /// bytes, or `None` when no cert is available.
     pub async fn get_token_broker_cert_config(&self) -> Result<Option<Vec<u8>>> {
-        if let Some(content) = self.token_broker.signer_cert_content().await? {
-            return Ok(Some(content));
+        if let Some(content) = self.token_broker.signer_cert_content().await {
+            return Ok(Some(content?));
         }
         match self.token_broker.signer_cert_url() {
             Some(url) => self.fetch_cert_url(url).await,

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -520,7 +520,7 @@ impl AttestationService {
     /// broker; only brokers that publish a public key (e.g. OIDC with a
     /// configured signer) return `Some`.
     pub async fn get_token_broker_public_key(&self) -> Result<Option<String>> {
-        self.token_broker.public_jwks().await
+        self.token_broker.configured_signer_jwks().await
     }
 
     /// Get the token broker's OIDC discovery configuration (JSON). Delegates to

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -481,7 +481,7 @@ impl AttestationService {
     /// HTTP-fetches the broker's published `cert_url`. Returns the binary PEM
     /// bytes, or `None` when no cert is available.
     pub async fn get_token_broker_cert_config(&self) -> Result<Option<Vec<u8>>> {
-        if let Some(content) = self.token_broker.signer_cert_content().await {
+        if let Some(content) = self.token_broker.signer_cert_pem_live().await {
             return Ok(Some(content?));
         }
         match self.token_broker.signer_cert_url() {

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -18,7 +18,6 @@ use canon_json::CanonicalFormatter;
 use config::Config;
 pub use kbs_types::{Attestation, Tee};
 use log::info;
-#[cfg(feature = "fs")]
 use reqwest::Client;
 use rvps::{RvpsApi, RvpsError};
 use serde::{Deserialize, Serialize};

--- a/attestation-service/src/policy_engine/mod.rs
+++ b/attestation-service/src/policy_engine/mod.rs
@@ -1,6 +1,5 @@
 use crate::rvps::ReferenceValueResolver;
 use anyhow::Result;
-use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -86,7 +85,15 @@ pub struct EvaluationResult {
     pub policy_hash: String,
 }
 
-#[async_trait]
+#[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), async_trait::async_trait(?Send))]
+#[cfg_attr(
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )),
+    async_trait::async_trait
+)]
 pub trait PolicyEngine: Send + Sync {
     /// The inputs to an policy engine. Inspired by OPA, we divided the inputs
     /// into three parts:

--- a/attestation-service/src/policy_engine/opa/fs.rs
+++ b/attestation-service/src/policy_engine/opa/fs.rs
@@ -50,7 +50,15 @@ impl OPA {
     }
 }
 
-#[async_trait]
+#[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), async_trait::async_trait(?Send))]
+#[cfg_attr(
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )),
+    async_trait::async_trait
+)]
 impl PolicyEngine for OPA {
     async fn evaluate(
         &self,

--- a/attestation-service/src/policy_engine/opa/fs.rs
+++ b/attestation-service/src/policy_engine/opa/fs.rs
@@ -4,7 +4,6 @@
 
 use crate::rvps::ReferenceValueResolver;
 use anyhow::Result;
-use async_trait::async_trait;
 use base64::Engine;
 use log::warn;
 use sha2::{Digest, Sha384};

--- a/attestation-service/src/policy_engine/opa/in_memory.rs
+++ b/attestation-service/src/policy_engine/opa/in_memory.rs
@@ -5,7 +5,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use sha2::{Digest, Sha384};
@@ -45,7 +44,15 @@ impl OPAInMemory {
     }
 }
 
-#[async_trait]
+#[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), async_trait::async_trait(?Send))]
+#[cfg_attr(
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )),
+    async_trait::async_trait
+)]
 impl PolicyEngine for OPAInMemory {
     async fn evaluate(
         &self,

--- a/attestation-service/src/policy_engine/opa/mod.rs
+++ b/attestation-service/src/policy_engine/opa/mod.rs
@@ -32,6 +32,7 @@ const REFERENCE_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 #[cfg(all(feature = "policy-rvps", test))]
 const REFERENCE_QUERY_TIMEOUT: Duration = Duration::from_millis(100);
 
+#[allow(dead_code)]
 fn is_valid_policy_id(policy_id: &str) -> bool {
     policy_id
         .chars()

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -380,8 +380,8 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
             .map_err(Error::from)
     }
 
-    async fn signer_cert_content(&self) -> Option<Result<Vec<u8>>> {
-        self.signer.cert_pem_raw()
+    async fn signer_cert_pem_live(&self) -> Option<Result<Vec<u8>>> {
+        self.signer.cert_pem_live()
     }
 
     fn signer_cert_url(&self) -> Option<&str> {

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -12,9 +12,9 @@ use ear::{
     Algorithm, Appraisal, Ear, ExtensionKind, ExtensionValue, Extensions, RawValue, TrustVector,
     VerifierID,
 };
-use jsonwebtoken::{jwk, EncodingKey};
+use jsonwebtoken::jwk;
 use kbs_types::Tee;
-use log::{debug, info, warn};
+use log::{debug, warn};
 use p256::elliptic_curve::sec1::ToEncodedPoint;
 use p256::pkcs8::{EncodePrivateKey, LineEnding};
 use p256::SecretKey;
@@ -24,16 +24,15 @@ use serde_json::json;
 use serde_json::Value;
 use serde_variant::to_variant_name;
 use std::collections::{BTreeMap, HashMap};
-use std::path::Path;
 use std::sync::Arc;
 use time::{Duration, OffsetDateTime};
 
-use crate::policy_engine::{PolicyEngine, PolicyEngineType};
+use crate::policy_engine::PolicyEngine;
 use crate::rvps::ReferenceValueResolver;
 use crate::token::DEFAULT_TOKEN_WORK_DIR;
 use crate::{AttestationTokenBroker, TeeClaims};
 
-use super::signer::{EphemeralSigner, FsSigner, SignKeyProvider};
+use super::signer::SignKeyProvider;
 #[cfg(feature = "fs")]
 use super::signer_transparency;
 use super::{COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
@@ -160,20 +159,20 @@ impl EarAttestationTokenBroker {
     /// `policy_dir` (OPA fs / InMemory). Replaces the old `new(config)`.
     #[cfg(feature = "fs")]
     pub fn from_config(config: Configuration) -> Result<Self> {
-        let policy_engine = PolicyEngineType::OPA.to_policy_engine(
-            Path::new(&config.policy_dir),
+        let policy_engine = crate::policy_engine::PolicyEngineType::OPA.to_policy_engine(
+            std::path::Path::new(&config.policy_dir),
             DEFAULT_POLICY,
             DEFAULT_POLICY_ID,
         )?;
-        info!("Loading default AS policy \"default.rego\"");
+        log::info!("Loading default AS policy \"default.rego\"");
 
         let signer: Arc<dyn SignKeyProvider<SecretKey>> = match config.signer {
-            Some(sc) => Arc::new(FsSigner::<SecretKey>::from_config(sc)?),
+            Some(sc) => Arc::new(super::signer::FsSigner::<SecretKey>::from_config(sc)?),
             None => {
                 log::info!(
                     "No Token Signer key in config file, create an ephemeral key and without CA pubkey cert"
                 );
-                Arc::new(EphemeralSigner::<SecretKey>::new())
+                Arc::new(super::signer::EphemeralSigner::<SecretKey>::new())
             }
         };
 
@@ -342,7 +341,7 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
             jsonwebtoken::encode(
                 &jwt_header,
                 &Value::Object(ear_claims),
-                &EncodingKey::from_ec_pem(private_key_bytes)?,
+                &jsonwebtoken::EncodingKey::from_ec_pem(private_key_bytes)?,
             )?
         } else {
             ear.sign_jwt_pem_with_header(&jwt_header, private_key_bytes)?
@@ -666,7 +665,7 @@ default file_system := 35
         ));
         let broker = EarAttestationTokenBroker::from_components(
             TokenBrokerSettings::default(),
-            Arc::new(EphemeralSigner::<SecretKey>::new()),
+            Arc::new(crate::token::signer::EphemeralSigner::<SecretKey>::new()),
             policy_engine,
         );
 

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -167,13 +167,13 @@ impl Default for Configuration {
 /// Resolution is eager, in the provider's constructor.
 pub trait SignerProvider: Send + Sync {
     fn private_key(&self) -> &SecretKey;
-    fn cert_chain(&self) -> Option<&[Certificate]>;
+    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>>;
     fn cert_url(&self) -> Option<&str>;
     /// The signer's certificate-chain raw PEM bytes, read lazily from the
     /// configured `cert_path` on each call (not cached at construction).
     /// `None` when no `cert_path` is configured. Ephemeral signers return
     /// `None`. The broker forwards this through `signer_cert_content`.
-    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>>;
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>>;
 }
 
 /// Signer resolved from a `SignerConfig` (native/serde path). Reads
@@ -182,7 +182,6 @@ pub trait SignerProvider: Send + Sync {
 #[cfg(feature = "fs")]
 struct ConfigSigner {
     private_key: SecretKey,
-    cert_chain: Option<Vec<Certificate>>,
     cert_url: Option<String>,
     // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
     cert_path: Option<String>,
@@ -198,8 +197,21 @@ impl ConfigSigner {
             .or_else(|_| SecretKey::from_pkcs8_pem(pem_str))
             .context("Parse Token Signer private key failed")?;
 
-        let cert_chain = signer
-            .cert_path
+        Ok(Self {
+            private_key,
+            cert_url: signer.cert_url,
+            cert_path: signer.cert_path,
+        })
+    }
+}
+
+#[cfg(feature = "fs")]
+impl SignerProvider for ConfigSigner {
+    fn private_key(&self) -> &SecretKey {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
+        self.cert_path
             .as_ref()
             .map(|cert_path| -> Result<Vec<Certificate>> {
                 let pem_cert_chain = std::fs::read_to_string(cert_path)
@@ -219,42 +231,21 @@ impl ConfigSigner {
                 }
                 Ok(chain)
             })
-            .transpose()?;
-
-        Ok(Self {
-            private_key,
-            cert_chain,
-            cert_url: signer.cert_url,
-            cert_path: signer.cert_path,
-        })
-    }
-}
-
-#[cfg(feature = "fs")]
-impl SignerProvider for ConfigSigner {
-    fn private_key(&self) -> &SecretKey {
-        &self.private_key
-    }
-    fn cert_chain(&self) -> Option<&[Certificate]> {
-        self.cert_chain.as_deref()
     }
     fn cert_url(&self) -> Option<&str> {
         self.cert_url.as_deref()
     }
-    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
-        match &self.cert_path {
-            Some(path) => {
-                use std::io::Read as _;
-                // Read certificate from file
-                let mut file = std::fs::File::open(path)
-                    .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
-                let mut content = Vec::new();
-                file.read_to_end(&mut content)
-                    .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
-                Ok(Some(content))
-            }
-            None => Ok(None),
-        }
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
+        self.cert_path.as_ref().map(|path| {
+            use std::io::Read as _;
+            // Read certificate from file
+            let mut file = std::fs::File::open(path)
+                .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
+            let mut content = Vec::new();
+            file.read_to_end(&mut content)
+                .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
+            Ok(content)
+        })
     }
 }
 
@@ -277,14 +268,14 @@ impl SignerProvider for EphemeralSigner {
     fn private_key(&self) -> &SecretKey {
         &self.private_key
     }
-    fn cert_chain(&self) -> Option<&[Certificate]> {
+    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
         None
     }
     fn cert_url(&self) -> Option<&str> {
         None
     }
-    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
-        Ok(None)
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
+        None
     }
 }
 
@@ -513,7 +504,7 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
             .map_err(Error::from)
     }
 
-    async fn signer_cert_content(&self) -> Result<Option<Vec<u8>>> {
+    async fn signer_cert_content(&self) -> Option<Result<Vec<u8>>> {
         self.signer.cert_pem_raw()
     }
 
@@ -528,6 +519,7 @@ impl EarAttestationTokenBroker {
         let chain = self
             .signer
             .cert_chain()
+            .transpose()?
             .map(|certs| -> Result<Vec<String>> {
                 let mut chain = vec![];
                 for cert in certs {

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -197,7 +197,15 @@ impl EarAttestationTokenBroker {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), async_trait::async_trait(?Send))]
+#[cfg_attr(
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )),
+    async_trait::async_trait
+)]
 impl AttestationTokenBroker for EarAttestationTokenBroker {
     async fn issue(
         &self,

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -19,6 +19,9 @@ use p256::elliptic_curve::sec1::ToEncodedPoint;
 use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding};
 use p256::SecretKey;
 use rand::rngs::OsRng;
+#[cfg(feature = "fs")]
+use rustls_pki_types::pem::PemObject;
+use rustls_pki_types::CertificateDer;
 use serde::Deserialize;
 #[cfg(test)]
 use serde_json::json;
@@ -28,8 +31,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use std::sync::Arc;
 use time::{Duration, OffsetDateTime};
-use x509_cert::der::{DecodePem, Encode};
-use x509_cert::Certificate;
 
 use crate::policy_engine::{PolicyEngine, PolicyEngineType};
 use crate::rvps::ReferenceValueResolver;
@@ -167,7 +168,7 @@ impl Default for Configuration {
 /// Resolution is eager, in the provider's constructor.
 pub trait SignerProvider: Send + Sync {
     fn private_key(&self) -> &SecretKey;
-    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>>;
+    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>>;
     fn cert_url(&self) -> Option<&str>;
     /// The signer's certificate-chain raw PEM bytes, read lazily from the
     /// configured `cert_path` on each call (not cached at construction).
@@ -213,23 +214,12 @@ impl SignerProvider for ConfigSigner {
     fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
         self.cert_path
             .as_ref()
-            .map(|cert_path| -> Result<Vec<Certificate>> {
+            .map(|cert_path| -> Result<Vec<CertificateDer<'static>>> {
                 let pem_cert_chain = std::fs::read_to_string(cert_path)
                     .context("Read Token Signer cert file failed")?;
-                let mut chain = Vec::new();
-
-                for pem in pem_cert_chain.split("-----END CERTIFICATE-----") {
-                    let trimmed = format!("{}\n-----END CERTIFICATE-----", pem.trim());
-                    if !trimmed.starts_with("-----BEGIN CERTIFICATE-----") {
-                        continue;
-                    }
-                    // x509-cert's DecodePem expects a single PEM block; the split
-                    // above already isolates one. Use the Label-aware decoder.
-                    let cert = Certificate::from_pem(trimmed.as_bytes())
-                        .context("Invalid PEM certificate chain")?;
-                    chain.push(cert);
-                }
-                Ok(chain)
+                let chain: Result<Vec<_>, rustls_pki_types::pem::Error> =
+                    CertificateDer::pem_slice_iter(pem_cert_chain.as_bytes()).collect();
+                chain.context("Invalid PEM certificate chain")
             })
     }
     fn cert_url(&self) -> Option<&str> {
@@ -268,7 +258,7 @@ impl SignerProvider for EphemeralSigner {
     fn private_key(&self) -> &SecretKey {
         &self.private_key
     }
-    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
+    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>> {
         None
     }
     fn cert_url(&self) -> Option<&str> {
@@ -520,15 +510,13 @@ impl EarAttestationTokenBroker {
             .signer
             .cert_chain()
             .transpose()?
-            .map(|certs| -> Result<Vec<String>> {
+            .map(|certs| -> Vec<String> {
                 let mut chain = vec![];
                 for cert in certs {
-                    let der = cert.to_der()?;
-                    chain.push(URL_SAFE_NO_PAD.encode(der));
+                    chain.push(URL_SAFE_NO_PAD.encode(cert));
                 }
-                Ok(chain)
-            })
-            .transpose()?;
+                chain
+            });
 
         let common = jwk::CommonParameters {
             key_algorithm: Some(jwk::KeyAlgorithm::ES256),

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -44,6 +44,8 @@ pub const DEFAULT_PROFILE: &str = "tag:github.com,2024:confidential-containers/T
 pub const DEFAULT_DEVELOPER_NAME: &str = "https://confidentialcontainers.org";
 
 const DEFAULT_POLICY_DIR: &str = concatcp!(DEFAULT_TOKEN_WORK_DIR, "/ear/policies");
+pub const DEFAULT_POLICY: &str = include_str!("ear_default_policy_cpu.rego");
+pub const DEFAULT_POLICY_ID: &str = "default.rego";
 
 /// Part 2 — signer resolution spec (native/serde path only). Renamed from
 /// `TokenSignerConfig`; field set unchanged.
@@ -272,8 +274,8 @@ impl EarAttestationTokenBroker {
     pub fn from_config(config: Configuration) -> Result<Self> {
         let policy_engine = PolicyEngineType::OPA.to_policy_engine(
             Path::new(&config.policy_dir),
-            include_str!("ear_default_policy_cpu.rego"),
-            "default.rego",
+            DEFAULT_POLICY,
+            DEFAULT_POLICY_ID,
         )?;
         info!("Loading default AS policy \"default.rego\"");
 
@@ -742,11 +744,7 @@ mod tests {
         // broker fall back to an ephemeral key. Proves issue() works with no
         // fs feature, no policy_dir, no SignerConfig.
         let policy_engine: Arc<dyn PolicyEngine> = PolicyEngineType::OPAInMemory
-            .to_policy_engine(
-                Path::new("/"),
-                include_str!("ear_default_policy_cpu.rego"),
-                "default.rego",
-            )
+            .to_policy_engine(Path::new("/"), DEFAULT_POLICY, DEFAULT_POLICY_ID)
             .unwrap();
         let broker = EarAttestationTokenBroker::from_components(
             TokenBrokerSettings::default(),

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -16,12 +16,8 @@ use jsonwebtoken::{jwk, EncodingKey};
 use kbs_types::Tee;
 use log::{debug, info, warn};
 use p256::elliptic_curve::sec1::ToEncodedPoint;
-use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding};
+use p256::pkcs8::{EncodePrivateKey, LineEnding};
 use p256::SecretKey;
-use rand::rngs::OsRng;
-#[cfg(feature = "fs")]
-use rustls_pki_types::pem::PemObject;
-use rustls_pki_types::CertificateDer;
 use serde::Deserialize;
 #[cfg(test)]
 use serde_json::json;
@@ -37,6 +33,7 @@ use crate::rvps::ReferenceValueResolver;
 use crate::token::DEFAULT_TOKEN_WORK_DIR;
 use crate::{AttestationTokenBroker, TeeClaims};
 
+use super::signer::{EphemeralSigner, FsSigner, SignKeyProvider};
 #[cfg(feature = "fs")]
 use super::signer_transparency;
 use super::{COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
@@ -48,19 +45,7 @@ const DEFAULT_POLICY_DIR: &str = concatcp!(DEFAULT_TOKEN_WORK_DIR, "/ear/policie
 pub const DEFAULT_POLICY: &str = include_str!("ear_default_policy_cpu.rego");
 pub const DEFAULT_POLICY_ID: &str = "default.rego";
 
-/// Part 2 — signer resolution spec (native/serde path only). Renamed from
-/// `TokenSignerConfig`; field set unchanged.
-#[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct SignerConfig {
-    pub key_path: String,
-
-    #[serde(default = "Option::default")]
-    pub cert_url: Option<String>,
-
-    // PEM format certificate chain.
-    #[serde(default = "Option::default")]
-    pub cert_path: Option<String>,
-}
+pub use super::signer::SignerConfig;
 
 /// Part 1 — fs-free token-issuance metadata. This is the *only* part of the
 /// config the broker holds at runtime.
@@ -163,121 +148,15 @@ impl Default for Configuration {
     }
 }
 
-/// Injected signer for the EAR broker. Returns already-resolved crypto
-/// material (borrowed) so the broker holds no PEM/path/fs knowledge.
-/// Resolution is eager, in the provider's constructor.
-pub trait SignerProvider: Send + Sync {
-    fn private_key(&self) -> &SecretKey;
-    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>>;
-    fn cert_url(&self) -> Option<&str>;
-    /// The signer's certificate-chain raw PEM bytes, read lazily from the
-    /// configured `cert_path` on each call (not cached at construction).
-    /// `None` when no `cert_path` is configured. Ephemeral signers return
-    /// `None`. The broker forwards this through `signer_cert_content`.
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>>;
-}
-
-/// Signer resolved from a `SignerConfig` (native/serde path). Reads
-/// `key_path`/`cert_path` under the `fs` feature; `key_pem`/`cert_pem` work
-/// without fs.
-#[cfg(feature = "fs")]
-struct ConfigSigner {
-    private_key: SecretKey,
-    cert_url: Option<String>,
-    // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
-    cert_path: Option<String>,
-}
-
-#[cfg(feature = "fs")]
-impl ConfigSigner {
-    fn from_signer_config(signer: SignerConfig) -> Result<Self> {
-        let pem_data =
-            std::fs::read(&signer.key_path).context("Read Token Signer private key failed")?;
-        let pem_str = std::str::from_utf8(&pem_data).context("Token Signer key not UTF-8")?;
-        let private_key = SecretKey::from_sec1_pem(pem_str)
-            .or_else(|_| SecretKey::from_pkcs8_pem(pem_str))
-            .context("Parse Token Signer private key failed")?;
-
-        Ok(Self {
-            private_key,
-            cert_url: signer.cert_url,
-            cert_path: signer.cert_path,
-        })
-    }
-}
-
-#[cfg(feature = "fs")]
-impl SignerProvider for ConfigSigner {
-    fn private_key(&self) -> &SecretKey {
-        &self.private_key
-    }
-    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
-        self.cert_path
-            .as_ref()
-            .map(|cert_path| -> Result<Vec<CertificateDer<'static>>> {
-                let pem_cert_chain = std::fs::read_to_string(cert_path)
-                    .context("Read Token Signer cert file failed")?;
-                let chain: Result<Vec<_>, rustls_pki_types::pem::Error> =
-                    CertificateDer::pem_slice_iter(pem_cert_chain.as_bytes()).collect();
-                chain.context("Invalid PEM certificate chain")
-            })
-    }
-    fn cert_url(&self) -> Option<&str> {
-        self.cert_url.as_deref()
-    }
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
-        self.cert_path.as_ref().map(|path| {
-            use std::io::Read as _;
-            // Read certificate from file
-            let mut file = std::fs::File::open(path)
-                .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
-            let mut content = Vec::new();
-            file.read_to_end(&mut content)
-                .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
-            Ok(content)
-        })
-    }
-}
-
-/// Ephemeral signer: generates a fresh EC key. Used when no signer is
-/// configured (both `from_config` and `from_components`).
-pub struct EphemeralSigner {
-    private_key: SecretKey,
-}
-
-impl EphemeralSigner {
-    pub fn new() -> Self {
-        let mut rng = OsRng;
-        Self {
-            private_key: SecretKey::random(&mut rng),
-        }
-    }
-}
-
-impl SignerProvider for EphemeralSigner {
-    fn private_key(&self) -> &SecretKey {
-        &self.private_key
-    }
-    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>> {
-        None
-    }
-    fn cert_url(&self) -> Option<&str> {
-        None
-    }
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
-        None
-    }
-}
-
 pub struct EarAttestationTokenBroker {
     settings: TokenBrokerSettings,
-    signer: Arc<dyn SignerProvider>,
+    signer: Arc<dyn SignKeyProvider<SecretKey>>,
     policy_engine: Arc<dyn PolicyEngine>,
 }
 
 impl EarAttestationTokenBroker {
     /// Native / serde path. Resolves the signer from `SignerConfig`
-    /// (`key_pem` | `key_path`, fs-gated) and builds the `PolicyEngine` from
+    /// (`key_path`, fs-gated) and builds the `PolicyEngine` from
     /// `policy_dir` (OPA fs / InMemory). Replaces the old `new(config)`.
     #[cfg(feature = "fs")]
     pub fn from_config(config: Configuration) -> Result<Self> {
@@ -288,13 +167,13 @@ impl EarAttestationTokenBroker {
         )?;
         info!("Loading default AS policy \"default.rego\"");
 
-        let signer: Arc<dyn SignerProvider> = match config.signer {
-            Some(sc) => Arc::new(ConfigSigner::from_signer_config(sc)?),
+        let signer: Arc<dyn SignKeyProvider<SecretKey>> = match config.signer {
+            Some(sc) => Arc::new(FsSigner::<SecretKey>::from_config(sc)?),
             None => {
                 log::info!(
                     "No Token Signer key in config file, create an ephemeral key and without CA pubkey cert"
                 );
-                Arc::new(EphemeralSigner::new())
+                Arc::new(EphemeralSigner::<SecretKey>::new())
             }
         };
 
@@ -307,7 +186,7 @@ impl EarAttestationTokenBroker {
 
     pub fn from_components(
         settings: TokenBrokerSettings,
-        signer: Arc<dyn SignerProvider>,
+        signer: Arc<dyn SignKeyProvider<SecretKey>>,
         policy_engine: Arc<dyn PolicyEngine>,
     ) -> Self {
         Self {
@@ -551,7 +430,7 @@ impl EarAttestationTokenBroker {
 fn generate_ec_keys() -> Result<(SecretKey, Vec<u8>, Vec<u8>)> {
     use rsa::pkcs8::EncodePublicKey as _;
 
-    let mut rng = OsRng;
+    let mut rng = rand::rngs::OsRng;
     let secret = SecretKey::random(&mut rng);
     let priv_pem = secret
         .to_pkcs8_pem(LineEnding::LF)

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -518,6 +518,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "fs")]
     #[tokio::test]
     async fn test_issue_ear_ephemeral_key() {
         // use default config with no signer.
@@ -542,6 +543,7 @@ mod tests {
             .unwrap();
     }
 
+    #[cfg(feature = "fs")]
     #[tokio::test]
     async fn test_issue_and_validate_ear() {
         let (_pkey, private_key_bytes, public_key_bytes) = generate_ec_keys().unwrap();
@@ -580,13 +582,14 @@ mod tests {
         ear.validate().unwrap();
     }
 
+    #[cfg(feature = "fs")]
     async fn issue_snp_ear(debug_allowed: &str) -> Value {
         let policy_dir = tempfile::tempdir().unwrap();
         let config = Configuration {
             policy_dir: policy_dir.path().to_string_lossy().into_owned(),
             ..Configuration::default()
         };
-        let broker = EarAttestationTokenBroker::new(config).unwrap();
+        let broker = EarAttestationTokenBroker::from_config(config).unwrap();
         let token = broker
             .issue(
                 vec![TeeClaims {
@@ -616,12 +619,14 @@ mod tests {
         serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload).unwrap()).unwrap()
     }
 
+    #[cfg(feature = "fs")]
     #[tokio::test]
     async fn test_snp_default_policy_affirms_without_reference_values() {
         let ear = issue_snp_ear("0").await;
         assert_eq!(ear["submods"]["cpu0"]["ear.status"], "affirming");
     }
 
+    #[cfg(feature = "fs")]
     #[tokio::test]
     async fn test_snp_default_policy_rejects_debug_guest() {
         let ear = issue_snp_ear("1").await;
@@ -631,18 +636,31 @@ mod tests {
     #[cfg(not(feature = "fs"))]
     #[tokio::test]
     async fn from_components_issues_without_fs() {
-        // Programmatic path: inject an InMemory policy engine and let the
-        // broker fall back to an ephemeral key. Proves issue() works with no
-        // fs feature, no policy_dir, no SignerConfig.
-        let policy_engine: Arc<dyn PolicyEngine> = PolicyEngineType::OPAInMemory
-            .to_policy_engine(Path::new("/"), DEFAULT_POLICY, DEFAULT_POLICY_ID)
-            .unwrap();
+        // Programmatic path: inject an fs-free InMemory policy engine
+        // (constructed directly, bypassing the fs-gated `PolicyEngineType`)
+        // and an ephemeral EC key. Proves issue() works with no fs feature,
+        // no policy_dir, no SignerConfig. A stripped-down policy (just the
+        // AR4SI trust-vector defaults, copied from the real default policy) is
+        // used instead of `DEFAULT_POLICY` because the real one calls the
+        // `query_reference_value` regorus extension, only registered under the
+        // `policy-rvps` feature — off under `--no-default-features`.
+        const TRIVIAL_EAR_POLICY: &str = r#"package policy
+import rego.v1
+default executables := 33
+default hardware := 97
+default configuration := 36
+default file_system := 35
+"#;
+        use crate::policy_engine::opa::OPAInMemory;
+        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(OPAInMemory::with_raw_default_policy(
+            TRIVIAL_EAR_POLICY,
+            DEFAULT_POLICY_ID,
+        ));
         let broker = EarAttestationTokenBroker::from_components(
             TokenBrokerSettings::default(),
-            None,
+            Arc::new(EphemeralSigner::<SecretKey>::new()),
             policy_engine,
-        )
-        .unwrap();
+        );
 
         let _token = broker
             .issue(
@@ -655,7 +673,7 @@ mod tests {
                     additional_data: None,
                 }],
                 vec!["default".into()],
-                HashMap::new(),
+                crate::rvps::empty_test_resolver(),
             )
             .await
             .unwrap();

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -36,16 +36,21 @@ use crate::rvps::ReferenceValueResolver;
 use crate::token::DEFAULT_TOKEN_WORK_DIR;
 use crate::{AttestationTokenBroker, TeeClaims};
 
-use super::{signer_transparency, COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
+#[cfg(feature = "fs")]
+use super::signer_transparency;
+use super::{COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
 
 pub const DEFAULT_PROFILE: &str = "tag:github.com,2024:confidential-containers/Trustee";
 pub const DEFAULT_DEVELOPER_NAME: &str = "https://confidentialcontainers.org";
 
 const DEFAULT_POLICY_DIR: &str = concatcp!(DEFAULT_TOKEN_WORK_DIR, "/ear/policies");
 
+/// Part 2 — signer resolution spec (native/serde path only). Renamed from
+/// `TokenSignerConfig`; field set unchanged.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct TokenSignerConfig {
+pub struct SignerConfig {
     pub key_path: String,
+
     #[serde(default = "Option::default")]
     pub cert_url: Option<String>,
 
@@ -54,8 +59,10 @@ pub struct TokenSignerConfig {
     pub cert_path: Option<String>,
 }
 
+/// Part 1 — fs-free token-issuance metadata. This is the *only* part of the
+/// config the broker holds at runtime.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct Configuration {
+pub struct TokenBrokerSettings {
     /// The Attestation Results Token duration time (in minutes)
     /// Default: 5 minutes
     #[serde(default = "default_duration")]
@@ -65,14 +72,12 @@ pub struct Configuration {
     #[serde(default = "default_issuer_name")]
     pub issuer_name: String,
 
-    /// The developer name to be used as part of the Verifier ID
-    /// in the EAR.
+    /// The developer name to be used as part of the Verifier ID in the EAR.
     /// Default: `https://confidentialcontainers.org`
     #[serde(default = "default_developer")]
     pub developer_name: String,
 
-    /// The build name to be used as part of the Verifier ID
-    /// in the EAR.
+    /// The build name to be used as part of the Verifier ID in the EAR.
     /// The default value will be generated from the Cargo package
     /// name and version of the AS.
     #[serde(default = "default_build")]
@@ -82,12 +87,32 @@ pub struct Configuration {
     /// Default: `tag:github.com,2024:confidential-containers/Trustee`
     #[serde(default = "default_profile")]
     pub profile_name: String,
+}
+
+impl Default for TokenBrokerSettings {
+    fn default() -> Self {
+        Self {
+            duration_min: default_duration(),
+            issuer_name: default_issuer_name(),
+            developer_name: default_developer(),
+            build_name: default_build(),
+            profile_name: default_profile(),
+        }
+    }
+}
+
+/// The serde Configuration = parts 1 + 2 + 3, composed. `#[serde(flatten)]`
+/// on `settings` keeps the existing flat JSON/TOML config format working.
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct Configuration {
+    #[serde(flatten)]
+    pub settings: TokenBrokerSettings,
 
     /// Configuration for signing the EAR
     /// If this is not specified, the EAR
     /// will be signed with an ephemeral private key.
     #[serde(default = "Option::default")]
-    pub signer: Option<TokenSignerConfig>,
+    pub signer: Option<SignerConfig>,
 
     /// The path to the work directory that contains policies
     /// to provision the tokens.
@@ -128,46 +153,34 @@ fn default_policy_dir() -> String {
 impl Default for Configuration {
     fn default() -> Self {
         Self {
-            duration_min: default_duration(),
-            issuer_name: default_issuer_name(),
-            developer_name: default_developer(),
-            build_name: default_build(),
-            profile_name: default_profile(),
+            settings: TokenBrokerSettings::default(),
             signer: None,
             policy_dir: default_policy_dir(),
         }
     }
 }
 
-pub struct EarAttestationTokenBroker {
-    config: Configuration,
-    private_key: SecretKey,
-    cert_url: Option<String>,
-    cert_chain: Option<Vec<Certificate>>,
-    policy_engine: Arc<dyn PolicyEngine>,
+/// Injected signer for the EAR broker. Returns already-resolved crypto
+/// material (borrowed) so the broker holds no PEM/path/fs knowledge.
+/// Resolution is eager, in the provider's constructor.
+pub trait SignerProvider: Send + Sync {
+    fn private_key(&self) -> &SecretKey;
+    fn cert_chain(&self) -> Option<&[Certificate]>;
+    fn cert_url(&self) -> Option<&str>;
 }
 
-impl EarAttestationTokenBroker {
-    pub fn new(config: Configuration) -> Result<Self> {
-        let policy_engine = PolicyEngineType::OPA.to_policy_engine(
-            Path::new(&config.policy_dir),
-            include_str!("ear_default_policy_cpu.rego"),
-            "default.rego",
-        )?;
-        info!("Loading default AS policy \"default.rego\"");
+/// Signer resolved from a `SignerConfig` (native/serde path). Reads
+/// `key_path`/`cert_path` under the `fs` feature; `key_pem`/`cert_pem` work
+/// without fs.
+struct ConfigSigner {
+    private_key: SecretKey,
+    cert_chain: Option<Vec<Certificate>>,
+    cert_url: Option<String>,
+}
 
-        if config.signer.is_none() {
-            log::info!("No Token Signer key in config file, create an ephemeral key and without CA pubkey cert");
-            return Ok(Self {
-                private_key: generate_ec_keys()?.0,
-                config,
-                cert_url: None,
-                cert_chain: None,
-                policy_engine,
-            });
-        }
-
-        let signer = config.signer.clone().unwrap();
+impl ConfigSigner {
+    #[cfg(feature = "fs")]
+    fn from_signer_config(signer: SignerConfig) -> Result<Self> {
         let pem_data =
             std::fs::read(&signer.key_path).context("Read Token Signer private key failed")?;
         let pem_str = std::str::from_utf8(&pem_data).context("Token Signer key not UTF-8")?;
@@ -199,12 +212,104 @@ impl EarAttestationTokenBroker {
             .transpose()?;
 
         Ok(Self {
-            config,
             private_key,
-            cert_url: signer.cert_url,
             cert_chain,
+            cert_url: signer.cert_url,
+        })
+    }
+}
+
+impl SignerProvider for ConfigSigner {
+    fn private_key(&self) -> &SecretKey {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<&[Certificate]> {
+        self.cert_chain.as_deref()
+    }
+    fn cert_url(&self) -> Option<&str> {
+        self.cert_url.as_deref()
+    }
+}
+
+/// Ephemeral signer: generates a fresh EC key. Used when no signer is
+/// configured (both `from_config` and `from_components`).
+struct EphemeralSigner {
+    private_key: SecretKey,
+}
+
+impl EphemeralSigner {
+    fn new() -> Self {
+        let mut rng = OsRng;
+        Self {
+            private_key: SecretKey::random(&mut rng),
+        }
+    }
+}
+
+impl SignerProvider for EphemeralSigner {
+    fn private_key(&self) -> &SecretKey {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<&[Certificate]> {
+        None
+    }
+    fn cert_url(&self) -> Option<&str> {
+        None
+    }
+}
+
+pub struct EarAttestationTokenBroker {
+    settings: TokenBrokerSettings,
+    signer: Arc<dyn SignerProvider>,
+    policy_engine: Arc<dyn PolicyEngine>,
+}
+
+impl EarAttestationTokenBroker {
+    /// Native / serde path. Resolves the signer from `SignerConfig`
+    /// (`key_pem` | `key_path`, fs-gated) and builds the `PolicyEngine` from
+    /// `policy_dir` (OPA fs / InMemory). Replaces the old `new(config)`.
+    #[cfg(feature = "fs")]
+    pub fn from_config(config: Configuration) -> Result<Self> {
+        let policy_engine = PolicyEngineType::OPA.to_policy_engine(
+            Path::new(&config.policy_dir),
+            include_str!("ear_default_policy_cpu.rego"),
+            "default.rego",
+        )?;
+        info!("Loading default AS policy \"default.rego\"");
+
+        let signer: Arc<dyn SignerProvider> = match config.signer {
+            Some(sc) => Arc::new(ConfigSigner::from_signer_config(sc)?),
+            None => {
+                log::info!(
+                    "No Token Signer key in config file, create an ephemeral key and without CA pubkey cert"
+                );
+                Arc::new(EphemeralSigner::new())
+            }
+        };
+
+        Ok(Self {
+            settings: config.settings,
+            signer,
             policy_engine,
         })
+    }
+
+    /// Pure-lib / wasm path. Objects injected — zero fs, zero paths.
+    /// Falls back to an ephemeral key when `signer` is None.
+    pub fn from_components(
+        settings: TokenBrokerSettings,
+        signer: Option<Arc<dyn SignerProvider>>,
+        policy_engine: Arc<dyn PolicyEngine>,
+    ) -> Self {
+        let signer: Arc<dyn SignerProvider> = match signer {
+            Some(s) => s,
+            None => Arc::new(EphemeralSigner::new()),
+        };
+        Self {
+            settings,
+            signer,
+            policy_engine,
+        }
     }
 }
 
@@ -303,7 +408,7 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
 
         let now = OffsetDateTime::now_utc();
         let exp = now
-            .checked_add(Duration::minutes(self.config.duration_min))
+            .checked_add(Duration::minutes(self.settings.duration_min))
             .ok_or(anyhow!("Token expiration overflow."))?;
 
         let mut extensions = Extensions::new();
@@ -311,11 +416,11 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
         extensions.set_by_name("exp", ExtensionValue::Integer(exp.unix_timestamp()))?;
 
         let ear = Ear {
-            profile: self.config.profile_name.clone(),
+            profile: self.settings.profile_name.clone(),
             iat: now.unix_timestamp(),
             vid: VerifierID {
-                build: self.config.build_name.clone(),
-                developer: self.config.developer_name.clone(),
+                build: self.settings.build_name.clone(),
+                developer: self.settings.developer_name.clone(),
             },
             raw_evidence: None,
             nonce: None,
@@ -326,11 +431,13 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
         jwt_header.jwk = Some(self.pubkey_jwk()?);
 
         let private_key_bytes = self
-            .private_key
+            .signer
+            .private_key()
             .to_pkcs8_pem(LineEnding::LF)
             .context("serialize EC private key to PKCS#8 PEM")?;
         let private_key_bytes: &[u8] = private_key_bytes.as_bytes();
 
+        #[cfg(feature = "fs")]
         let signed_ear = if let Some(transparency) = signer_transparency::load_signer_transparency()
         {
             let mut ear_claims = serde_json::to_value(&ear)?
@@ -348,6 +455,8 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
         } else {
             ear.sign_jwt_pem_with_header(&jwt_header, private_key_bytes)?
         };
+        #[cfg(not(feature = "fs"))]
+        let signed_ear = ear.sign_jwt_pem_with_header(&jwt_header, private_key_bytes)?;
 
         Ok(signed_ear)
     }
@@ -385,8 +494,8 @@ impl EarAttestationTokenBroker {
     // TODO: converge this with the jwk function in the simple token broker
     fn pubkey_jwk(&self) -> Result<jwk::Jwk> {
         let chain = self
-            .cert_chain
-            .as_ref()
+            .signer
+            .cert_chain()
             .map(|certs| -> Result<Vec<String>> {
                 let mut chain = vec![];
                 for cert in certs {
@@ -399,12 +508,12 @@ impl EarAttestationTokenBroker {
 
         let common = jwk::CommonParameters {
             key_algorithm: Some(jwk::KeyAlgorithm::ES256),
-            x509_url: self.cert_url.clone(),
+            x509_url: self.signer.cert_url().map(str::to_owned),
             x509_chain: chain,
             ..Default::default()
         };
 
-        let public_key = self.private_key.public_key();
+        let public_key = self.signer.private_key().public_key();
         let encoded = public_key.to_encoded_point(false);
         let x = encoded
             .x()
@@ -426,6 +535,7 @@ impl EarAttestationTokenBroker {
     }
 }
 
+#[cfg(all(test, feature = "fs"))]
 fn generate_ec_keys() -> Result<(SecretKey, Vec<u8>, Vec<u8>)> {
     let mut rng = OsRng;
     let secret = SecretKey::random(&mut rng);
@@ -520,7 +630,7 @@ mod tests {
         // use default config with no signer.
         // this will sign the token with an ephemeral key.
         let config = Configuration::default();
-        let broker = EarAttestationTokenBroker::new(config).unwrap();
+        let broker = EarAttestationTokenBroker::from_config(config).unwrap();
 
         let _token = broker
             .issue(
@@ -545,8 +655,8 @@ mod tests {
         let mut private_key_file = NamedTempFile::new().unwrap();
         private_key_file.write_all(&private_key_bytes).unwrap();
 
-        let signer = TokenSignerConfig {
-            key_path: private_key_file.path().to_str().unwrap().to_string(),
+        let signer = SignerConfig {
+            key_path: Some(private_key_file.path().to_str().unwrap().to_string()),
             cert_url: None,
             cert_path: None,
         };
@@ -554,7 +664,7 @@ mod tests {
         let mut config = Configuration::default();
         config.signer = Some(signer);
 
-        let broker = EarAttestationTokenBroker::new(config).unwrap();
+        let broker = EarAttestationTokenBroker::from_config(config).unwrap();
         let token = broker
             .issue(
                 vec![TeeClaims {
@@ -623,6 +733,43 @@ mod tests {
     async fn test_snp_default_policy_rejects_debug_guest() {
         let ear = issue_snp_ear("1").await;
         assert_eq!(ear["submods"]["cpu0"]["ear.status"], "warning");
+    }
+
+    #[cfg(not(feature = "fs"))]
+    #[tokio::test]
+    async fn from_components_issues_without_fs() {
+        // Programmatic path: inject an InMemory policy engine and let the
+        // broker fall back to an ephemeral key. Proves issue() works with no
+        // fs feature, no policy_dir, no SignerConfig.
+        let policy_engine: Arc<dyn PolicyEngine> = PolicyEngineType::OPAInMemory
+            .to_policy_engine(
+                Path::new("/"),
+                include_str!("ear_default_policy_cpu.rego"),
+                "default.rego",
+            )
+            .unwrap();
+        let broker = EarAttestationTokenBroker::from_components(
+            TokenBrokerSettings::default(),
+            None,
+            policy_engine,
+        )
+        .unwrap();
+
+        let _token = broker
+            .issue(
+                vec![TeeClaims {
+                    tee: Tee::Sample,
+                    tee_class: "cpu".to_string(),
+                    claims: json!({"claim": "claim1"}),
+                    runtime_data_claims: json!({"runtime_data": "111"}),
+                    init_data_claims: json!({"initdata": "111"}),
+                    additional_data: None,
+                }],
+                vec!["default".into()],
+                HashMap::new(),
+            )
+            .await
+            .unwrap();
     }
 
     #[test]

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -16,7 +16,7 @@ use jsonwebtoken::{jwk, EncodingKey};
 use kbs_types::Tee;
 use log::{debug, info, warn};
 use p256::elliptic_curve::sec1::ToEncodedPoint;
-use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding};
+use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding};
 use p256::SecretKey;
 use rand::rngs::OsRng;
 use serde::Deserialize;
@@ -169,19 +169,27 @@ pub trait SignerProvider: Send + Sync {
     fn private_key(&self) -> &SecretKey;
     fn cert_chain(&self) -> Option<&[Certificate]>;
     fn cert_url(&self) -> Option<&str>;
+    /// The signer's certificate-chain raw PEM bytes, read lazily from the
+    /// configured `cert_path` on each call (not cached at construction).
+    /// `None` when no `cert_path` is configured. Ephemeral signers return
+    /// `None`. The broker forwards this through `signer_cert_content`.
+    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>>;
 }
 
 /// Signer resolved from a `SignerConfig` (native/serde path). Reads
 /// `key_path`/`cert_path` under the `fs` feature; `key_pem`/`cert_pem` work
 /// without fs.
+#[cfg(feature = "fs")]
 struct ConfigSigner {
     private_key: SecretKey,
     cert_chain: Option<Vec<Certificate>>,
     cert_url: Option<String>,
+    // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
+    cert_path: Option<String>,
 }
 
+#[cfg(feature = "fs")]
 impl ConfigSigner {
-    #[cfg(feature = "fs")]
     fn from_signer_config(signer: SignerConfig) -> Result<Self> {
         let pem_data =
             std::fs::read(&signer.key_path).context("Read Token Signer private key failed")?;
@@ -217,10 +225,12 @@ impl ConfigSigner {
             private_key,
             cert_chain,
             cert_url: signer.cert_url,
+            cert_path: signer.cert_path,
         })
     }
 }
 
+#[cfg(feature = "fs")]
 impl SignerProvider for ConfigSigner {
     fn private_key(&self) -> &SecretKey {
         &self.private_key
@@ -231,16 +241,31 @@ impl SignerProvider for ConfigSigner {
     fn cert_url(&self) -> Option<&str> {
         self.cert_url.as_deref()
     }
+    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
+        match &self.cert_path {
+            Some(path) => {
+                use std::io::Read as _;
+                // Read certificate from file
+                let mut file = std::fs::File::open(path)
+                    .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
+                let mut content = Vec::new();
+                file.read_to_end(&mut content)
+                    .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
+                Ok(Some(content))
+            }
+            None => Ok(None),
+        }
+    }
 }
 
 /// Ephemeral signer: generates a fresh EC key. Used when no signer is
 /// configured (both `from_config` and `from_components`).
-struct EphemeralSigner {
+pub struct EphemeralSigner {
     private_key: SecretKey,
 }
 
 impl EphemeralSigner {
-    fn new() -> Self {
+    pub fn new() -> Self {
         let mut rng = OsRng;
         Self {
             private_key: SecretKey::random(&mut rng),
@@ -257,6 +282,9 @@ impl SignerProvider for EphemeralSigner {
     }
     fn cert_url(&self) -> Option<&str> {
         None
+    }
+    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
+        Ok(None)
     }
 }
 
@@ -296,17 +324,11 @@ impl EarAttestationTokenBroker {
         })
     }
 
-    /// Pure-lib / wasm path. Objects injected — zero fs, zero paths.
-    /// Falls back to an ephemeral key when `signer` is None.
     pub fn from_components(
         settings: TokenBrokerSettings,
-        signer: Option<Arc<dyn SignerProvider>>,
+        signer: Arc<dyn SignerProvider>,
         policy_engine: Arc<dyn PolicyEngine>,
     ) -> Self {
-        let signer: Arc<dyn SignerProvider> = match signer {
-            Some(s) => s,
-            None => Arc::new(EphemeralSigner::new()),
-        };
         Self {
             settings,
             signer,
@@ -490,6 +512,14 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
             .await
             .map_err(Error::from)
     }
+
+    async fn signer_cert_content(&self) -> Result<Option<Vec<u8>>> {
+        self.signer.cert_pem_raw()
+    }
+
+    fn signer_cert_url(&self) -> Option<&str> {
+        self.signer.cert_url()
+    }
 }
 
 impl EarAttestationTokenBroker {
@@ -539,6 +569,8 @@ impl EarAttestationTokenBroker {
 
 #[cfg(all(test, feature = "fs"))]
 fn generate_ec_keys() -> Result<(SecretKey, Vec<u8>, Vec<u8>)> {
+    use rsa::pkcs8::EncodePublicKey as _;
+
     let mut rng = OsRng;
     let secret = SecretKey::random(&mut rng);
     let priv_pem = secret
@@ -658,7 +690,7 @@ mod tests {
         private_key_file.write_all(&private_key_bytes).unwrap();
 
         let signer = SignerConfig {
-            key_path: Some(private_key_file.path().to_str().unwrap().to_string()),
+            key_path: private_key_file.path().to_str().unwrap().to_string(),
             cert_url: None,
             cert_path: None,
         };

--- a/attestation-service/src/token/mod.rs
+++ b/attestation-service/src/token/mod.rs
@@ -50,6 +50,35 @@ pub trait AttestationTokenBroker: Send + Sync {
     async fn delete_policy(&self, _policy_id: String) -> Result<()> {
         bail!("Delete Policy not support")
     }
+
+    /// The signer's certificate-chain PEM bytes this broker already holds
+    /// (loaded from an inline `cert_pem` or a `cert_path` at construction).
+    /// `None` if the broker has no local signer cert. The service uses this to
+    /// answer its "get token broker certificate" endpoint — it no longer holds
+    /// a `Config` to read these from, so the broker self-reports. Default: none.
+    async fn signer_cert_content(&self) -> Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    /// The signer certificate URL (x5u) the broker publishes, if any. The
+    /// service HTTP-fetches it when [`Self::signer_cert_content`] returns
+    /// `None`. Default: none.
+    fn signer_cert_url(&self) -> Option<&str> {
+        None
+    }
+
+    /// The broker's public key set as a JWKS JSON string, for the service's
+    /// "get token broker public key" endpoint. Default: not supported (the
+    /// service returns `None`).
+    async fn public_jwks(&self) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    /// The broker's OIDC discovery configuration as a JSON string, for the
+    /// service's "get token broker oid config" endpoint. Default: not supported.
+    async fn oid_config_json(&self) -> Result<Option<String>> {
+        Ok(None)
+    }
 }
 
 #[derive(Deserialize, Debug, Clone, Display, PartialEq)]

--- a/attestation-service/src/token/mod.rs
+++ b/attestation-service/src/token/mod.rs
@@ -56,8 +56,8 @@ pub trait AttestationTokenBroker: Send + Sync {
     /// `None` if the broker has no local signer cert. The service uses this to
     /// answer its "get token broker certificate" endpoint — it no longer holds
     /// a `Config` to read these from, so the broker self-reports. Default: none.
-    async fn signer_cert_content(&self) -> Result<Option<Vec<u8>>> {
-        Ok(None)
+    async fn signer_cert_content(&self) -> Option<Result<Vec<u8>>> {
+        None
     }
 
     /// The signer certificate URL (x5u) the broker publishes, if any. The

--- a/attestation-service/src/token/mod.rs
+++ b/attestation-service/src/token/mod.rs
@@ -63,12 +63,12 @@ pub trait AttestationTokenBroker: Send + Sync {
     /// `None` if the broker has no local signer cert. The service uses this to
     /// answer its "get token broker certificate" endpoint — it no longer holds
     /// a `Config` to read these from, so the broker self-reports. Default: none.
-    async fn signer_cert_content(&self) -> Option<Result<Vec<u8>>> {
+    async fn signer_cert_pem_live(&self) -> Option<Result<Vec<u8>>> {
         None
     }
 
     /// The signer certificate URL (x5u) the broker publishes, if any. The
-    /// service HTTP-fetches it when [`Self::signer_cert_content`] returns
+    /// service HTTP-fetches it when [`Self::signer_cert_pem_live`] returns
     /// `None`. Default: none.
     fn signer_cert_url(&self) -> Option<&str> {
         None

--- a/attestation-service/src/token/mod.rs
+++ b/attestation-service/src/token/mod.rs
@@ -74,10 +74,21 @@ pub trait AttestationTokenBroker: Send + Sync {
         None
     }
 
-    /// The broker's public key set as a JWKS JSON string, for the service's
-    /// "get token broker public key" endpoint. Default: not supported (the
-    /// service returns `None`).
-    async fn public_jwks(&self) -> Result<Option<String>> {
+    /// The *configured* signer's public key set as a JWKS JSON string, for the
+    /// service's "get token broker public key" (`/jwks`) endpoint.
+    ///
+    /// Publishes the JWKS only when a signer was explicitly configured; an
+    /// ephemeral signer is intentionally **not** published (its key is freshly
+    /// generated per process start, so clients cannot pin it), and the method
+    /// returns `None` in that case — the service then answers `/jwks` with
+    /// 404. This preserves the long-standing behavior of only publishing a
+    /// JWKS for an explicitly configured signer. Default: not supported
+    /// (`None`).
+    ///
+    /// The name emphasizes "configured" so callers don't assume a generic
+    /// "any public key" contract. If a future use case needs to publish an
+    /// ephemeral key too, add a separate method rather than loosening this one.
+    async fn configured_signer_jwks(&self) -> Result<Option<String>> {
         Ok(None)
     }
 

--- a/attestation-service/src/token/mod.rs
+++ b/attestation-service/src/token/mod.rs
@@ -16,6 +16,7 @@ use crate::config::DEFAULT_WORK_DIR;
 
 pub mod ear_broker;
 pub mod oidc;
+pub mod signer;
 pub mod signer_transparency;
 pub mod simple;
 

--- a/attestation-service/src/token/mod.rs
+++ b/attestation-service/src/token/mod.rs
@@ -25,7 +25,15 @@ pub const COCO_AS_ISSUER_NAME: &str = "CoCo-Attestation-Service";
 
 const DEFAULT_TOKEN_WORK_DIR: &str = concatcp!(DEFAULT_WORK_DIR, "/token");
 
-#[async_trait::async_trait]
+#[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), async_trait::async_trait(?Send))]
+#[cfg_attr(
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )),
+    async_trait::async_trait
+)]
 pub trait AttestationTokenBroker: Send + Sync {
     /// Issue an signed attestation token with custom claims.
     /// Return base64 encoded Json Web Token.

--- a/attestation-service/src/token/mod.rs
+++ b/attestation-service/src/token/mod.rs
@@ -36,22 +36,20 @@ pub trait AttestationTokenBroker: Send + Sync {
         reference_value_resolver: Arc<ReferenceValueResolver>,
     ) -> Result<String>;
 
-    async fn set_policy(&self, _policy_id: String, _policy: String) -> Result<()> {
-        bail!("Set Policy not support")
-    }
+    /// Set a policy for the given `policy_id`.
+    /// The `policy` string is encoded in URL-safe base64 (no padding, i.e. URL_SAFE_NO_PAD).
+    async fn set_policy(&self, policy_id: String, policy: String) -> Result<()>;
 
-    async fn list_policies(&self) -> Result<HashMap<String, String>> {
-        bail!("List Policies not support")
-    }
+    /// List all policies. The returned map's values are encoded in URL-safe base64 (no padding,
+    /// i.e. URL_SAFE_NO_PAD).
+    async fn list_policies(&self) -> Result<HashMap<String, String>>;
 
-    async fn get_policy(&self, _policy_id: String) -> Result<String> {
-        bail!("Get Policy not support")
-    }
+    /// Get the policy for the given `policy_id`.
+    /// The returned string is encoded in URL-safe base64 (no padding, i.e. URL_SAFE_NO_PAD).
+    async fn get_policy(&self, policy_id: String) -> Result<String>;
 
-    async fn delete_policy(&self, _policy_id: String) -> Result<()> {
-        bail!("Delete Policy not support")
-    }
-
+    /// Delete the policy for the given `policy_id`.
+    async fn delete_policy(&self, policy_id: String) -> Result<()>;
     /// The signer's certificate-chain PEM bytes this broker already holds
     /// (loaded from an inline `cert_pem` or a `cert_path` at construction).
     /// `None` if the broker has no local signer cert. The service uses this to

--- a/attestation-service/src/token/mod.rs
+++ b/attestation-service/src/token/mod.rs
@@ -67,20 +67,21 @@ impl Default for AttestationTokenConfig {
 }
 
 impl AttestationTokenConfig {
+    #[cfg(feature = "fs")]
     pub fn to_token_broker(&self) -> Result<Box<dyn AttestationTokenBroker + Send + Sync>> {
         match self {
             AttestationTokenConfig::Simple(cfg) => Ok(Box::new(
-                simple::SimpleAttestationTokenBroker::new(cfg.clone())?,
+                simple::SimpleAttestationTokenBroker::from_config(cfg.clone())?,
             )
                 as Box<dyn AttestationTokenBroker + Send + Sync>),
             AttestationTokenConfig::Ear(cfg) => Ok(Box::new(
-                ear_broker::EarAttestationTokenBroker::new(cfg.clone())?,
+                ear_broker::EarAttestationTokenBroker::from_config(cfg.clone())?,
             )
                 as Box<dyn AttestationTokenBroker + Send + Sync>),
-            AttestationTokenConfig::OIDC(cfg) => Ok(
-                Box::new(oidc::OIDCAttestationTokenBroker::new(cfg.clone())?)
-                    as Box<dyn AttestationTokenBroker + Send + Sync>,
-            ),
+            AttestationTokenConfig::OIDC(cfg) => Ok(Box::new(
+                oidc::OIDCAttestationTokenBroker::from_config(cfg.clone())?,
+            )
+                as Box<dyn AttestationTokenBroker + Send + Sync>),
         }
     }
 }

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -465,8 +465,8 @@ impl AttestationTokenBroker for OIDCAttestationTokenBroker {
             .map_err(Error::from)
     }
 
-    async fn signer_cert_content(&self) -> Option<Result<Vec<u8>>> {
-        self.signer.cert_pem_raw()
+    async fn signer_cert_pem_live(&self) -> Option<Result<Vec<u8>>> {
+        self.signer.cert_pem_live()
     }
 
     fn signer_cert_url(&self) -> Option<&str> {

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -160,19 +160,27 @@ pub trait SignerProvider: Send + Sync {
     fn private_key(&self) -> &RsaPrivateKey;
     fn cert_chain(&self) -> Option<&[Certificate]>;
     fn cert_url(&self) -> Option<&str>;
+    /// The signer's certificate-chain raw PEM bytes, read lazily from the
+    /// configured `cert_path` on each call (not cached at construction).
+    /// `None` when no `cert_path` is configured. Ephemeral signers return
+    /// `None`. The broker forwards this through `signer_cert_content`.
+    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>>;
 }
 
 /// Signer resolved from a `SignerConfig` (native/serde path). Reads
 /// `key_path`/`cert_path` under the `fs` feature; `key_pem`/`cert_pem` work
 /// without fs.
+#[cfg(feature = "fs")]
 struct ConfigSigner {
     private_key: RsaPrivateKey,
     cert_chain: Option<Vec<Certificate>>,
     cert_url: Option<String>,
+    // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
+    cert_path: Option<String>,
 }
 
+#[cfg(feature = "fs")]
 impl ConfigSigner {
-    #[cfg(feature = "fs")]
     fn from_signer_config(signer: SignerConfig) -> Result<Self> {
         let pem_data = std::fs::read_to_string(&signer.key_path)
             .context("Read Token Signer private key failed")?;
@@ -207,10 +215,12 @@ impl ConfigSigner {
             private_key,
             cert_chain,
             cert_url: signer.cert_url,
+            cert_path: signer.cert_path,
         })
     }
 }
 
+#[cfg(feature = "fs")]
 impl SignerProvider for ConfigSigner {
     fn private_key(&self) -> &RsaPrivateKey {
         &self.private_key
@@ -221,16 +231,32 @@ impl SignerProvider for ConfigSigner {
     fn cert_url(&self) -> Option<&str> {
         self.cert_url.as_deref()
     }
+    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
+        match &self.cert_path {
+            Some(path) => {
+                use std::io::Read as _;
+
+                // Read certificate from file
+                let mut file = std::fs::File::open(path)
+                    .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
+                let mut content = Vec::new();
+                file.read_to_end(&mut content)
+                    .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
+                Ok(Some(content))
+            }
+            None => Ok(None),
+        }
+    }
 }
 
 /// Ephemeral signer: generates a fresh RSA key. Used when no signer is
 /// configured (both `from_config` and `from_components`).
-struct EphemeralSigner {
+pub struct EphemeralSigner {
     private_key: RsaPrivateKey,
 }
 
 impl EphemeralSigner {
-    fn new() -> Result<Self> {
+    pub fn new() -> Result<Self> {
         let mut rng = OsRng;
         Ok(Self {
             private_key: RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?,
@@ -247,6 +273,9 @@ impl SignerProvider for EphemeralSigner {
     }
     fn cert_url(&self) -> Option<&str> {
         None
+    }
+    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
+        Ok(None)
     }
 }
 
@@ -285,13 +314,9 @@ impl OIDCAttestationTokenBroker {
 
     pub fn from_components(
         settings: TokenBrokerSettings,
-        signer: Option<Arc<dyn SignerProvider>>,
+        signer: Arc<dyn SignerProvider>,
         policy_engine: Arc<dyn PolicyEngine>,
     ) -> Self {
-        let signer: Arc<dyn SignerProvider> = match signer {
-            Some(s) => s,
-            None => Arc::new(EphemeralSigner::new()?),
-        };
         Self {
             settings,
             signer,
@@ -571,6 +596,43 @@ impl AttestationTokenBroker for OIDCAttestationTokenBroker {
             .delete_policy(policy_id)
             .await
             .map_err(Error::from)
+    }
+
+    async fn signer_cert_content(&self) -> Result<Option<Vec<u8>>> {
+        self.signer.cert_pem_raw()
+    }
+
+    fn signer_cert_url(&self) -> Option<&str> {
+        self.signer.cert_url()
+    }
+
+    /// OIDC broker publishes its signer RSA public key as a JWKS `{"keys":[...]}`
+    /// with `kty/n/e` only — matching the historical service endpoint output.
+    /// `None` when no signer is configured (ephemeral key).
+    async fn public_jwks(&self) -> Result<Option<String>> {
+        let n = self.signer.private_key().n().to_bytes_be();
+        let e = self.signer.private_key().e().to_bytes_be();
+        let jwk = json!({
+            "kty": "RSA",
+            "n": URL_SAFE_NO_PAD.encode(n),
+            "e": URL_SAFE_NO_PAD.encode(e),
+        });
+        Ok(Some(serde_json::to_string(&json!({ "keys": vec![jwk] }))?))
+    }
+
+    async fn oid_config_json(&self) -> Result<Option<String>> {
+        match &self.settings.oid_config {
+            Some(oid) => {
+                let info = json!({
+                    "issuer": oid.issuer,
+                    "jwks_uri": oid.jwks_uri,
+                    "id_token_signing_alg_values_supported":
+                        oid.id_token_signing_alg_values_supported,
+                });
+                Ok(Some(serde_json::to_string(&info)?))
+            }
+            None => Ok(None),
+        }
     }
 }
 

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -13,17 +13,11 @@ use base64::Engine;
 use const_format::concatcp;
 use log::info;
 use rand::distributions::Alphanumeric;
-use rand::rngs::OsRng;
 use rand::{thread_rng, Rng};
-use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::pkcs1v15::{Signature, SigningKey};
-use rsa::pkcs8::DecodePrivateKey;
 use rsa::signature::Signer;
 use rsa::traits::PublicKeyParts;
 use rsa::RsaPrivateKey;
-#[cfg(feature = "fs")]
-use rustls_pki_types::pem::PemObject;
-use rustls_pki_types::CertificateDer;
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use serde_variant::to_variant_name;
@@ -37,11 +31,11 @@ use crate::rvps::ReferenceValueResolver;
 use crate::token::{AttestationTokenBroker, DEFAULT_TOKEN_WORK_DIR};
 use crate::TeeClaims;
 
+use super::signer::{EphemeralSigner, FsSigner, SignKeyProvider};
 #[cfg(feature = "fs")]
 use super::signer_transparency;
 use super::{COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
 
-const RSA_KEY_BITS: u32 = 2048;
 const OIDC_TOKEN_ALG: &str = "RS256";
 const DEFAULT_OIDC_AUDIENCE: &str = "sigstore";
 
@@ -49,17 +43,7 @@ const DEFAULT_POLICY_DIR: &str = concatcp!(DEFAULT_TOKEN_WORK_DIR, "/oidc/polici
 pub const DEFAULT_POLICY: &str = include_str!("oidc_default_policy.rego");
 pub const DEFAULT_POLICY_ID: &str = "default.rego";
 
-/// Part 2 — signer resolution spec (native/serde path only). Renamed from
-/// `TokenSignerConfig`; field set unchanged.
-#[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct SignerConfig {
-    pub key_path: String,
-
-    pub cert_url: Option<String>,
-
-    // PEM format certificate chain.
-    pub cert_path: Option<String>,
-}
+pub use super::signer::SignerConfig;
 
 /// Part 1 — fs-free token-issuance metadata (incl. `oid_config`). The only
 /// part the broker holds.
@@ -157,111 +141,9 @@ impl Default for Configuration {
     }
 }
 
-pub trait SignerProvider: Send + Sync {
-    fn private_key(&self) -> &RsaPrivateKey;
-    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>>;
-    fn cert_url(&self) -> Option<&str>;
-    /// The signer's certificate-chain raw PEM bytes, read lazily from the
-    /// configured `cert_path` on each call (not cached at construction).
-    /// `None` when no `cert_path` is configured. Ephemeral signers return
-    /// `None`. The broker forwards this through `signer_cert_content`.
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>>;
-}
-
-/// Signer resolved from a `SignerConfig` (native/serde path). Reads
-/// `key_path`/`cert_path` under the `fs` feature; `key_pem`/`cert_pem` work
-/// without fs.
-#[cfg(feature = "fs")]
-struct ConfigSigner {
-    private_key: RsaPrivateKey,
-    cert_url: Option<String>,
-    // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
-    cert_path: Option<String>,
-}
-
-#[cfg(feature = "fs")]
-impl ConfigSigner {
-    fn from_signer_config(signer: SignerConfig) -> Result<Self> {
-        let pem_data = std::fs::read_to_string(&signer.key_path)
-            .context("Read Token Signer private key failed")?;
-        let private_key = RsaPrivateKey::from_pkcs8_pem(&pem_data)
-            .or_else(|_| RsaPrivateKey::from_pkcs1_pem(&pem_data))
-            .context("Parse Token Signer private key failed")?;
-
-        Ok(Self {
-            private_key,
-            cert_url: signer.cert_url,
-            cert_path: signer.cert_path,
-        })
-    }
-}
-
-#[cfg(feature = "fs")]
-impl SignerProvider for ConfigSigner {
-    fn private_key(&self) -> &RsaPrivateKey {
-        &self.private_key
-    }
-    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
-        self.cert_path
-            .as_ref()
-            .map(|cert_path| -> Result<Vec<CertificateDer<'static>>> {
-                let pem_cert_chain = std::fs::read_to_string(cert_path)
-                    .context("Read Token Signer cert file failed")?;
-                let chain: Result<Vec<_>, rustls_pki_types::pem::Error> =
-                    CertificateDer::pem_slice_iter(pem_cert_chain.as_bytes()).collect();
-                chain.context("Invalid PEM certificate chain")
-            })
-    }
-    fn cert_url(&self) -> Option<&str> {
-        self.cert_url.as_deref()
-    }
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
-        self.cert_path.as_ref().map(|path| {
-            use std::io::Read as _;
-            // Read certificate from file
-            let mut file = std::fs::File::open(path)
-                .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
-            let mut content = Vec::new();
-            file.read_to_end(&mut content)
-                .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
-            Ok(content)
-        })
-    }
-}
-
-/// Ephemeral signer: generates a fresh RSA key. Used when no signer is
-/// configured (both `from_config` and `from_components`).
-pub struct EphemeralSigner {
-    private_key: RsaPrivateKey,
-}
-
-impl EphemeralSigner {
-    pub fn new() -> Result<Self> {
-        let mut rng = OsRng;
-        Ok(Self {
-            private_key: RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?,
-        })
-    }
-}
-
-impl SignerProvider for EphemeralSigner {
-    fn private_key(&self) -> &RsaPrivateKey {
-        &self.private_key
-    }
-    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>> {
-        None
-    }
-    fn cert_url(&self) -> Option<&str> {
-        None
-    }
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
-        None
-    }
-}
-
 pub struct OIDCAttestationTokenBroker {
     settings: TokenBrokerSettings,
-    signer: Arc<dyn SignerProvider>,
+    signer: Arc<dyn SignKeyProvider<RsaPrivateKey>>,
     policy_engine: Arc<dyn PolicyEngine>,
 }
 
@@ -275,13 +157,13 @@ impl OIDCAttestationTokenBroker {
         )?;
         info!("Loading default AS policy \"oidc_default_policy.rego\"");
 
-        let signer: Arc<dyn SignerProvider> = match config.signer {
-            Some(sc) => Arc::new(ConfigSigner::from_signer_config(sc)?),
+        let signer: Arc<dyn SignKeyProvider<RsaPrivateKey>> = match config.signer {
+            Some(sc) => Arc::new(FsSigner::<RsaPrivateKey>::from_config(sc)?),
             None => {
                 log::info!(
                     "No Token Signer key in config file, create an ephemeral key and without CA pubkey cert"
                 );
-                Arc::new(EphemeralSigner::new()?)
+                Arc::new(EphemeralSigner::<RsaPrivateKey>::new()?)
             }
         };
 
@@ -294,7 +176,7 @@ impl OIDCAttestationTokenBroker {
 
     pub fn from_components(
         settings: TokenBrokerSettings,
-        signer: Arc<dyn SignerProvider>,
+        signer: Arc<dyn SignKeyProvider<RsaPrivateKey>>,
         policy_engine: Arc<dyn PolicyEngine>,
     ) -> Self {
         Self {

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -36,7 +36,9 @@ use crate::rvps::ReferenceValueResolver;
 use crate::token::{AttestationTokenBroker, DEFAULT_TOKEN_WORK_DIR};
 use crate::TeeClaims;
 
-use super::{signer_transparency, COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
+#[cfg(feature = "fs")]
+use super::signer_transparency;
+use super::{COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
 
 const RSA_KEY_BITS: u32 = 2048;
 const OIDC_TOKEN_ALG: &str = "RS256";
@@ -44,13 +46,42 @@ const DEFAULT_OIDC_AUDIENCE: &str = "sigstore";
 
 const DEFAULT_POLICY_DIR: &str = concatcp!(DEFAULT_TOKEN_WORK_DIR, "/oidc/policies");
 
+/// Part 2 — signer resolution spec (native/serde path only). Renamed from
+/// `TokenSignerConfig`; field set unchanged.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct TokenSignerConfig {
+pub struct SignerConfig {
     pub key_path: String,
+
     pub cert_url: Option<String>,
 
     // PEM format certificate chain.
     pub cert_path: Option<String>,
+}
+
+/// Part 1 — fs-free token-issuance metadata (incl. `oid_config`). The only
+/// part the broker holds.
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct TokenBrokerSettings {
+    /// The Attestation Results Token duration time (in minutes)
+    /// Default: 5 minutes
+    #[serde(default = "default_duration")]
+    pub duration_min: i64,
+
+    /// the issuer of the token
+    #[serde(default = "default_issuer_name")]
+    pub issuer_name: String,
+
+    pub oid_config: Option<OpenIDConfig>,
+}
+
+impl Default for TokenBrokerSettings {
+    fn default() -> Self {
+        Self {
+            duration_min: default_duration(),
+            issuer_name: default_issuer_name(),
+            oid_config: None,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -70,23 +101,17 @@ pub struct OpenIDConfig {
     pub additional_claims: Option<Vec<String>>,
 }
 
+/// The serde Configuration = parts 1 + 2 + 3, composed. `#[serde(flatten)]`
+/// on `settings` keeps the existing flat JSON/TOML config format working.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct Configuration {
-    /// The Attestation Results Token duration time (in minutes)
-    /// Default: 5 minutes
-    #[serde(default = "default_duration")]
-    pub duration_min: i64,
-
-    /// the issuer of the token
-    #[serde(default = "default_issuer_name")]
-    pub issuer_name: String,
+    #[serde(flatten)]
+    pub settings: TokenBrokerSettings,
 
     /// Configuration for signing the token.
     /// If this is not specified, the token
     /// will be signed with an ephemeral private key.
-    pub signer: Option<TokenSignerConfig>,
-
-    pub oid_config: Option<OpenIDConfig>,
+    pub signer: Option<SignerConfig>,
 
     /// The path to the work directory that contains policies
     /// to provision the tokens.
@@ -122,45 +147,31 @@ fn default_policy_dir() -> String {
 impl Default for Configuration {
     fn default() -> Self {
         Self {
-            duration_min: default_duration(),
-            issuer_name: default_issuer_name(),
+            settings: TokenBrokerSettings::default(),
             signer: None,
-            oid_config: None,
             policy_dir: default_policy_dir(),
         }
     }
 }
 
-pub struct OIDCAttestationTokenBroker {
-    private_key: RsaPrivateKey,
-    config: Configuration,
-    cert_url: Option<String>,
-    cert_chain: Option<Vec<Certificate>>,
-    policy_engine: Arc<dyn PolicyEngine>,
+pub trait SignerProvider: Send + Sync {
+    fn private_key(&self) -> &RsaPrivateKey;
+    fn cert_chain(&self) -> Option<&[Certificate]>;
+    fn cert_url(&self) -> Option<&str>;
 }
 
-impl OIDCAttestationTokenBroker {
-    pub fn new(config: Configuration) -> Result<Self> {
-        let policy_engine = PolicyEngineType::OPA.to_policy_engine(
-            Path::new(&config.policy_dir),
-            include_str!("oidc_default_policy.rego"),
-            "default.rego",
-        )?;
-        info!("Loading default AS policy \"oidc_default_policy.rego\"");
+/// Signer resolved from a `SignerConfig` (native/serde path). Reads
+/// `key_path`/`cert_path` under the `fs` feature; `key_pem`/`cert_pem` work
+/// without fs.
+struct ConfigSigner {
+    private_key: RsaPrivateKey,
+    cert_chain: Option<Vec<Certificate>>,
+    cert_url: Option<String>,
+}
 
-        if config.signer.is_none() {
-            log::info!("No Token Signer key in config file, create an ephemeral key and without CA pubkey cert");
-            let mut rng = OsRng;
-            return Ok(Self {
-                private_key: RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?,
-                config,
-                cert_url: None,
-                cert_chain: None,
-                policy_engine,
-            });
-        }
-
-        let signer = config.signer.clone().unwrap();
+impl ConfigSigner {
+    #[cfg(feature = "fs")]
+    fn from_signer_config(signer: SignerConfig) -> Result<Self> {
         let pem_data = std::fs::read_to_string(&signer.key_path)
             .context("Read Token Signer private key failed")?;
         let private_key = RsaPrivateKey::from_pkcs8_pem(&pem_data)
@@ -192,24 +203,111 @@ impl OIDCAttestationTokenBroker {
 
         Ok(Self {
             private_key,
-            config,
-            cert_url: signer.cert_url,
             cert_chain,
+            cert_url: signer.cert_url,
+        })
+    }
+}
+
+impl SignerProvider for ConfigSigner {
+    fn private_key(&self) -> &RsaPrivateKey {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<&[Certificate]> {
+        self.cert_chain.as_deref()
+    }
+    fn cert_url(&self) -> Option<&str> {
+        self.cert_url.as_deref()
+    }
+}
+
+/// Ephemeral signer: generates a fresh RSA key. Used when no signer is
+/// configured (both `from_config` and `from_components`).
+struct EphemeralSigner {
+    private_key: RsaPrivateKey,
+}
+
+impl EphemeralSigner {
+    fn new() -> Result<Self> {
+        let mut rng = OsRng;
+        Ok(Self {
+            private_key: RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?,
+        })
+    }
+}
+
+impl SignerProvider for EphemeralSigner {
+    fn private_key(&self) -> &RsaPrivateKey {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<&[Certificate]> {
+        None
+    }
+    fn cert_url(&self) -> Option<&str> {
+        None
+    }
+}
+
+pub struct OIDCAttestationTokenBroker {
+    settings: TokenBrokerSettings,
+    signer: Arc<dyn SignerProvider>,
+    policy_engine: Arc<dyn PolicyEngine>,
+}
+
+impl OIDCAttestationTokenBroker {
+    #[cfg(feature = "fs")]
+    pub fn from_config(config: Configuration) -> Result<Self> {
+        let policy_engine = PolicyEngineType::OPA.to_policy_engine(
+            Path::new(&config.policy_dir),
+            include_str!("oidc_default_policy.rego"),
+            "default.rego",
+        )?;
+        info!("Loading default AS policy \"oidc_default_policy.rego\"");
+
+        let signer: Arc<dyn SignerProvider> = match config.signer {
+            Some(sc) => Arc::new(ConfigSigner::from_signer_config(sc)?),
+            None => {
+                log::info!(
+                    "No Token Signer key in config file, create an ephemeral key and without CA pubkey cert"
+                );
+                Arc::new(EphemeralSigner::new()?)
+            }
+        };
+
+        Ok(Self {
+            settings: config.settings,
+            signer,
             policy_engine,
         })
+    }
+
+    pub fn from_components(
+        settings: TokenBrokerSettings,
+        signer: Option<Arc<dyn SignerProvider>>,
+        policy_engine: Arc<dyn PolicyEngine>,
+    ) -> Self {
+        let signer: Arc<dyn SignerProvider> = match signer {
+            Some(s) => s,
+            None => Arc::new(EphemeralSigner::new()?),
+        };
+        Self {
+            settings,
+            signer,
+            policy_engine,
+        }
     }
 }
 
 impl OIDCAttestationTokenBroker {
     fn rs256_sign(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        let signing_key = SigningKey::<Sha256>::new(self.private_key.clone());
+        let signing_key = SigningKey::<Sha256>::new(self.signer.private_key().clone());
         let sig: Signature = signing_key.sign(payload);
         Ok(Box::<[u8]>::from(sig).to_vec())
     }
 
     fn pubkey_jwks(&self) -> Result<String> {
-        let n = self.private_key.n().to_bytes_be();
-        let e = self.private_key.e().to_bytes_be();
+        let n = self.signer.private_key().n().to_bytes_be();
+        let e = self.signer.private_key().e().to_bytes_be();
 
         let mut jwk = Jwk {
             kty: "RSA".to_string(),
@@ -220,8 +318,8 @@ impl OIDCAttestationTokenBroker {
             x5c: None,
         };
 
-        jwk.x5u.clone_from(&self.cert_url);
-        if let Some(cert_chain) = self.cert_chain.clone() {
+        jwk.x5u = self.signer.cert_url().map(str::to_owned);
+        if let Some(cert_chain) = self.signer.cert_chain() {
             let mut x5c = Vec::new();
             for cert in cert_chain {
                 let der = cert.to_der()?;
@@ -317,7 +415,7 @@ impl AttestationTokenBroker for OIDCAttestationTokenBroker {
         let header_b64 = URL_SAFE_NO_PAD.encode(header_string.as_bytes());
 
         let now = time::OffsetDateTime::now_utc();
-        let exp = now + time::Duration::minutes(self.config.duration_min);
+        let exp = now + time::Duration::minutes(self.settings.duration_min);
 
         let id: String = thread_rng()
             .sample_iter(&Alphanumeric)
@@ -325,13 +423,13 @@ impl AttestationTokenBroker for OIDCAttestationTokenBroker {
             .map(char::from)
             .collect();
 
-        let audience: String = if let Some(oidc) = &self.config.oid_config {
+        let audience: String = if let Some(oidc) = &self.settings.oid_config {
             oidc.audience.clone()
         } else {
             default_oidc_audience()
         };
 
-        let sub: String = if let Some(oidc) = &self.config.oid_config {
+        let sub: String = if let Some(oidc) = &self.settings.oid_config {
             let parts: Vec<String> = oidc.sub_claims.as_ref().map_or_else(Vec::new, |k| {
                 k.iter()
                     .map(|s| {
@@ -385,7 +483,7 @@ impl AttestationTokenBroker for OIDCAttestationTokenBroker {
         }; // Some OIDC clients require non-empty sub
 
         let mut jwt_claims = json!({
-            "iss": self.config.issuer_name.clone(),
+            "iss": self.settings.issuer_name.clone(),
             "aud": audience,
             "sub": sub,
             "iat": now.unix_timestamp(),
@@ -403,11 +501,12 @@ impl AttestationTokenBroker for OIDCAttestationTokenBroker {
                 .ok_or_else(|| anyhow!("Illegal token custom claims"))?
                 .to_owned(),
         );
+        #[cfg(feature = "fs")]
         if let Some(transparency) = signer_transparency::load_signer_transparency() {
             jwt_claims.insert("signer_transparency".to_string(), transparency);
         }
 
-        let additional_claims: HashSet<String> = if let Some(oidc) = &self.config.oid_config {
+        let additional_claims: HashSet<String> = if let Some(oidc) = &self.settings.oid_config {
             oidc.additional_claims
                 .as_ref()
                 .map_or_else(HashSet::new, |v| v.iter().cloned().collect())
@@ -513,7 +612,7 @@ mod tests {
     use x509_cert::Certificate;
 
     use crate::token::{
-        oidc::{Configuration, OIDCAttestationTokenBroker, TokenSignerConfig},
+        oidc::{Configuration, OIDCAttestationTokenBroker, SignerConfig},
         AttestationTokenBroker,
     };
 
@@ -522,7 +621,7 @@ mod tests {
         // use default config with no signer.
         // this will sign the token with an ephemeral key.
         let config = Configuration::default();
-        let broker = OIDCAttestationTokenBroker::new(config).unwrap();
+        let broker = OIDCAttestationTokenBroker::from_config(config).unwrap();
 
         let _token = broker
             .issue(
@@ -577,12 +676,52 @@ mod tests {
         assert_eq!(token.split('.').count(), 3);
     }
 
+    #[cfg(not(feature = "fs"))]
+    #[tokio::test]
+    async fn from_components_issues_without_fs() {
+        use std::path::Path;
+        use std::sync::Arc;
+
+        use crate::policy_engine::{PolicyEngine, PolicyEngineType};
+
+        let policy_engine: Arc<dyn PolicyEngine> = PolicyEngineType::InMemory
+            .to_policy_engine(
+                Path::new("/"),
+                include_str!("oidc_default_policy.rego"),
+                "default.rego",
+            )
+            .unwrap();
+        let broker = OIDCAttestationTokenBroker::from_components(
+            super::TokenBrokerSettings::default(),
+            None,
+            policy_engine,
+        )
+        .unwrap();
+
+        let _token = broker
+            .issue(
+                vec![TeeClaims {
+                    tee: Tee::Sample,
+                    tee_class: "cpu".to_string(),
+                    claims: json!({"claim": "claim1"}),
+                    runtime_data_claims: json!({"runtime_data": "111"}),
+                    init_data_claims: json!({"initdata": "111"}),
+                    additional_data: None,
+                }],
+                vec!["default".into()],
+                HashMap::new(),
+            )
+            .await
+            .unwrap();
+    }
+
     // A pre-generated RSA-2048 PKCS#8 private key (PEM). Used together with
     // `TEST_CERT_CHAIN_PEM` to exercise the `signer = Some(...)` branch of
     // `OIDCAttestationTokenBroker::new`, which parses the PEM cert chain via
     // `Certificate::from_pem` and later encodes it into the JWK `x5c` array via
     // `Certificate::to_der`. Generated with `openssl genpkey` / `openssl req
     // -x509`; embedded as text so no binary fixture is committed.
+    #[cfg(feature = "fs")]
     const TEST_SIGNER_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCdazaeItcE7c8W
 cuc3i+KE94fKdLt/aOw2oIr6lVlzW95cwuok35uTYlJwTrvhPd8Qz1xBuerk9qAQ
@@ -615,6 +754,7 @@ wihjpplQnoBixGHV/2XFex6x
 
     // A 2-cert PEM chain (leaf + CA). The split-on-`-----END CERTIFICATE-----`
     // loop in `OIDCAttestationTokenBroker::new` parses both entries.
+    #[cfg(feature = "fs")]
     const TEST_CERT_CHAIN_PEM: &str = "-----BEGIN CERTIFICATE-----
 MIIDCTCCAfGgAwIBAgIUdzxyN1GLEQxMXM8WxZBC8XyZgLswDQYJKoZIhvcNAQEL
 BQAwFDESMBAGA1UEAwwJdGVzdC1sZWFmMB4XDTI2MDcxMzEzMzMyOFoXDTI2MDcx
@@ -669,16 +809,15 @@ frJCGYDUg+8c
         std::fs::write(&chain_file, TEST_CERT_CHAIN_PEM).expect("write temp chain file");
 
         let config = Configuration {
-            signer: Some(TokenSignerConfig {
+            signer: Some(SignerConfig {
                 key_path: key_file.path().to_string_lossy().to_string(),
                 cert_url: None,
                 cert_path: Some(chain_file.path().to_string_lossy().to_string()),
             }),
-            oid_config: None,
             ..Configuration::default()
         };
 
-        let broker = OIDCAttestationTokenBroker::new(config)
+        let broker = OIDCAttestationTokenBroker::from_config(config)
             .expect("broker construction with signer + cert chain must succeed");
 
         let jwks = serde_json::from_str::<serde_json::Value>(

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -541,6 +541,7 @@ mod tests {
         AttestationTokenBroker,
     };
 
+    #[cfg(feature = "fs")]
     #[tokio::test]
     async fn test_issue_oidc_ephemeral_key() {
         // use default config with no signer.
@@ -565,6 +566,7 @@ mod tests {
             .unwrap();
     }
 
+    #[cfg(feature = "fs")]
     #[tokio::test]
     async fn test_snp_default_policy_accepts_without_reference_values() {
         let policy_dir = tempfile::tempdir().unwrap();
@@ -572,7 +574,7 @@ mod tests {
             policy_dir: policy_dir.path().to_string_lossy().into_owned(),
             ..Configuration::default()
         };
-        let broker = OIDCAttestationTokenBroker::new(config).unwrap();
+        let broker = OIDCAttestationTokenBroker::from_config(config).unwrap();
         let claims = TeeClaims {
             tee: Tee::Snp,
             tee_class: "cpu".to_string(),
@@ -604,20 +606,33 @@ mod tests {
     #[cfg(not(feature = "fs"))]
     #[tokio::test]
     async fn from_components_issues_without_fs() {
-        use std::path::Path;
+        use std::collections::HashMap;
         use std::sync::Arc;
 
-        use crate::policy_engine::{PolicyEngine, PolicyEngineType};
+        use rsa::RsaPrivateKey;
 
-        let policy_engine: Arc<dyn PolicyEngine> = PolicyEngineType::InMemory
-            .to_policy_engine(Path::new("/"), DEFAULT_POLICY, DEFAULT_POLICY_ID)
-            .unwrap();
+        use crate::policy_engine::opa::OPAInMemory;
+        use crate::policy_engine::PolicyEngine;
+        use crate::token::signer::EphemeralSigner;
+
+        // Construct the fs-free InMemory policy engine directly (bypassing the
+        // fs-gated `PolicyEngineType`/`to_policy_engine`) and inject an
+        // ephemeral RSA signer, proving `from_components` + `issue()` work
+        // with no filesystem access at all. A trivial `allow` policy is used
+        // instead of `DEFAULT_POLICY` because the real default policy calls
+        // the `query_reference_value` regorus extension, which is only
+        // registered under the `policy-rvps` feature — off under
+        // `--no-default-features`.
+        const TRIVIAL_ALLOW_POLICY: &str = "package policy\ndefault allow = true";
+        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(OPAInMemory::with_raw_default_policy(
+            TRIVIAL_ALLOW_POLICY,
+            super::DEFAULT_POLICY_ID,
+        ));
         let broker = OIDCAttestationTokenBroker::from_components(
             super::TokenBrokerSettings::default(),
-            None,
+            Arc::new(EphemeralSigner::<RsaPrivateKey>::new().unwrap()),
             policy_engine,
-        )
-        .unwrap();
+        );
 
         let _token = broker
             .issue(
@@ -630,7 +645,7 @@ mod tests {
                     additional_data: None,
                 }],
                 vec!["default".into()],
-                HashMap::new(),
+                crate::rvps::empty_test_resolver(),
             )
             .await
             .unwrap();
@@ -716,6 +731,7 @@ frJCGYDUg+8c
 -----END CERTIFICATE-----
 ";
 
+    #[cfg(feature = "fs")]
     #[test]
     fn test_oidc_signer_cert_chain_x5c() {
         // Exercise the `signer = Some(...)` branch of

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -158,13 +158,13 @@ impl Default for Configuration {
 
 pub trait SignerProvider: Send + Sync {
     fn private_key(&self) -> &RsaPrivateKey;
-    fn cert_chain(&self) -> Option<&[Certificate]>;
+    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>>;
     fn cert_url(&self) -> Option<&str>;
     /// The signer's certificate-chain raw PEM bytes, read lazily from the
     /// configured `cert_path` on each call (not cached at construction).
     /// `None` when no `cert_path` is configured. Ephemeral signers return
     /// `None`. The broker forwards this through `signer_cert_content`.
-    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>>;
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>>;
 }
 
 /// Signer resolved from a `SignerConfig` (native/serde path). Reads
@@ -173,7 +173,6 @@ pub trait SignerProvider: Send + Sync {
 #[cfg(feature = "fs")]
 struct ConfigSigner {
     private_key: RsaPrivateKey,
-    cert_chain: Option<Vec<Certificate>>,
     cert_url: Option<String>,
     // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
     cert_path: Option<String>,
@@ -188,8 +187,21 @@ impl ConfigSigner {
             .or_else(|_| RsaPrivateKey::from_pkcs1_pem(&pem_data))
             .context("Parse Token Signer private key failed")?;
 
-        let cert_chain = signer
-            .cert_path
+        Ok(Self {
+            private_key,
+            cert_url: signer.cert_url,
+            cert_path: signer.cert_path,
+        })
+    }
+}
+
+#[cfg(feature = "fs")]
+impl SignerProvider for ConfigSigner {
+    fn private_key(&self) -> &RsaPrivateKey {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
+        self.cert_path
             .as_ref()
             .map(|cert_path| -> Result<Vec<Certificate>> {
                 let pem_cert_chain = std::fs::read_to_string(cert_path)
@@ -209,43 +221,21 @@ impl ConfigSigner {
                 }
                 Ok(chain)
             })
-            .transpose()?;
-
-        Ok(Self {
-            private_key,
-            cert_chain,
-            cert_url: signer.cert_url,
-            cert_path: signer.cert_path,
-        })
-    }
-}
-
-#[cfg(feature = "fs")]
-impl SignerProvider for ConfigSigner {
-    fn private_key(&self) -> &RsaPrivateKey {
-        &self.private_key
-    }
-    fn cert_chain(&self) -> Option<&[Certificate]> {
-        self.cert_chain.as_deref()
     }
     fn cert_url(&self) -> Option<&str> {
         self.cert_url.as_deref()
     }
-    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
-        match &self.cert_path {
-            Some(path) => {
-                use std::io::Read as _;
-
-                // Read certificate from file
-                let mut file = std::fs::File::open(path)
-                    .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
-                let mut content = Vec::new();
-                file.read_to_end(&mut content)
-                    .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
-                Ok(Some(content))
-            }
-            None => Ok(None),
-        }
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
+        self.cert_path.as_ref().map(|path| {
+            use std::io::Read as _;
+            // Read certificate from file
+            let mut file = std::fs::File::open(path)
+                .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
+            let mut content = Vec::new();
+            file.read_to_end(&mut content)
+                .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
+            Ok(content)
+        })
     }
 }
 
@@ -268,14 +258,14 @@ impl SignerProvider for EphemeralSigner {
     fn private_key(&self) -> &RsaPrivateKey {
         &self.private_key
     }
-    fn cert_chain(&self) -> Option<&[Certificate]> {
+    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
         None
     }
     fn cert_url(&self) -> Option<&str> {
         None
     }
-    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
-        Ok(None)
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
+        None
     }
 }
 
@@ -346,7 +336,7 @@ impl OIDCAttestationTokenBroker {
         };
 
         jwk.x5u = self.signer.cert_url().map(str::to_owned);
-        if let Some(cert_chain) = self.signer.cert_chain() {
+        if let Some(cert_chain) = self.signer.cert_chain().transpose()? {
             let mut x5c = Vec::new();
             for cert in cert_chain {
                 let der = cert.to_der()?;
@@ -598,7 +588,7 @@ impl AttestationTokenBroker for OIDCAttestationTokenBroker {
             .map_err(Error::from)
     }
 
-    async fn signer_cert_content(&self) -> Result<Option<Vec<u8>>> {
+    async fn signer_cert_content(&self) -> Option<Result<Vec<u8>>> {
         self.signer.cert_pem_raw()
     }
 

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -224,7 +224,15 @@ impl OIDCAttestationTokenBroker {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), async_trait::async_trait(?Send))]
+#[cfg_attr(
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )),
+    async_trait::async_trait
+)]
 impl AttestationTokenBroker for OIDCAttestationTokenBroker {
     async fn issue(
         &self,

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -21,6 +21,9 @@ use rsa::pkcs8::DecodePrivateKey;
 use rsa::signature::Signer;
 use rsa::traits::PublicKeyParts;
 use rsa::RsaPrivateKey;
+#[cfg(feature = "fs")]
+use rustls_pki_types::pem::PemObject;
+use rustls_pki_types::CertificateDer;
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use serde_variant::to_variant_name;
@@ -28,8 +31,6 @@ use sha2::Sha256;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
-use x509_cert::der::{DecodePem, Encode};
-use x509_cert::Certificate;
 
 use crate::policy_engine::{PolicyEngine, PolicyEngineType};
 use crate::rvps::ReferenceValueResolver;
@@ -158,7 +159,7 @@ impl Default for Configuration {
 
 pub trait SignerProvider: Send + Sync {
     fn private_key(&self) -> &RsaPrivateKey;
-    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>>;
+    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>>;
     fn cert_url(&self) -> Option<&str>;
     /// The signer's certificate-chain raw PEM bytes, read lazily from the
     /// configured `cert_path` on each call (not cached at construction).
@@ -203,23 +204,12 @@ impl SignerProvider for ConfigSigner {
     fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
         self.cert_path
             .as_ref()
-            .map(|cert_path| -> Result<Vec<Certificate>> {
+            .map(|cert_path| -> Result<Vec<CertificateDer<'static>>> {
                 let pem_cert_chain = std::fs::read_to_string(cert_path)
                     .context("Read Token Signer cert file failed")?;
-                let mut chain = Vec::new();
-
-                for pem in pem_cert_chain.split("-----END CERTIFICATE-----") {
-                    let trimmed = format!("{}\n-----END CERTIFICATE-----", pem.trim());
-                    if !trimmed.starts_with("-----BEGIN CERTIFICATE-----") {
-                        continue;
-                    }
-                    // x509-cert's DecodePem expects a single PEM block; the split
-                    // above already isolates one. Use the Label-aware decoder.
-                    let cert = Certificate::from_pem(trimmed.as_bytes())
-                        .context("Invalid PEM certificate chain")?;
-                    chain.push(cert);
-                }
-                Ok(chain)
+                let chain: Result<Vec<_>, rustls_pki_types::pem::Error> =
+                    CertificateDer::pem_slice_iter(pem_cert_chain.as_bytes()).collect();
+                chain.context("Invalid PEM certificate chain")
             })
     }
     fn cert_url(&self) -> Option<&str> {
@@ -258,7 +248,7 @@ impl SignerProvider for EphemeralSigner {
     fn private_key(&self) -> &RsaPrivateKey {
         &self.private_key
     }
-    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
+    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>> {
         None
     }
     fn cert_url(&self) -> Option<&str> {
@@ -339,8 +329,7 @@ impl OIDCAttestationTokenBroker {
         if let Some(cert_chain) = self.signer.cert_chain().transpose()? {
             let mut x5c = Vec::new();
             for cert in cert_chain {
-                let der = cert.to_der()?;
-                x5c.push(URL_SAFE_NO_PAD.encode(der));
+                x5c.push(URL_SAFE_NO_PAD.encode(cert));
             }
             jwk.x5c = Some(x5c);
         }

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -45,6 +45,8 @@ const OIDC_TOKEN_ALG: &str = "RS256";
 const DEFAULT_OIDC_AUDIENCE: &str = "sigstore";
 
 const DEFAULT_POLICY_DIR: &str = concatcp!(DEFAULT_TOKEN_WORK_DIR, "/oidc/policies");
+pub const DEFAULT_POLICY: &str = include_str!("oidc_default_policy.rego");
+pub const DEFAULT_POLICY_ID: &str = "default.rego";
 
 /// Part 2 — signer resolution spec (native/serde path only). Renamed from
 /// `TokenSignerConfig`; field set unchanged.
@@ -259,8 +261,8 @@ impl OIDCAttestationTokenBroker {
     pub fn from_config(config: Configuration) -> Result<Self> {
         let policy_engine = PolicyEngineType::OPA.to_policy_engine(
             Path::new(&config.policy_dir),
-            include_str!("oidc_default_policy.rego"),
-            "default.rego",
+            DEFAULT_POLICY,
+            DEFAULT_POLICY_ID,
         )?;
         info!("Loading default AS policy \"oidc_default_policy.rego\"");
 
@@ -685,11 +687,7 @@ mod tests {
         use crate::policy_engine::{PolicyEngine, PolicyEngineType};
 
         let policy_engine: Arc<dyn PolicyEngine> = PolicyEngineType::InMemory
-            .to_policy_engine(
-                Path::new("/"),
-                include_str!("oidc_default_policy.rego"),
-                "default.rego",
-            )
+            .to_policy_engine(Path::new("/"), DEFAULT_POLICY, DEFAULT_POLICY_ID)
             .unwrap();
         let broker = OIDCAttestationTokenBroker::from_components(
             super::TokenBrokerSettings::default(),

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -11,7 +11,6 @@ use anyhow::*;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use const_format::concatcp;
-use log::info;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use rsa::pkcs1v15::{Signature, SigningKey};
@@ -23,15 +22,14 @@ use serde_json::{json, Map, Value};
 use serde_variant::to_variant_name;
 use sha2::Sha256;
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
 use std::sync::Arc;
 
-use crate::policy_engine::{PolicyEngine, PolicyEngineType};
+use crate::policy_engine::PolicyEngine;
 use crate::rvps::ReferenceValueResolver;
 use crate::token::{AttestationTokenBroker, DEFAULT_TOKEN_WORK_DIR};
 use crate::TeeClaims;
 
-use super::signer::{EphemeralSigner, FsSigner, SignKeyProvider};
+use super::signer::SignKeyProvider;
 #[cfg(feature = "fs")]
 use super::signer_transparency;
 use super::{COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
@@ -150,20 +148,20 @@ pub struct OIDCAttestationTokenBroker {
 impl OIDCAttestationTokenBroker {
     #[cfg(feature = "fs")]
     pub fn from_config(config: Configuration) -> Result<Self> {
-        let policy_engine = PolicyEngineType::OPA.to_policy_engine(
-            Path::new(&config.policy_dir),
+        let policy_engine = crate::policy_engine::PolicyEngineType::OPA.to_policy_engine(
+            std::path::Path::new(&config.policy_dir),
             DEFAULT_POLICY,
             DEFAULT_POLICY_ID,
         )?;
-        info!("Loading default AS policy \"oidc_default_policy.rego\"");
+        log::info!("Loading default AS policy \"oidc_default_policy.rego\"");
 
         let signer: Arc<dyn SignKeyProvider<RsaPrivateKey>> = match config.signer {
-            Some(sc) => Arc::new(FsSigner::<RsaPrivateKey>::from_config(sc)?),
+            Some(sc) => Arc::new(super::signer::FsSigner::<RsaPrivateKey>::from_config(sc)?),
             None => {
                 log::info!(
                     "No Token Signer key in config file, create an ephemeral key and without CA pubkey cert"
                 );
-                Arc::new(EphemeralSigner::<RsaPrivateKey>::new()?)
+                Arc::new(super::signer::EphemeralSigner::<RsaPrivateKey>::new()?)
             }
         };
 

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -473,10 +473,18 @@ impl AttestationTokenBroker for OIDCAttestationTokenBroker {
         self.signer.cert_url()
     }
 
-    /// OIDC broker publishes its signer RSA public key as a JWKS `{"keys":[...]}`
-    /// with `kty/n/e` only — matching the historical service endpoint output.
-    /// `None` when no signer is configured (ephemeral key).
-    async fn public_jwks(&self) -> Result<Option<String>> {
+    /// Publish the configured signer's RSA public key as a JWKS
+    /// `{"keys":[...]}` with `kty/n/e` only — matching the historical service
+    /// endpoint output. Returns `None` when no signer is configured (i.e. the
+    /// signer is ephemeral, per [`SignKeyProvider::is_configured`]): an
+    /// ephemeral key is freshly generated per process start and is not
+    /// publishable, so the `/jwks` endpoint answers `404`. This preserves the
+    /// long-standing behavior of only publishing a JWKS for an explicitly
+    /// configured signer.
+    async fn configured_signer_jwks(&self) -> Result<Option<String>> {
+        if !self.signer.is_configured() {
+            return Ok(None);
+        }
         let n = self.signer.private_key().n().to_bytes_be();
         let e = self.signer.private_key().e().to_bytes_be();
         let jwk = json!({
@@ -806,5 +814,58 @@ frJCGYDUg+8c
                 .expect("each x5c entry must base64url-decode to DER bytes");
             Certificate::from_der(&der).expect("decoded x5c entry must be a valid DER certificate");
         }
+    }
+
+    /// `configured_signer_jwks` must publish a JWKS only for a *configured*
+    /// signer; an ephemeral signer returns `None` (so `/jwks` answers 404),
+    /// preserving the long-standing behavior of only publishing a JWKS when a
+    /// signer was explicitly configured.
+    #[cfg(feature = "fs")]
+    #[tokio::test]
+    async fn test_configured_signer_jwks_visibility() {
+        use crate::policy_engine::opa::OPAInMemory;
+        use crate::policy_engine::PolicyEngine;
+        use crate::token::signer::EphemeralSigner;
+        use rsa::RsaPrivateKey;
+        use std::sync::Arc;
+
+        // Configured signer → published.
+        let key_file = NamedTempFile::new().expect("create temp key file");
+        std::fs::write(&key_file, TEST_SIGNER_KEY_PEM).expect("write temp key file");
+        let cfg = Configuration {
+            signer: Some(SignerConfig {
+                key_path: key_file.path().to_string_lossy().to_string(),
+                cert_url: None,
+                cert_path: None,
+            }),
+            ..Configuration::default()
+        };
+        let broker =
+            OIDCAttestationTokenBroker::from_config(cfg).expect("configured broker must construct");
+        let jwks = broker
+            .configured_signer_jwks()
+            .await
+            .expect("configured_signer_jwks must not error");
+        assert!(jwks.is_some(), "configured signer must publish a JWKS");
+        let v: serde_json::Value =
+            serde_json::from_str(&jwks.unwrap()).expect("published JWKS must be valid JSON");
+        assert_eq!(v["keys"][0]["kty"], "RSA", "JWK kty must be RSA");
+
+        // Ephemeral signer → not published (None).
+        const TRIVIAL_ALLOW_POLICY: &str = "package policy\ndefault allow = true";
+        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(OPAInMemory::with_raw_default_policy(
+            TRIVIAL_ALLOW_POLICY,
+            super::DEFAULT_POLICY_ID,
+        ));
+        let ephemeral = OIDCAttestationTokenBroker::from_components(
+            super::TokenBrokerSettings::default(),
+            Arc::new(EphemeralSigner::<RsaPrivateKey>::new().unwrap()),
+            policy_engine,
+        );
+        assert_eq!(
+            ephemeral.configured_signer_jwks().await.unwrap(),
+            None,
+            "ephemeral signer must not be published at /jwks"
+        );
     }
 }

--- a/attestation-service/src/token/signer.rs
+++ b/attestation-service/src/token/signer.rs
@@ -1,0 +1,185 @@
+// Copyright (c) 2023 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Shared, generic signing-key providers for the token brokers.
+//!
+//! [`SignKeyProvider`]`<K>` is the common trait; [`FsSigner`]`<K>` (key
+//! material loaded from a [`SignerConfig`] on disk, fs-gated construction)
+//! and [`EphemeralSigner`]`<K>` (a fresh key generated at runtime) are the
+//! two implementations. The shared cert-chain / cert-url / cert-pem-raw
+//! plumbing is written once in the generic trait impls; K-specific
+//! construction (PEM parsing, key generation) is provided via concrete
+//! inherent impls on the specific key types the brokers use
+//! (`rsa::RsaPrivateKey`, `p256::SecretKey`).
+
+use anyhow::{anyhow, Context, Result};
+use p256::SecretKey;
+use rand::rngs::OsRng;
+use rsa::RsaPrivateKey;
+use rustls_pki_types::CertificateDer;
+use serde::Deserialize;
+
+#[cfg(feature = "fs")]
+use p256::pkcs8::DecodePrivateKey as EcDecodePrivateKey;
+#[cfg(feature = "fs")]
+use rsa::pkcs1::DecodeRsaPrivateKey;
+#[cfg(feature = "fs")]
+use rustls_pki_types::pem::PemObject;
+
+/// Shared RSA key size (bits) for ephemeral RSA signers.
+const RSA_KEY_BITS: u32 = 2048;
+
+/// A signing-key provider. `K` is the concrete key type and is fixed per
+/// broker, so `dyn SignKeyProvider<RsaPrivateKey>` /
+/// `dyn SignKeyProvider<SecretKey>` are valid trait objects: every method has
+/// no method-level generics and does not return `Self`.
+pub trait SignKeyProvider<K>: Send + Sync {
+    fn private_key(&self) -> &K;
+    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>>;
+    fn cert_url(&self) -> Option<&str>;
+    /// The signer's certificate-chain raw PEM bytes, read lazily from the
+    /// configured `cert_path` on each call (not cached at construction).
+    /// `None` when no `cert_path` is configured. Ephemeral signers return
+    /// `None`. The broker forwards this through `signer_cert_content`.
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>>;
+}
+
+/// Signer resolved from a [`SignerConfig`] (native/serde path). Reads
+/// `key_path`/`cert_path` on disk under the `fs` feature.
+pub struct FsSigner<K> {
+    private_key: K,
+    cert_url: Option<String>,
+    // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
+    cert_path: Option<String>,
+}
+
+/// Ephemeral signer: generates a fresh key at runtime. Used when no signer is
+/// configured (both `from_config` and `from_components`).
+pub struct EphemeralSigner<K> {
+    private_key: K,
+}
+
+#[cfg(feature = "fs")]
+impl<K: Send + Sync> SignKeyProvider<K> for FsSigner<K> {
+    fn private_key(&self) -> &K {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>> {
+        self.cert_path
+            .as_ref()
+            .map(|cert_path| -> Result<Vec<CertificateDer<'static>>> {
+                let pem_cert_chain = std::fs::read_to_string(cert_path)
+                    .context("Read Token Signer cert file failed")?;
+                let chain: Result<Vec<_>, rustls_pki_types::pem::Error> =
+                    CertificateDer::pem_slice_iter(pem_cert_chain.as_bytes()).collect();
+                chain.context("Invalid PEM certificate chain")
+            })
+    }
+    fn cert_url(&self) -> Option<&str> {
+        self.cert_url.as_deref()
+    }
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
+        self.cert_path.as_ref().map(|path| {
+            use std::io::Read as _;
+            // Read certificate from file
+            let mut file = std::fs::File::open(path)
+                .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
+            let mut content = Vec::new();
+            file.read_to_end(&mut content)
+                .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
+            Ok(content)
+        })
+    }
+}
+
+impl<K: Send + Sync> SignKeyProvider<K> for EphemeralSigner<K> {
+    fn private_key(&self) -> &K {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>> {
+        None
+    }
+    fn cert_url(&self) -> Option<&str> {
+        None
+    }
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
+        None
+    }
+}
+
+/// Shared signer configuration (deserialized from the token-broker config).
+///
+/// Note: unifying on `#[serde(default)]` for `cert_url`/`cert_path` relaxes
+/// the simple/oidc configs (which previously errored on a missing field) to
+/// match ear's existing tolerant behavior. This does not affect emitted
+/// tokens; `cert_url`/`cert_path` only influence `x5u`/`x5c` when set.
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct SignerConfig {
+    pub key_path: String,
+    #[serde(default)]
+    pub cert_url: Option<String>,
+    // PEM format certificate chain.
+    #[serde(default)]
+    pub cert_path: Option<String>,
+}
+
+// --- Concrete construction impls ("specific code on the generic") ---
+
+#[cfg(feature = "fs")]
+impl FsSigner<RsaPrivateKey> {
+    /// Parse an RSA private key from `SignerConfig::key_path` (PKCS#8, with a
+    /// PKCS#1 fallback).
+    pub fn from_config(signer: SignerConfig) -> Result<Self> {
+        let pem_data = std::fs::read_to_string(&signer.key_path)
+            .context("Read Token Signer private key failed")?;
+        let private_key = RsaPrivateKey::from_pkcs8_pem(&pem_data)
+            .or_else(|_| RsaPrivateKey::from_pkcs1_pem(&pem_data))
+            .context("Parse Token Signer private key failed")?;
+        Ok(Self {
+            private_key,
+            cert_url: signer.cert_url,
+            cert_path: signer.cert_path,
+        })
+    }
+}
+
+#[cfg(feature = "fs")]
+impl FsSigner<SecretKey> {
+    /// Parse an EC P-256 private key from `SignerConfig::key_path` (SEC1, with
+    /// a PKCS#8 fallback).
+    pub fn from_config(signer: SignerConfig) -> Result<Self> {
+        let pem_data =
+            std::fs::read(&signer.key_path).context("Read Token Signer private key failed")?;
+        let pem_str = std::str::from_utf8(&pem_data).context("Token Signer key not UTF-8")?;
+        let private_key = SecretKey::from_sec1_pem(pem_str)
+            .or_else(|_| SecretKey::from_pkcs8_pem(pem_str))
+            .context("Parse Token Signer private key failed")?;
+        Ok(Self {
+            private_key,
+            cert_url: signer.cert_url,
+            cert_path: signer.cert_path,
+        })
+    }
+}
+
+impl EphemeralSigner<RsaPrivateKey> {
+    /// Generate a fresh 2048-bit RSA key.
+    pub fn new() -> Result<Self> {
+        let mut rng = OsRng;
+        Ok(Self {
+            private_key: RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?,
+        })
+    }
+}
+
+impl EphemeralSigner<SecretKey> {
+    /// Generate a fresh EC P-256 key.
+    pub fn new() -> Self {
+        let mut rng = OsRng;
+        Self {
+            private_key: SecretKey::random(&mut rng),
+        }
+    }
+}

--- a/attestation-service/src/token/signer.rs
+++ b/attestation-service/src/token/signer.rs
@@ -8,7 +8,7 @@
 //! [`SignKeyProvider`]`<K>` is the common trait; [`FsSigner`]`<K>` (key
 //! material loaded from a [`SignerConfig`] on disk, fs-gated construction)
 //! and [`EphemeralSigner`]`<K>` (a fresh key generated at runtime) are the
-//! two implementations. The shared cert-chain / cert-url / cert-pem-raw
+//! two implementations. The shared cert-chain / cert-url / cert-pem-live
 //! plumbing is written once in the generic trait impls; K-specific
 //! construction (PEM parsing, key generation) is provided via concrete
 //! inherent impls on the specific key types the brokers use
@@ -44,8 +44,8 @@ pub trait SignKeyProvider<K>: Send + Sync {
     /// The signer's certificate-chain raw PEM bytes, read lazily from the
     /// configured `cert_path` on each call (not cached at construction).
     /// `None` when no `cert_path` is configured. Ephemeral signers return
-    /// `None`. The broker forwards this through `signer_cert_content`.
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>>;
+    /// `None`. The broker forwards this through `signer_cert_pem_live`.
+    fn cert_pem_live(&self) -> Option<Result<Vec<u8>>>;
 }
 
 /// Signer resolved from a [`SignerConfig`] (native/serde path). Reads
@@ -54,8 +54,26 @@ pub trait SignKeyProvider<K>: Send + Sync {
 pub struct FsSigner<K> {
     private_key: K,
     cert_url: Option<String>,
-    // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
+    // Kept so `cert_pem_live` can re-read the raw PEM bytes lazily on each call.
+    // This mirrors the historical `get_token_broker_cert_config` /
+    // `get_cert_content` cert endpoint, which always served the *current*
+    // on-disk certificate (no cache) — the right behavior for an endpoint
+    // whose job is to expose whatever cert is deployed.
     cert_path: Option<String>,
+    // Parsed certificate chain, loaded *once* at construction and cached.
+    // This backs the `x5c`/`jwk` embedded in issued tokens via `cert_chain()`.
+    // Caching (rather than re-reading per attest) does two things:
+    //   1. avoids a file read + PEM parse on every token issuance; and
+    //   2. keeps the cert chain and `private_key` as a single
+    //      construction-time snapshot, so the `x5c` in a token always matches
+    //      the key that signed it — even if the cert file is swapped at run
+    //      time. (A re-read-per-attest design would let `x5c` drift away from
+    //      the cached signing key.) This matches the pre-PR behavior, where
+    //      the broker cached `cert_chain` in `new()` and reused it.
+    // Note: `cert_path` is kept separately above so `cert_pem_live` (the cert
+    // *endpoint*) can still re-read lazily — the two paths have different
+    // semantics and must not be unified.
+    cert_chain: Option<Vec<CertificateDer<'static>>>,
 }
 
 /// Ephemeral signer: generates a fresh key at runtime. Used when no signer is
@@ -69,21 +87,18 @@ impl<K: Send + Sync> SignKeyProvider<K> for FsSigner<K> {
     fn private_key(&self) -> &K {
         &self.private_key
     }
+    // Returns the construction-time cached chain (see field doc). Never reads
+    // disk here — the read+parse already happened in `from_config`, so by the
+    // time this is called the result is infallible. (The `Result` in the
+    // return type is kept to satisfy the trait signature; other impls may be
+    // fallible at call time.)
     fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>> {
-        self.cert_path
-            .as_ref()
-            .map(|cert_path| -> Result<Vec<CertificateDer<'static>>> {
-                let pem_cert_chain = std::fs::read_to_string(cert_path)
-                    .context("Read Token Signer cert file failed")?;
-                let chain: Result<Vec<_>, rustls_pki_types::pem::Error> =
-                    CertificateDer::pem_slice_iter(pem_cert_chain.as_bytes()).collect();
-                chain.context("Invalid PEM certificate chain")
-            })
+        self.cert_chain.clone().map(Ok)
     }
     fn cert_url(&self) -> Option<&str> {
         self.cert_url.as_deref()
     }
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
+    fn cert_pem_live(&self) -> Option<Result<Vec<u8>>> {
         self.cert_path.as_ref().map(|path| {
             use std::io::Read as _;
             // Read certificate from file
@@ -107,7 +122,7 @@ impl<K: Send + Sync> SignKeyProvider<K> for EphemeralSigner<K> {
     fn cert_url(&self) -> Option<&str> {
         None
     }
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
+    fn cert_pem_live(&self) -> Option<Result<Vec<u8>>> {
         None
     }
 }
@@ -130,6 +145,24 @@ pub struct SignerConfig {
 
 // --- Concrete construction impls ("specific code on the generic") ---
 
+/// Read and PEM-parse a certificate chain from `cert_path` once, returning
+/// the parsed `CertificateDer` list (or `None` when no `cert_path` is
+/// configured). Used by both `FsSigner::*::from_config` to populate the
+/// cached `cert_chain` field at construction time.
+#[cfg(feature = "fs")]
+fn load_cert_chain(cert_path: &Option<String>) -> Result<Option<Vec<CertificateDer<'static>>>> {
+    match cert_path {
+        Some(cert_path) => {
+            let pem_cert_chain =
+                std::fs::read_to_string(cert_path).context("Read Token Signer cert file failed")?;
+            let chain: Result<Vec<_>, rustls_pki_types::pem::Error> =
+                CertificateDer::pem_slice_iter(pem_cert_chain.as_bytes()).collect();
+            Ok(Some(chain.context("Invalid PEM certificate chain")?))
+        }
+        None => Ok(None),
+    }
+}
+
 #[cfg(feature = "fs")]
 impl FsSigner<RsaPrivateKey> {
     /// Parse an RSA private key from `SignerConfig::key_path` (PKCS#8, with a
@@ -140,10 +173,13 @@ impl FsSigner<RsaPrivateKey> {
         let private_key = RsaPrivateKey::from_pkcs8_pem(&pem_data)
             .or_else(|_| RsaPrivateKey::from_pkcs1_pem(&pem_data))
             .context("Parse Token Signer private key failed")?;
+        // Cache the cert chain at construction (see `cert_chain` field doc).
+        let cert_chain = load_cert_chain(&signer.cert_path)?;
         Ok(Self {
             private_key,
             cert_url: signer.cert_url,
             cert_path: signer.cert_path,
+            cert_chain,
         })
     }
 }
@@ -159,10 +195,13 @@ impl FsSigner<SecretKey> {
         let private_key = SecretKey::from_sec1_pem(pem_str)
             .or_else(|_| SecretKey::from_pkcs8_pem(pem_str))
             .context("Parse Token Signer private key failed")?;
+        // Cache the cert chain at construction (see `cert_chain` field doc).
+        let cert_chain = load_cert_chain(&signer.cert_path)?;
         Ok(Self {
             private_key,
             cert_url: signer.cert_url,
             cert_path: signer.cert_path,
+            cert_chain,
         })
     }
 }

--- a/attestation-service/src/token/signer.rs
+++ b/attestation-service/src/token/signer.rs
@@ -46,6 +46,20 @@ pub trait SignKeyProvider<K>: Send + Sync {
     /// `None` when no `cert_path` is configured. Ephemeral signers return
     /// `None`. The broker forwards this through `signer_cert_pem_live`.
     fn cert_pem_live(&self) -> Option<Result<Vec<u8>>>;
+    /// Whether this signer was loaded from explicit configuration
+    /// ([`FsSigner`]) rather than an ephemeral key generated at runtime
+    /// ([`EphemeralSigner`]).
+    ///
+    /// Brokers use this to decide whether to publish the signer's public key
+    /// at the `/jwks` endpoint: the attestation service has historically
+    /// published a JWKS only when a signer was explicitly configured,
+    /// answering `404` otherwise. An ephemeral key is freshly generated per
+    /// process start, so clients cannot pin it and it is not published.
+    /// [`FsSigner`] overrides this to `true`; [`EphemeralSigner`] keeps the
+    /// default `false`.
+    fn is_configured(&self) -> bool {
+        false
+    }
 }
 
 /// Signer resolved from a [`SignerConfig`] (native/serde path). Reads
@@ -68,8 +82,10 @@ pub struct FsSigner<K> {
     //      construction-time snapshot, so the `x5c` in a token always matches
     //      the key that signed it — even if the cert file is swapped at run
     //      time. (A re-read-per-attest design would let `x5c` drift away from
-    //      the cached signing key.) This matches the pre-PR behavior, where
-    //      the broker cached `cert_chain` in `new()` and reused it.
+    //      the cached signing key.) This matches the historical behavior of
+    //      the attestation-service brokers, which loaded and cached the cert
+    //      chain once at construction (alongside the private key) and reused
+    //      it for every issued token.
     // Note: `cert_path` is kept separately above so `cert_pem_live` (the cert
     // *endpoint*) can still re-read lazily — the two paths have different
     // semantics and must not be unified.
@@ -109,6 +125,10 @@ impl<K: Send + Sync> SignKeyProvider<K> for FsSigner<K> {
                 .map_err(|e| anyhow::anyhow!("Failed to read certificate file: {}", e))?;
             Ok(content)
         })
+    }
+    // Loaded from an explicit `SignerConfig` on disk — publishable.
+    fn is_configured(&self) -> bool {
+        true
     }
 }
 

--- a/attestation-service/src/token/signer.rs
+++ b/attestation-service/src/token/signer.rs
@@ -149,10 +149,11 @@ impl<K: Send + Sync> SignKeyProvider<K> for EphemeralSigner<K> {
 
 /// Shared signer configuration (deserialized from the token-broker config).
 ///
-/// Note: unifying on `#[serde(default)]` for `cert_url`/`cert_path` relaxes
-/// the simple/oidc configs (which previously errored on a missing field) to
-/// match ear's existing tolerant behavior. This does not affect emitted
-/// tokens; `cert_url`/`cert_path` only influence `x5u`/`x5c` when set.
+/// `key_path` is required. `cert_url`/`cert_path` are optional: when omitted
+/// from the config they deserialize to `None` (serde already defaults a
+/// missing `Option<T>` field to `None`, so the `#[serde(default)]` attributes
+/// are kept for explicitness rather than out of necessity). When set, they
+/// only influence the token's `x5u`/`x5c`; they do not affect the signing key.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct SignerConfig {
     pub key_path: String,

--- a/attestation-service/src/token/signer.rs
+++ b/attestation-service/src/token/signer.rs
@@ -14,7 +14,9 @@
 //! inherent impls on the specific key types the brokers use
 //! (`rsa::RsaPrivateKey`, `p256::SecretKey`).
 
-use anyhow::{anyhow, Context, Result};
+#[cfg(feature = "fs")]
+use anyhow::Context;
+use anyhow::Result;
 use p256::SecretKey;
 use rand::rngs::OsRng;
 use rsa::RsaPrivateKey;
@@ -48,6 +50,7 @@ pub trait SignKeyProvider<K>: Send + Sync {
 
 /// Signer resolved from a [`SignerConfig`] (native/serde path). Reads
 /// `key_path`/`cert_path` on disk under the `fs` feature.
+#[cfg(feature = "fs")]
 pub struct FsSigner<K> {
     private_key: K,
     cert_url: Option<String>,
@@ -85,10 +88,10 @@ impl<K: Send + Sync> SignKeyProvider<K> for FsSigner<K> {
             use std::io::Read as _;
             // Read certificate from file
             let mut file = std::fs::File::open(path)
-                .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
+                .map_err(|e| anyhow::anyhow!("Failed to open certificate file: {}", e))?;
             let mut content = Vec::new();
             file.read_to_end(&mut content)
-                .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
+                .map_err(|e| anyhow::anyhow!("Failed to read certificate file: {}", e))?;
             Ok(content)
         })
     }

--- a/attestation-service/src/token/signer.rs
+++ b/attestation-service/src/token/signer.rs
@@ -186,3 +186,9 @@ impl EphemeralSigner<SecretKey> {
         }
     }
 }
+
+impl Default for EphemeralSigner<SecretKey> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -13,17 +13,11 @@ use base64::Engine;
 use const_format::concatcp;
 use log::info;
 use rand::distributions::Alphanumeric;
-use rand::rngs::OsRng;
 use rand::{thread_rng, Rng};
-use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::pkcs1v15::{Signature, SigningKey};
-use rsa::pkcs8::DecodePrivateKey;
 use rsa::signature::Signer;
 use rsa::traits::PublicKeyParts;
 use rsa::RsaPrivateKey;
-#[cfg(feature = "fs")]
-use rustls_pki_types::pem::PemObject;
-use rustls_pki_types::CertificateDer;
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use serde_variant::to_variant_name;
@@ -37,28 +31,18 @@ use crate::rvps::ReferenceValueResolver;
 use crate::token::{AttestationTokenBroker, DEFAULT_TOKEN_WORK_DIR};
 use crate::{TeeClaims, TeeEvidenceParsedClaim};
 
+use super::signer::{EphemeralSigner, FsSigner, SignKeyProvider};
 #[cfg(feature = "fs")]
 use super::signer_transparency;
 use super::{COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
 
-const RSA_KEY_BITS: u32 = 2048;
 const SIMPLE_TOKEN_ALG: &str = "RS384";
 
 const DEFAULT_POLICY_DIR: &str = concatcp!(DEFAULT_TOKEN_WORK_DIR, "/simple/policies");
 pub const DEFAULT_POLICY: &str = include_str!("simple_default_policy.rego");
 pub const DEFAULT_POLICY_ID: &str = "default.rego";
 
-/// Part 2 — signer resolution spec (native/serde path only). Renamed from
-/// `TokenSignerConfig`; field set unchanged.
-#[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct SignerConfig {
-    pub key_path: String,
-
-    pub cert_url: Option<String>,
-
-    // PEM format certificate chain.
-    pub cert_path: Option<String>,
-}
+pub use super::signer::SignerConfig;
 
 /// Part 1 — fs-free token-issuance metadata. The only part the broker holds.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -125,111 +109,9 @@ impl Default for Configuration {
     }
 }
 
-pub trait SignerProvider: Send + Sync {
-    fn private_key(&self) -> &RsaPrivateKey;
-    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>>;
-    fn cert_url(&self) -> Option<&str>;
-    /// The signer's certificate-chain raw PEM bytes, read lazily from the
-    /// configured `cert_path` on each call (not cached at construction).
-    /// `None` when no `cert_path` is configured. Ephemeral signers return
-    /// `None`. The broker forwards this through `signer_cert_content`.
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>>;
-}
-
-/// Signer resolved from a `SignerConfig` (native/serde path). Reads
-/// `key_path`/`cert_path` under the `fs` feature; `key_pem`/`cert_pem` work
-/// without fs.
-#[cfg(feature = "fs")]
-struct ConfigSigner {
-    private_key: RsaPrivateKey,
-    cert_url: Option<String>,
-    // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
-    cert_path: Option<String>,
-}
-
-#[cfg(feature = "fs")]
-impl ConfigSigner {
-    fn from_signer_config(signer: SignerConfig) -> Result<Self> {
-        let pem_data = std::fs::read_to_string(&signer.key_path)
-            .context("Read Token Signer private key failed")?;
-        let private_key = RsaPrivateKey::from_pkcs8_pem(&pem_data)
-            .or_else(|_| RsaPrivateKey::from_pkcs1_pem(&pem_data))
-            .context("Parse Token Signer private key failed")?;
-
-        Ok(Self {
-            private_key,
-            cert_url: signer.cert_url,
-            cert_path: signer.cert_path,
-        })
-    }
-}
-
-#[cfg(feature = "fs")]
-impl SignerProvider for ConfigSigner {
-    fn private_key(&self) -> &RsaPrivateKey {
-        &self.private_key
-    }
-    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
-        self.cert_path
-            .as_ref()
-            .map(|cert_path| -> Result<Vec<CertificateDer<'static>>> {
-                let pem_cert_chain = std::fs::read_to_string(cert_path)
-                    .context("Read Token Signer cert file failed")?;
-                let chain: Result<Vec<_>, rustls_pki_types::pem::Error> =
-                    CertificateDer::pem_slice_iter(pem_cert_chain.as_bytes()).collect();
-                chain.context("Invalid PEM certificate chain")
-            })
-    }
-    fn cert_url(&self) -> Option<&str> {
-        self.cert_url.as_deref()
-    }
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
-        self.cert_path.as_ref().map(|path| {
-            use std::io::Read as _;
-            // Read certificate from file
-            let mut file = std::fs::File::open(path)
-                .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
-            let mut content = Vec::new();
-            file.read_to_end(&mut content)
-                .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
-            Ok(content)
-        })
-    }
-}
-
-/// Ephemeral signer: generates a fresh RSA key. Used when no signer is
-/// configured (both `from_config` and `from_components`).
-pub struct EphemeralSigner {
-    private_key: RsaPrivateKey,
-}
-
-impl EphemeralSigner {
-    pub fn new() -> Result<Self> {
-        let mut rng = OsRng;
-        Ok(Self {
-            private_key: RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?,
-        })
-    }
-}
-
-impl SignerProvider for EphemeralSigner {
-    fn private_key(&self) -> &RsaPrivateKey {
-        &self.private_key
-    }
-    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>> {
-        None
-    }
-    fn cert_url(&self) -> Option<&str> {
-        None
-    }
-    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
-        None
-    }
-}
-
 pub struct SimpleAttestationTokenBroker {
     settings: TokenBrokerSettings,
-    signer: Arc<dyn SignerProvider>,
+    signer: Arc<dyn SignKeyProvider<RsaPrivateKey>>,
     policy_engine: Arc<dyn PolicyEngine>,
 }
 
@@ -243,13 +125,13 @@ impl SimpleAttestationTokenBroker {
         )?;
         info!("Loading default AS policy \"simple_default_policy.rego\"");
 
-        let signer: Arc<dyn SignerProvider> = match config.signer {
-            Some(sc) => Arc::new(ConfigSigner::from_signer_config(sc)?),
+        let signer: Arc<dyn SignKeyProvider<RsaPrivateKey>> = match config.signer {
+            Some(sc) => Arc::new(FsSigner::<RsaPrivateKey>::from_config(sc)?),
             None => {
                 log::info!(
                     "No Token Signer key in config file, create an ephemeral key and without CA pubkey cert"
                 );
-                Arc::new(EphemeralSigner::new()?)
+                Arc::new(EphemeralSigner::<RsaPrivateKey>::new()?)
             }
         };
 
@@ -262,7 +144,7 @@ impl SimpleAttestationTokenBroker {
 
     pub fn from_components(
         settings: TokenBrokerSettings,
-        signer: Arc<dyn SignerProvider>,
+        signer: Arc<dyn SignKeyProvider<RsaPrivateKey>>,
         policy_engine: Arc<dyn PolicyEngine>,
     ) -> Self {
         Self {

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -36,24 +36,30 @@ use crate::rvps::ReferenceValueResolver;
 use crate::token::{AttestationTokenBroker, DEFAULT_TOKEN_WORK_DIR};
 use crate::{TeeClaims, TeeEvidenceParsedClaim};
 
-use super::{signer_transparency, COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
+#[cfg(feature = "fs")]
+use super::signer_transparency;
+use super::{COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
 
 const RSA_KEY_BITS: u32 = 2048;
 const SIMPLE_TOKEN_ALG: &str = "RS384";
 
 const DEFAULT_POLICY_DIR: &str = concatcp!(DEFAULT_TOKEN_WORK_DIR, "/simple/policies");
 
+/// Part 2 — signer resolution spec (native/serde path only). Renamed from
+/// `TokenSignerConfig`; field set unchanged.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct TokenSignerConfig {
+pub struct SignerConfig {
     pub key_path: String,
+
     pub cert_url: Option<String>,
 
     // PEM format certificate chain.
     pub cert_path: Option<String>,
 }
 
+/// Part 1 — fs-free token-issuance metadata. The only part the broker holds.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct Configuration {
+pub struct TokenBrokerSettings {
     /// The Attestation Results Token duration time (in minutes)
     /// Default: 5 minutes
     #[serde(default = "default_duration")]
@@ -62,11 +68,28 @@ pub struct Configuration {
     /// the issuer of the token
     #[serde(default = "default_issuer_name")]
     pub issuer_name: String,
+}
+
+impl Default for TokenBrokerSettings {
+    fn default() -> Self {
+        Self {
+            duration_min: default_duration(),
+            issuer_name: default_issuer_name(),
+        }
+    }
+}
+
+/// The serde Configuration = parts 1 + 2 + 3, composed. `#[serde(flatten)]`
+/// on `settings` keeps the existing flat JSON/TOML config format working.
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct Configuration {
+    #[serde(flatten)]
+    pub settings: TokenBrokerSettings,
 
     /// Configuration for signing the token.
     /// If this is not specified, the token
     /// will be signed with an ephemeral private key.
-    pub signer: Option<TokenSignerConfig>,
+    pub signer: Option<SignerConfig>,
 
     /// The path to the work directory that contains policies
     /// to provision the tokens.
@@ -92,44 +115,31 @@ fn default_policy_dir() -> String {
 impl Default for Configuration {
     fn default() -> Self {
         Self {
-            duration_min: default_duration(),
-            issuer_name: default_issuer_name(),
+            settings: TokenBrokerSettings::default(),
             signer: None,
             policy_dir: default_policy_dir(),
         }
     }
 }
 
-pub struct SimpleAttestationTokenBroker {
-    private_key: RsaPrivateKey,
-    config: Configuration,
-    cert_url: Option<String>,
-    cert_chain: Option<Vec<Certificate>>,
-    policy_engine: Arc<dyn PolicyEngine>,
+pub trait SignerProvider: Send + Sync {
+    fn private_key(&self) -> &RsaPrivateKey;
+    fn cert_chain(&self) -> Option<&[Certificate]>;
+    fn cert_url(&self) -> Option<&str>;
 }
 
-impl SimpleAttestationTokenBroker {
-    pub fn new(config: Configuration) -> Result<Self> {
-        let policy_engine = PolicyEngineType::OPA.to_policy_engine(
-            Path::new(&config.policy_dir),
-            include_str!("simple_default_policy.rego"),
-            "default.rego",
-        )?;
-        info!("Loading default AS policy \"simple_default_policy.rego\"");
+/// Signer resolved from a `SignerConfig` (native/serde path). Reads
+/// `key_path`/`cert_path` under the `fs` feature; `key_pem`/`cert_pem` work
+/// without fs.
+struct ConfigSigner {
+    private_key: RsaPrivateKey,
+    cert_chain: Option<Vec<Certificate>>,
+    cert_url: Option<String>,
+}
 
-        if config.signer.is_none() {
-            log::info!("No Token Signer key in config file, create an ephemeral key and without CA pubkey cert");
-            let mut rng = OsRng;
-            return Ok(Self {
-                private_key: RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?,
-                config,
-                cert_url: None,
-                cert_chain: None,
-                policy_engine,
-            });
-        }
-
-        let signer = config.signer.clone().unwrap();
+impl ConfigSigner {
+    #[cfg(feature = "fs")]
+    fn from_signer_config(signer: SignerConfig) -> Result<Self> {
         let pem_data = std::fs::read_to_string(&signer.key_path)
             .context("Read Token Signer private key failed")?;
         let private_key = RsaPrivateKey::from_pkcs8_pem(&pem_data)
@@ -161,24 +171,111 @@ impl SimpleAttestationTokenBroker {
 
         Ok(Self {
             private_key,
-            config,
-            cert_url: signer.cert_url,
             cert_chain,
+            cert_url: signer.cert_url,
+        })
+    }
+}
+
+impl SignerProvider for ConfigSigner {
+    fn private_key(&self) -> &RsaPrivateKey {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<&[Certificate]> {
+        self.cert_chain.as_deref()
+    }
+    fn cert_url(&self) -> Option<&str> {
+        self.cert_url.as_deref()
+    }
+}
+
+/// Ephemeral signer: generates a fresh RSA key. Used when no signer is
+/// configured (both `from_config` and `from_components`).
+struct EphemeralSigner {
+    private_key: RsaPrivateKey,
+}
+
+impl EphemeralSigner {
+    fn new() -> Result<Self> {
+        let mut rng = OsRng;
+        Ok(Self {
+            private_key: RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?,
+        })
+    }
+}
+
+impl SignerProvider for EphemeralSigner {
+    fn private_key(&self) -> &RsaPrivateKey {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<&[Certificate]> {
+        None
+    }
+    fn cert_url(&self) -> Option<&str> {
+        None
+    }
+}
+
+pub struct SimpleAttestationTokenBroker {
+    settings: TokenBrokerSettings,
+    signer: Arc<dyn SignerProvider>,
+    policy_engine: Arc<dyn PolicyEngine>,
+}
+
+impl SimpleAttestationTokenBroker {
+    #[cfg(feature = "fs")]
+    pub fn from_config(config: Configuration) -> Result<Self> {
+        let policy_engine = PolicyEngineType::OPA.to_policy_engine(
+            Path::new(&config.policy_dir),
+            include_str!("simple_default_policy.rego"),
+            "default.rego",
+        )?;
+        info!("Loading default AS policy \"simple_default_policy.rego\"");
+
+        let signer: Arc<dyn SignerProvider> = match config.signer {
+            Some(sc) => Arc::new(ConfigSigner::from_signer_config(sc)?),
+            None => {
+                log::info!(
+                    "No Token Signer key in config file, create an ephemeral key and without CA pubkey cert"
+                );
+                Arc::new(EphemeralSigner::new()?)
+            }
+        };
+
+        Ok(Self {
+            settings: config.settings,
+            signer,
             policy_engine,
         })
+    }
+
+    pub fn from_components(
+        settings: TokenBrokerSettings,
+        signer: Option<Arc<dyn SignerProvider>>,
+        policy_engine: Arc<dyn PolicyEngine>,
+    ) -> Self {
+        let signer: Arc<dyn SignerProvider> = match signer {
+            Some(s) => s,
+            None => Arc::new(EphemeralSigner::new()?),
+        };
+        Self {
+            settings,
+            signer,
+            policy_engine,
+        }
     }
 }
 
 impl SimpleAttestationTokenBroker {
     fn rs384_sign(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        let signing_key = SigningKey::<Sha384>::new(self.private_key.clone());
+        let signing_key = SigningKey::<Sha384>::new(self.signer.private_key().clone());
         let sig: Signature = signing_key.sign(payload);
         Ok(Box::<[u8]>::from(sig).to_vec())
     }
 
     fn pubkey_jwks(&self) -> Result<String> {
-        let n = self.private_key.n().to_bytes_be();
-        let e = self.private_key.e().to_bytes_be();
+        let n = self.signer.private_key().n().to_bytes_be();
+        let e = self.signer.private_key().e().to_bytes_be();
 
         let mut jwk = Jwk {
             kty: "RSA".to_string(),
@@ -189,8 +286,8 @@ impl SimpleAttestationTokenBroker {
             x5c: None,
         };
 
-        jwk.x5u.clone_from(&self.cert_url);
-        if let Some(cert_chain) = self.cert_chain.clone() {
+        jwk.x5u = self.signer.cert_url().map(str::to_owned);
+        if let Some(cert_chain) = self.signer.cert_chain() {
             let mut x5c = Vec::new();
             for cert in cert_chain {
                 let der = cert.to_der()?;
@@ -281,7 +378,7 @@ impl AttestationTokenBroker for SimpleAttestationTokenBroker {
         let header_b64 = URL_SAFE_NO_PAD.encode(header_string.as_bytes());
 
         let now = time::OffsetDateTime::now_utc();
-        let exp = now + time::Duration::minutes(self.config.duration_min);
+        let exp = now + time::Duration::minutes(self.settings.duration_min);
 
         let id: String = thread_rng()
             .sample_iter(&Alphanumeric)
@@ -290,7 +387,7 @@ impl AttestationTokenBroker for SimpleAttestationTokenBroker {
             .collect();
 
         let mut jwt_claims = json!({
-            "iss": self.config.issuer_name.clone(),
+            "iss": self.settings.issuer_name.clone(),
             "iat": now.unix_timestamp(),
             "jti": id,
             "nbf": now.unix_timestamp(),
@@ -306,6 +403,7 @@ impl AttestationTokenBroker for SimpleAttestationTokenBroker {
                 .ok_or_else(|| anyhow!("Illegal token custom claims"))?
                 .to_owned(),
         );
+        #[cfg(feature = "fs")]
         if let Some(transparency) = signer_transparency::load_signer_transparency() {
             jwt_claims.insert("signer_transparency".to_string(), transparency);
         }
@@ -453,18 +551,99 @@ mod tests {
     use x509_cert::Certificate;
 
     use crate::token::{
-        simple::{Configuration, SimpleAttestationTokenBroker, TokenSignerConfig},
+        simple::{Configuration, SignerConfig, SimpleAttestationTokenBroker},
         AttestationTokenBroker,
     };
 
     use super::flatten_claims;
+
+    #[test]
+    fn token_iat_uses_injected_now() {
+        crate::time::set_now(2_000_000_000);
+        let now = crate::time::now_unix();
+        // Reset before the assert so a pinned clock never leaks into later
+        // tests in this binary (the override is process-global).
+        crate::time::reset_now();
+        assert_eq!(now, 2_000_000_000);
+    }
+
+    #[cfg(not(feature = "fs"))]
+    #[test]
+    fn broker_from_inline_key_pem_without_fs() {
+        // A throwaway RSA PKCS#8 PEM generated in-test via the `rsa` crate.
+        // The pure-lib / wasm path supplies the signer key inline as `key_pem`
+        // instead of reading it from a filesystem path, so broker construction
+        // must succeed with `--no-default-features`.
+        use rsa::pkcs8::EncodePrivateKey;
+        let mut rng = rand::rngs::OsRng;
+        let k = rsa::RsaPrivateKey::new(&mut rng, 2048).unwrap();
+        let pem = k
+            .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
+            .unwrap()
+            .to_string();
+
+        let cfg = Configuration {
+            signer: Some(SignerConfig {
+                key_path: None,
+                cert_url: None,
+                cert_path: None,
+                cert_pem: None,
+            }),
+            ..Configuration::default()
+        };
+        // to_token_broker must succeed without touching the filesystem.
+        crate::token::AttestationTokenConfig::Simple(cfg)
+            .to_token_broker()
+            .expect("broker from inline key");
+    }
+
+    #[cfg(not(feature = "fs"))]
+    #[tokio::test]
+    async fn issue_with_inline_key_and_in_memory_default_policy() {
+        // End-to-end fs-free smoke: build a broker from an inline `key_pem` AND
+        // call `issue()` with `policy_ids = ["default"]`, proving the InMemory
+        // default-policy preload + Regorus eval path works without the fs
+        // feature. Mirrors `test_issue_simple_ephemeral_key`'s TeeClaims shape.
+        use rsa::pkcs8::EncodePrivateKey;
+        let mut rng = rand::rngs::OsRng;
+        let k = rsa::RsaPrivateKey::new(&mut rng, 2048).unwrap();
+        let pem = k
+            .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
+            .unwrap()
+            .to_string();
+        let cfg = Configuration {
+            signer: Some(SignerConfig {
+                key_path: None,
+                cert_url: None,
+                cert_path: None,
+                cert_pem: None,
+            }),
+            ..Configuration::default()
+        };
+        let broker = SimpleAttestationTokenBroker::from_config(cfg).unwrap();
+        let _token = broker
+            .issue(
+                vec![TeeClaims {
+                    tee: kbs_types::Tee::Sample,
+                    tee_class: "cpu".to_string(),
+                    claims: json!({"claim": "claim1"}),
+                    runtime_data_claims: json!({"runtime_data": "111"}),
+                    init_data_claims: json!({"initdata": "111"}),
+                    additional_data: None,
+                }],
+                vec!["default".into()],
+                HashMap::new(),
+            )
+            .await
+            .unwrap();
+    }
 
     #[tokio::test]
     async fn test_issue_simple_ephemeral_key() {
         // use default config with no signer.
         // this will sign the token with an ephemeral key.
         let config = Configuration::default();
-        let broker = SimpleAttestationTokenBroker::new(config).unwrap();
+        let broker = SimpleAttestationTokenBroker::from_config(config).unwrap();
 
         let _token = broker
             .issue(
@@ -478,6 +657,45 @@ mod tests {
                 }],
                 vec!["default".into()],
                 crate::rvps::empty_test_resolver(),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[cfg(not(feature = "fs"))]
+    #[tokio::test]
+    async fn from_components_issues_without_fs() {
+        use std::path::Path;
+        use std::sync::Arc;
+
+        use crate::policy_engine::{PolicyEngine, PolicyEngineType};
+
+        let policy_engine: Arc<dyn PolicyEngine> = PolicyEngineType::InMemory
+            .to_policy_engine(
+                Path::new("/"),
+                include_str!("simple_default_policy.rego"),
+                "default.rego",
+            )
+            .unwrap();
+        let broker = SimpleAttestationTokenBroker::from_components(
+            super::TokenBrokerSettings::default(),
+            None,
+            policy_engine,
+        )
+        .unwrap();
+
+        let _token = broker
+            .issue(
+                vec![TeeClaims {
+                    tee: kbs_types::Tee::Sample,
+                    tee_class: "cpu".to_string(),
+                    claims: json!({"claim": "claim1"}),
+                    runtime_data_claims: json!({"runtime_data": "111"}),
+                    init_data_claims: json!({"initdata": "111"}),
+                    additional_data: None,
+                }],
+                vec!["default".into()],
+                HashMap::new(),
             )
             .await
             .unwrap();
@@ -555,6 +773,7 @@ mod tests {
     // `Certificate::from_pem` and later encodes it into the JWK `x5c` array via
     // `Certificate::to_der`. Generated with `openssl genpkey` / `openssl req
     // -x509`; embedded as text so no binary fixture is committed.
+    #[cfg(feature = "fs")]
     const TEST_SIGNER_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCdazaeItcE7c8W
 cuc3i+KE94fKdLt/aOw2oIr6lVlzW95cwuok35uTYlJwTrvhPd8Qz1xBuerk9qAQ
@@ -587,6 +806,7 @@ wihjpplQnoBixGHV/2XFex6x
 
     // A 2-cert PEM chain (leaf + CA). The split-on-`-----END CERTIFICATE-----`
     // loop in `SimpleAttestationTokenBroker::new` parses both entries.
+    #[cfg(feature = "fs")]
     const TEST_CERT_CHAIN_PEM: &str = "-----BEGIN CERTIFICATE-----
 MIIDCTCCAfGgAwIBAgIUdzxyN1GLEQxMXM8WxZBC8XyZgLswDQYJKoZIhvcNAQEL
 BQAwFDESMBAGA1UEAwwJdGVzdC1sZWFmMB4XDTI2MDcxMzEzMzMyOFoXDTI2MDcx
@@ -641,15 +861,15 @@ frJCGYDUg+8c
         std::fs::write(&chain_file, TEST_CERT_CHAIN_PEM).expect("write temp chain file");
 
         let config = Configuration {
-            signer: Some(TokenSignerConfig {
-                key_path: key_file.path().to_string_lossy().to_string(),
+            signer: Some(SignerConfig {
+                key_path: Some(key_file.path().to_string_lossy().to_string()),
                 cert_url: None,
                 cert_path: Some(chain_file.path().to_string_lossy().to_string()),
             }),
             ..Configuration::default()
         };
 
-        let broker = SimpleAttestationTokenBroker::new(config)
+        let broker = SimpleAttestationTokenBroker::from_config(config)
             .expect("broker construction with signer + cert chain must succeed");
 
         let jwks = serde_json::from_str::<serde_json::Value>(

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -21,6 +21,9 @@ use rsa::pkcs8::DecodePrivateKey;
 use rsa::signature::Signer;
 use rsa::traits::PublicKeyParts;
 use rsa::RsaPrivateKey;
+#[cfg(feature = "fs")]
+use rustls_pki_types::pem::PemObject;
+use rustls_pki_types::CertificateDer;
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use serde_variant::to_variant_name;
@@ -28,8 +31,6 @@ use sha2::Sha384;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-use x509_cert::der::{DecodePem, Encode};
-use x509_cert::Certificate;
 
 use crate::policy_engine::{PolicyEngine, PolicyEngineType};
 use crate::rvps::ReferenceValueResolver;
@@ -126,7 +127,7 @@ impl Default for Configuration {
 
 pub trait SignerProvider: Send + Sync {
     fn private_key(&self) -> &RsaPrivateKey;
-    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>>;
+    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>>;
     fn cert_url(&self) -> Option<&str>;
     /// The signer's certificate-chain raw PEM bytes, read lazily from the
     /// configured `cert_path` on each call (not cached at construction).
@@ -171,23 +172,12 @@ impl SignerProvider for ConfigSigner {
     fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
         self.cert_path
             .as_ref()
-            .map(|cert_path| -> Result<Vec<Certificate>> {
+            .map(|cert_path| -> Result<Vec<CertificateDer<'static>>> {
                 let pem_cert_chain = std::fs::read_to_string(cert_path)
                     .context("Read Token Signer cert file failed")?;
-                let mut chain = Vec::new();
-
-                for pem in pem_cert_chain.split("-----END CERTIFICATE-----") {
-                    let trimmed = format!("{}\n-----END CERTIFICATE-----", pem.trim());
-                    if !trimmed.starts_with("-----BEGIN CERTIFICATE-----") {
-                        continue;
-                    }
-                    // x509-cert's DecodePem expects a single PEM block; the split
-                    // above already isolates one. Use the Label-aware decoder.
-                    let cert = Certificate::from_pem(trimmed.as_bytes())
-                        .context("Invalid PEM certificate chain")?;
-                    chain.push(cert);
-                }
-                Ok(chain)
+                let chain: Result<Vec<_>, rustls_pki_types::pem::Error> =
+                    CertificateDer::pem_slice_iter(pem_cert_chain.as_bytes()).collect();
+                chain.context("Invalid PEM certificate chain")
             })
     }
     fn cert_url(&self) -> Option<&str> {
@@ -226,7 +216,7 @@ impl SignerProvider for EphemeralSigner {
     fn private_key(&self) -> &RsaPrivateKey {
         &self.private_key
     }
-    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
+    fn cert_chain(&self) -> Option<Result<Vec<CertificateDer<'static>>>> {
         None
     }
     fn cert_url(&self) -> Option<&str> {
@@ -307,8 +297,7 @@ impl SimpleAttestationTokenBroker {
         if let Some(cert_chain) = self.signer.cert_chain().transpose()? {
             let mut x5c = Vec::new();
             for cert in cert_chain {
-                let der = cert.to_der()?;
-                x5c.push(URL_SAFE_NO_PAD.encode(der));
+                x5c.push(URL_SAFE_NO_PAD.encode(cert));
             }
             jwk.x5c = Some(x5c);
         }

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -44,6 +44,8 @@ const RSA_KEY_BITS: u32 = 2048;
 const SIMPLE_TOKEN_ALG: &str = "RS384";
 
 const DEFAULT_POLICY_DIR: &str = concatcp!(DEFAULT_TOKEN_WORK_DIR, "/simple/policies");
+pub const DEFAULT_POLICY: &str = include_str!("simple_default_policy.rego");
+pub const DEFAULT_POLICY_ID: &str = "default.rego";
 
 /// Part 2 — signer resolution spec (native/serde path only). Renamed from
 /// `TokenSignerConfig`; field set unchanged.
@@ -227,8 +229,8 @@ impl SimpleAttestationTokenBroker {
     pub fn from_config(config: Configuration) -> Result<Self> {
         let policy_engine = PolicyEngineType::OPA.to_policy_engine(
             Path::new(&config.policy_dir),
-            include_str!("simple_default_policy.rego"),
-            "default.rego",
+            DEFAULT_POLICY,
+            DEFAULT_POLICY_ID,
         )?;
         info!("Loading default AS policy \"simple_default_policy.rego\"");
 
@@ -671,11 +673,7 @@ mod tests {
         use crate::policy_engine::{PolicyEngine, PolicyEngineType};
 
         let policy_engine: Arc<dyn PolicyEngine> = PolicyEngineType::InMemory
-            .to_policy_engine(
-                Path::new("/"),
-                include_str!("simple_default_policy.rego"),
-                "default.rego",
-            )
+            .to_policy_engine(Path::new("/"), DEFAULT_POLICY, DEFAULT_POLICY_ID)
             .unwrap();
         let broker = SimpleAttestationTokenBroker::from_components(
             super::TokenBrokerSettings::default(),

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -11,7 +11,6 @@ use anyhow::*;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use const_format::concatcp;
-use log::info;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use rsa::pkcs1v15::{Signature, SigningKey};
@@ -23,15 +22,14 @@ use serde_json::{json, Map, Value};
 use serde_variant::to_variant_name;
 use sha2::Sha384;
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::Arc;
 
-use crate::policy_engine::{PolicyEngine, PolicyEngineType};
+use crate::policy_engine::PolicyEngine;
 use crate::rvps::ReferenceValueResolver;
 use crate::token::{AttestationTokenBroker, DEFAULT_TOKEN_WORK_DIR};
 use crate::{TeeClaims, TeeEvidenceParsedClaim};
 
-use super::signer::{EphemeralSigner, FsSigner, SignKeyProvider};
+use super::signer::SignKeyProvider;
 #[cfg(feature = "fs")]
 use super::signer_transparency;
 use super::{COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION};
@@ -118,20 +116,20 @@ pub struct SimpleAttestationTokenBroker {
 impl SimpleAttestationTokenBroker {
     #[cfg(feature = "fs")]
     pub fn from_config(config: Configuration) -> Result<Self> {
-        let policy_engine = PolicyEngineType::OPA.to_policy_engine(
-            Path::new(&config.policy_dir),
+        let policy_engine = crate::policy_engine::PolicyEngineType::OPA.to_policy_engine(
+            std::path::Path::new(&config.policy_dir),
             DEFAULT_POLICY,
             DEFAULT_POLICY_ID,
         )?;
-        info!("Loading default AS policy \"simple_default_policy.rego\"");
+        log::info!("Loading default AS policy \"simple_default_policy.rego\"");
 
         let signer: Arc<dyn SignKeyProvider<RsaPrivateKey>> = match config.signer {
-            Some(sc) => Arc::new(FsSigner::<RsaPrivateKey>::from_config(sc)?),
+            Some(sc) => Arc::new(super::signer::FsSigner::<RsaPrivateKey>::from_config(sc)?),
             None => {
                 log::info!(
                     "No Token Signer key in config file, create an ephemeral key and without CA pubkey cert"
                 );
-                Arc::new(EphemeralSigner::<RsaPrivateKey>::new()?)
+                Arc::new(super::signer::EphemeralSigner::<RsaPrivateKey>::new()?)
             }
         };
 

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -128,19 +128,27 @@ pub trait SignerProvider: Send + Sync {
     fn private_key(&self) -> &RsaPrivateKey;
     fn cert_chain(&self) -> Option<&[Certificate]>;
     fn cert_url(&self) -> Option<&str>;
+    /// The signer's certificate-chain raw PEM bytes, read lazily from the
+    /// configured `cert_path` on each call (not cached at construction).
+    /// `None` when no `cert_path` is configured. Ephemeral signers return
+    /// `None`. The broker forwards this through `signer_cert_content`.
+    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>>;
 }
 
 /// Signer resolved from a `SignerConfig` (native/serde path). Reads
 /// `key_path`/`cert_path` under the `fs` feature; `key_pem`/`cert_pem` work
 /// without fs.
+#[cfg(feature = "fs")]
 struct ConfigSigner {
     private_key: RsaPrivateKey,
     cert_chain: Option<Vec<Certificate>>,
     cert_url: Option<String>,
+    // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
+    cert_path: Option<String>,
 }
 
+#[cfg(feature = "fs")]
 impl ConfigSigner {
-    #[cfg(feature = "fs")]
     fn from_signer_config(signer: SignerConfig) -> Result<Self> {
         let pem_data = std::fs::read_to_string(&signer.key_path)
             .context("Read Token Signer private key failed")?;
@@ -175,10 +183,12 @@ impl ConfigSigner {
             private_key,
             cert_chain,
             cert_url: signer.cert_url,
+            cert_path: signer.cert_path,
         })
     }
 }
 
+#[cfg(feature = "fs")]
 impl SignerProvider for ConfigSigner {
     fn private_key(&self) -> &RsaPrivateKey {
         &self.private_key
@@ -189,16 +199,32 @@ impl SignerProvider for ConfigSigner {
     fn cert_url(&self) -> Option<&str> {
         self.cert_url.as_deref()
     }
+    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
+        match &self.cert_path {
+            Some(path) => {
+                use std::io::Read as _;
+
+                // Read certificate from file
+                let mut file = std::fs::File::open(path)
+                    .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
+                let mut content = Vec::new();
+                file.read_to_end(&mut content)
+                    .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
+                Ok(Some(content))
+            }
+            None => Ok(None),
+        }
+    }
 }
 
 /// Ephemeral signer: generates a fresh RSA key. Used when no signer is
 /// configured (both `from_config` and `from_components`).
-struct EphemeralSigner {
+pub struct EphemeralSigner {
     private_key: RsaPrivateKey,
 }
 
 impl EphemeralSigner {
-    fn new() -> Result<Self> {
+    pub fn new() -> Result<Self> {
         let mut rng = OsRng;
         Ok(Self {
             private_key: RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?,
@@ -215,6 +241,9 @@ impl SignerProvider for EphemeralSigner {
     }
     fn cert_url(&self) -> Option<&str> {
         None
+    }
+    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
+        Ok(None)
     }
 }
 
@@ -253,13 +282,9 @@ impl SimpleAttestationTokenBroker {
 
     pub fn from_components(
         settings: TokenBrokerSettings,
-        signer: Option<Arc<dyn SignerProvider>>,
+        signer: Arc<dyn SignerProvider>,
         policy_engine: Arc<dyn PolicyEngine>,
     ) -> Self {
-        let signer: Arc<dyn SignerProvider> = match signer {
-            Some(s) => s,
-            None => Arc::new(EphemeralSigner::new()?),
-        };
         Self {
             settings,
             signer,
@@ -450,6 +475,14 @@ impl AttestationTokenBroker for SimpleAttestationTokenBroker {
             .await
             .map_err(Error::from)
     }
+
+    async fn signer_cert_content(&self) -> Result<Option<Vec<u8>>> {
+        self.signer.cert_pem_raw()
+    }
+
+    fn signer_cert_url(&self) -> Option<&str> {
+        self.signer.cert_url()
+    }
 }
 
 #[derive(serde::Serialize, Debug, Clone)]
@@ -558,16 +591,6 @@ mod tests {
     };
 
     use super::flatten_claims;
-
-    #[test]
-    fn token_iat_uses_injected_now() {
-        crate::time::set_now(2_000_000_000);
-        let now = crate::time::now_unix();
-        // Reset before the assert so a pinned clock never leaks into later
-        // tests in this binary (the override is process-global).
-        crate::time::reset_now();
-        assert_eq!(now, 2_000_000_000);
-    }
 
     #[cfg(not(feature = "fs"))]
     #[test]
@@ -860,7 +883,7 @@ frJCGYDUg+8c
 
         let config = Configuration {
             signer: Some(SignerConfig {
-                key_path: Some(key_file.path().to_string_lossy().to_string()),
+                key_path: key_file.path().to_string_lossy().to_string(),
                 cert_url: None,
                 cert_path: Some(chain_file.path().to_string_lossy().to_string()),
             }),

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -192,7 +192,15 @@ impl SimpleAttestationTokenBroker {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), async_trait::async_trait(?Send))]
+#[cfg_attr(
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )),
+    async_trait::async_trait
+)]
 impl AttestationTokenBroker for SimpleAttestationTokenBroker {
     async fn issue(
         &self,

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -343,8 +343,8 @@ impl AttestationTokenBroker for SimpleAttestationTokenBroker {
             .map_err(Error::from)
     }
 
-    async fn signer_cert_content(&self) -> Option<Result<Vec<u8>>> {
-        self.signer.cert_pem_raw()
+    async fn signer_cert_pem_live(&self) -> Option<Result<Vec<u8>>> {
+        self.signer.cert_pem_live()
     }
 
     fn signer_cert_url(&self) -> Option<&str> {

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -453,77 +453,7 @@ mod tests {
 
     use super::flatten_claims;
 
-    #[cfg(not(feature = "fs"))]
-    #[test]
-    fn broker_from_inline_key_pem_without_fs() {
-        // A throwaway RSA PKCS#8 PEM generated in-test via the `rsa` crate.
-        // The pure-lib / wasm path supplies the signer key inline as `key_pem`
-        // instead of reading it from a filesystem path, so broker construction
-        // must succeed with `--no-default-features`.
-        use rsa::pkcs8::EncodePrivateKey;
-        let mut rng = rand::rngs::OsRng;
-        let k = rsa::RsaPrivateKey::new(&mut rng, 2048).unwrap();
-        let pem = k
-            .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
-            .unwrap()
-            .to_string();
-
-        let cfg = Configuration {
-            signer: Some(SignerConfig {
-                key_path: None,
-                cert_url: None,
-                cert_path: None,
-                cert_pem: None,
-            }),
-            ..Configuration::default()
-        };
-        // to_token_broker must succeed without touching the filesystem.
-        crate::token::AttestationTokenConfig::Simple(cfg)
-            .to_token_broker()
-            .expect("broker from inline key");
-    }
-
-    #[cfg(not(feature = "fs"))]
-    #[tokio::test]
-    async fn issue_with_inline_key_and_in_memory_default_policy() {
-        // End-to-end fs-free smoke: build a broker from an inline `key_pem` AND
-        // call `issue()` with `policy_ids = ["default"]`, proving the InMemory
-        // default-policy preload + Regorus eval path works without the fs
-        // feature. Mirrors `test_issue_simple_ephemeral_key`'s TeeClaims shape.
-        use rsa::pkcs8::EncodePrivateKey;
-        let mut rng = rand::rngs::OsRng;
-        let k = rsa::RsaPrivateKey::new(&mut rng, 2048).unwrap();
-        let pem = k
-            .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
-            .unwrap()
-            .to_string();
-        let cfg = Configuration {
-            signer: Some(SignerConfig {
-                key_path: None,
-                cert_url: None,
-                cert_path: None,
-                cert_pem: None,
-            }),
-            ..Configuration::default()
-        };
-        let broker = SimpleAttestationTokenBroker::from_config(cfg).unwrap();
-        let _token = broker
-            .issue(
-                vec![TeeClaims {
-                    tee: kbs_types::Tee::Sample,
-                    tee_class: "cpu".to_string(),
-                    claims: json!({"claim": "claim1"}),
-                    runtime_data_claims: json!({"runtime_data": "111"}),
-                    init_data_claims: json!({"initdata": "111"}),
-                    additional_data: None,
-                }],
-                vec!["default".into()],
-                HashMap::new(),
-            )
-            .await
-            .unwrap();
-    }
-
+    #[cfg(feature = "fs")]
     #[tokio::test]
     async fn test_issue_simple_ephemeral_key() {
         // use default config with no signer.
@@ -551,20 +481,31 @@ mod tests {
     #[cfg(not(feature = "fs"))]
     #[tokio::test]
     async fn from_components_issues_without_fs() {
-        use std::path::Path;
         use std::sync::Arc;
 
-        use crate::policy_engine::{PolicyEngine, PolicyEngineType};
+        use rsa::RsaPrivateKey;
 
-        let policy_engine: Arc<dyn PolicyEngine> = PolicyEngineType::InMemory
-            .to_policy_engine(Path::new("/"), DEFAULT_POLICY, DEFAULT_POLICY_ID)
-            .unwrap();
+        use crate::policy_engine::opa::OPAInMemory;
+        use crate::policy_engine::PolicyEngine;
+        use crate::token::signer::EphemeralSigner;
+
+        // Construct the fs-free InMemory policy engine directly (bypassing the
+        // fs-gated `PolicyEngineType`/`to_policy_engine`) and inject an
+        // ephemeral signer, proving `from_components` + `issue()` work with no
+        // filesystem access at all. A trivial `allow` policy is used instead of
+        // `DEFAULT_POLICY` because the real default policy calls the
+        // `query_reference_value` regorus extension, which is only registered
+        // under the `policy-rvps` feature — off under `--no-default-features`.
+        const TRIVIAL_ALLOW_POLICY: &str = "package policy\ndefault allow = true";
+        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(OPAInMemory::with_raw_default_policy(
+            TRIVIAL_ALLOW_POLICY,
+            super::DEFAULT_POLICY_ID,
+        ));
         let broker = SimpleAttestationTokenBroker::from_components(
             super::TokenBrokerSettings::default(),
-            None,
+            Arc::new(EphemeralSigner::<RsaPrivateKey>::new().unwrap()),
             policy_engine,
-        )
-        .unwrap();
+        );
 
         let _token = broker
             .issue(
@@ -577,7 +518,7 @@ mod tests {
                     additional_data: None,
                 }],
                 vec!["default".into()],
-                HashMap::new(),
+                crate::rvps::empty_test_resolver(),
             )
             .await
             .unwrap();
@@ -729,6 +670,7 @@ frJCGYDUg+8c
 -----END CERTIFICATE-----
 ";
 
+    #[cfg(feature = "fs")]
     #[test]
     fn test_simple_signer_cert_chain_x5c() {
         // Exercise the `signer = Some(...)` branch of

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -126,13 +126,13 @@ impl Default for Configuration {
 
 pub trait SignerProvider: Send + Sync {
     fn private_key(&self) -> &RsaPrivateKey;
-    fn cert_chain(&self) -> Option<&[Certificate]>;
+    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>>;
     fn cert_url(&self) -> Option<&str>;
     /// The signer's certificate-chain raw PEM bytes, read lazily from the
     /// configured `cert_path` on each call (not cached at construction).
     /// `None` when no `cert_path` is configured. Ephemeral signers return
     /// `None`. The broker forwards this through `signer_cert_content`.
-    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>>;
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>>;
 }
 
 /// Signer resolved from a `SignerConfig` (native/serde path). Reads
@@ -141,7 +141,6 @@ pub trait SignerProvider: Send + Sync {
 #[cfg(feature = "fs")]
 struct ConfigSigner {
     private_key: RsaPrivateKey,
-    cert_chain: Option<Vec<Certificate>>,
     cert_url: Option<String>,
     // Kept so `cert_pem_raw` can re-read the file lazily; not the cached PEM.
     cert_path: Option<String>,
@@ -156,8 +155,21 @@ impl ConfigSigner {
             .or_else(|_| RsaPrivateKey::from_pkcs1_pem(&pem_data))
             .context("Parse Token Signer private key failed")?;
 
-        let cert_chain = signer
-            .cert_path
+        Ok(Self {
+            private_key,
+            cert_url: signer.cert_url,
+            cert_path: signer.cert_path,
+        })
+    }
+}
+
+#[cfg(feature = "fs")]
+impl SignerProvider for ConfigSigner {
+    fn private_key(&self) -> &RsaPrivateKey {
+        &self.private_key
+    }
+    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
+        self.cert_path
             .as_ref()
             .map(|cert_path| -> Result<Vec<Certificate>> {
                 let pem_cert_chain = std::fs::read_to_string(cert_path)
@@ -177,43 +189,21 @@ impl ConfigSigner {
                 }
                 Ok(chain)
             })
-            .transpose()?;
-
-        Ok(Self {
-            private_key,
-            cert_chain,
-            cert_url: signer.cert_url,
-            cert_path: signer.cert_path,
-        })
-    }
-}
-
-#[cfg(feature = "fs")]
-impl SignerProvider for ConfigSigner {
-    fn private_key(&self) -> &RsaPrivateKey {
-        &self.private_key
-    }
-    fn cert_chain(&self) -> Option<&[Certificate]> {
-        self.cert_chain.as_deref()
     }
     fn cert_url(&self) -> Option<&str> {
         self.cert_url.as_deref()
     }
-    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
-        match &self.cert_path {
-            Some(path) => {
-                use std::io::Read as _;
-
-                // Read certificate from file
-                let mut file = std::fs::File::open(path)
-                    .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
-                let mut content = Vec::new();
-                file.read_to_end(&mut content)
-                    .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
-                Ok(Some(content))
-            }
-            None => Ok(None),
-        }
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
+        self.cert_path.as_ref().map(|path| {
+            use std::io::Read as _;
+            // Read certificate from file
+            let mut file = std::fs::File::open(path)
+                .map_err(|e| anyhow!("Failed to open certificate file: {}", e))?;
+            let mut content = Vec::new();
+            file.read_to_end(&mut content)
+                .map_err(|e| anyhow!("Failed to read certificate file: {}", e))?;
+            Ok(content)
+        })
     }
 }
 
@@ -236,14 +226,14 @@ impl SignerProvider for EphemeralSigner {
     fn private_key(&self) -> &RsaPrivateKey {
         &self.private_key
     }
-    fn cert_chain(&self) -> Option<&[Certificate]> {
+    fn cert_chain(&self) -> Option<Result<Vec<Certificate>>> {
         None
     }
     fn cert_url(&self) -> Option<&str> {
         None
     }
-    fn cert_pem_raw(&self) -> Result<Option<Vec<u8>>> {
-        Ok(None)
+    fn cert_pem_raw(&self) -> Option<Result<Vec<u8>>> {
+        None
     }
 }
 
@@ -314,7 +304,7 @@ impl SimpleAttestationTokenBroker {
         };
 
         jwk.x5u = self.signer.cert_url().map(str::to_owned);
-        if let Some(cert_chain) = self.signer.cert_chain() {
+        if let Some(cert_chain) = self.signer.cert_chain().transpose()? {
             let mut x5c = Vec::new();
             for cert in cert_chain {
                 let der = cert.to_der()?;
@@ -476,7 +466,7 @@ impl AttestationTokenBroker for SimpleAttestationTokenBroker {
             .map_err(Error::from)
     }
 
-    async fn signer_cert_content(&self) -> Result<Option<Vec<u8>>> {
+    async fn signer_cert_content(&self) -> Option<Result<Vec<u8>>> {
         self.signer.cert_pem_raw()
     }
 

--- a/attestation-service/tests/configs/example5.json
+++ b/attestation-service/tests/configs/example5.json
@@ -1,0 +1,28 @@
+{
+    "work_dir": "/var/lib/attestation-service/",
+    "rvps_config": {
+	"type": "BuiltIn",
+	"storage": {
+            "type": "LocalFs"
+	}
+    },
+    "attestation_token_broker": {
+        "type": "OIDC",
+        "duration_min": 5,
+        "policy_dir": "/var/lib/attestation-service/policies",
+        "issuer_name": "test",
+        "oid_config": {
+            "issuer": "https://example.com",
+            "jwks_uri": "https://example.com/jwks",
+            "id_token_signing_alg_values_supported": ["RS256"],
+            "audience": "sigstore",
+            "sub_claims": ["sub1"],
+            "additional_claims": ["extra1"]
+        },
+        "signer": {
+            "key_path": "/etc/key",
+            "cert_url": "https://example.io",
+            "cert_path": "/etc/cert.pem"
+        }
+    }
+}

--- a/attestation-service/tests/policy_rvps.rs
+++ b/attestation-service/tests/policy_rvps.rs
@@ -72,8 +72,10 @@ fn as_config(work_dir: &Path, rvps_config: RvpsConfig) -> Config {
         work_dir: work_dir.join("work"),
         rvps_config,
         attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration {
-            duration_min: 5,
-            issuer_name: "policy-rvps-e2e".to_string(),
+            settings: simple::TokenBrokerSettings {
+                duration_min: 5,
+                issuer_name: "policy-rvps-e2e".to_string(),
+            },
             signer: None,
             policy_dir: work_dir.join("policies").to_string_lossy().into_owned(),
         }),

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -95,7 +95,7 @@ tonic = { workspace = true, optional = true }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 openssl.workspace = true
 derivative = "2.2.0"
-rustls-pki-types = "1.14.0"
+rustls-pki-types.workspace = true
 rustls-webpki = { version = "0.103.9", features = ["ring"] }
 x509-cert = "0.2.5"
 zeroize.workspace = true

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -339,12 +339,15 @@ mod tests {
                             address: "http://127.0.0.1:50003".into(),
                         }),
                         attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration {
-                            duration_min: DEFAULT_TOKEN_DURATION,
-                            issuer_name: COCO_AS_ISSUER_NAME.into(),
+                            settings: simple::TokenBrokerSettings {
+                                duration_min: DEFAULT_TOKEN_DURATION,
+                                issuer_name: COCO_AS_ISSUER_NAME.into(),
+                            },
                             signer: None,
                             ..Default::default()
                         }),
                         challenge_key_path: None,
+                        ..Default::default()
                     }
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,
@@ -413,10 +416,14 @@ mod tests {
                             }),
                         }),
                         attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration{
-                            duration_min: 5,
+                            settings: simple::TokenBrokerSettings {
+                                duration_min: 5,
+                                ..Default::default()
+                            },
                             ..Default::default()
                         }),
                         challenge_key_path: None,
+                        ..Default::default()
                     }
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,
@@ -476,11 +483,15 @@ mod tests {
                         work_dir: "/opt/confidential-containers/attestation-service".into(),
                         rvps_config: RvpsConfig::BuiltIn(RvpsCrateConfig::default()),
                         attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration {
-                            duration_min: 5,
+                            settings: simple::TokenBrokerSettings {
+                                duration_min: 5,
+                                ..Default::default()
+                            },
                             policy_dir: "/opt/confidential-containers/attestation-service/simple-policies".into(),
                             ..Default::default()
                         }),
                         challenge_key_path: None,
+                        ..Default::default()
                     }
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,


### PR DESCRIPTION
Refactor the token broker layer of attestation-service, for WASM / pure library porting.

- **Signer abstraction**: Added `token/signer.rs`, introducing a generic trait `SignKeyProvider<K>` and two implementations:
    - `FsSigner<K>`: loads keys from `SignerConfig` on disk, gated by the `fs` feature flag.
    - `EphemeralSigner<K>`: generates a brand new key in memory.

- To support the above changes, we also decomposed the config. Previously, the three brokers had duplicated config structures. Now, each token broker's `Configuration` is restructured as `settings: TokenBrokerSettings` + `signer: Option<SignerConfig>` + `policy_dir`. `SignerConfig` is the shared struct across the three broker implementations.

- Furthermore, for using attestation-service as a crate dependency (without the `fs` feature enabled), we provide `EarAttestationTokenBroker::from_components(settings, signer, policy_engine)` in each token broker types, allowing callers to choose their own `Signer` and `PolicyEngine` implementations.