### PR TITLE
feat(as/policy): add query_artifact_server with AS-level artifact server config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "artifact-resolve-sdk"
+version = "0.1.0"
+source = "git+https://github.com/aliyun/artifact-server-rust-sdk.git?tag=v0.1.0#d4be739f76f03bea3574726975e984e6a9303685"
+dependencies = [
+ "reqwest 0.12.12",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +599,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "anyhow",
+ "artifact-resolve-sdk",
  "assert-json-diff",
  "async-trait",
  "base64 0.21.7",
@@ -7791,7 +7803,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -4,60 +4,94 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = [ "restful-bin", "rvps-grpc", "all-verifier", "fs", "policy-rvps" ]
+default = [
+    "restful-bin",
+    "rvps-grpc",
+    "all-verifier",
+    "fs",
+    "policy-rvps",
+    "policy-artifact-server",
+]
 
 # Filesystem-backed implementations: config-from-file, on-disk OPA policy engine,
 # rvps local_json/local_fs storage, nonce-key persistence, signer transparency
 # file, signer key/cert read by path. Turn off (`default-features = false`) for a
 # pure, fs-free library (e.g. wasm builds).
-fs = [ "tokio/fs", "reference-value-provider-service/fs" ]
+fs = ["tokio/fs", "reference-value-provider-service/fs"]
 # Runtime bridge used by synchronous Regorus extensions to make bounded
 # asynchronous RVPS queries. Normal AS binaries enable this through `fs`.
-policy-rvps = [ "tokio/rt", "tokio/time" ]
-all-verifier = [ "verifier/all-verifier" ]
+policy-rvps = ["tokio/rt", "tokio/time"]
+all-verifier = ["verifier/all-verifier"]
 # Like `all-verifier`, but the TDX verifier uses the dcap-qvl backend and SGX is
 # dropped (it would still link the DCAP shared library). See
 # deps/verifier/src/tdx/verify/native.rs.
-all-verifier-rust = [ "verifier/all-verifier-rust" ]
+all-verifier-rust = ["verifier/all-verifier-rust"]
 # `tdx-verifier` keeps its historical meaning (DCAP shared library backend) for
 # backward compatibility. The dcap-qvl backend is opt-in via `tdx-dcap-rust`.
-tdx-verifier = [ "verifier/tdx-dcap-ffi" ]
-tdx-dcap-ffi = [ "verifier/tdx-dcap-ffi" ]
-tdx-dcap-rust = [ "verifier/tdx-dcap-rust" ]
-sgx-verifier = [ "verifier/sgx-verifier" ]
-az-snp-vtpm-verifier = [ "verifier/az-snp-vtpm-verifier" ]
-az-tdx-vtpm-verifier = [ "verifier/az-tdx-vtpm-verifier" ]
-snp-verifier = [ "verifier/snp-verifier" ]
-csv-verifier = [ "verifier/csv-verifier" ]
+tdx-verifier = ["verifier/tdx-dcap-ffi"]
+tdx-dcap-ffi = ["verifier/tdx-dcap-ffi"]
+tdx-dcap-rust = ["verifier/tdx-dcap-rust"]
+sgx-verifier = ["verifier/sgx-verifier"]
+az-snp-vtpm-verifier = ["verifier/az-snp-vtpm-verifier"]
+az-tdx-vtpm-verifier = ["verifier/az-tdx-vtpm-verifier"]
+snp-verifier = ["verifier/snp-verifier"]
+csv-verifier = ["verifier/csv-verifier"]
 hygon-dcu-verifier = ["verifier/hygon-dcu-verifier"]
 # cca-verifier = [ "verifier/cca-verifier" ]
-se-verifier  = [ "verifier/se-verifier" ]
-system-verifier = [ "verifier/system-verifier" ]
-tpm-verifier = [ "verifier/tpm-verifier" ]
+se-verifier = ["verifier/se-verifier"]
+system-verifier = ["verifier/system-verifier"]
+tpm-verifier = ["verifier/tpm-verifier"]
 
-rvps-grpc = [ "prost", "tonic", "tokio/sync" ]
+rvps-grpc = ["prost", "tonic", "tokio/sync"]
+
+# For Artifact Server.
+policy-artifact-server = ["artifact-resolve-sdk", "tokio/rt"]
 
 # For building gRPC CoCo-AS binary
-grpc-bin = [ "clap", "env_logger", "prost", "tonic", "tokio/full", "fs", "policy-rvps" ]
+grpc-bin = [
+    "clap",
+    "env_logger",
+    "prost",
+    "tonic",
+    "tokio/full",
+    "fs",
+    "policy-rvps",
+    "policy-artifact-server",
+]
 
 # For restful CoCo-AS binary
-restful-bin = [ "actix-cors", "actix-web/openssl", "clap", "env_logger", "openssl", "tokio/full", "fs", "policy-rvps" ]
+restful-bin = [
+    "actix-cors",
+    "actix-web/openssl",
+    "clap",
+    "env_logger",
+    "openssl",
+    "tokio/full",
+    "fs",
+    "policy-rvps",
+    "policy-artifact-server",
+]
 
 # For attestation-challenge-client binary
-attestation-challenge-client = [ "tokio/full", "fs", "policy-rvps" ]
+attestation-challenge-client = [
+    "tokio/full",
+    "fs",
+    "policy-rvps",
+    "policy-artifact-server",
+]
 
 [[bin]]
 name = "grpc-as"
-required-features = [ "grpc-bin" ]
+required-features = ["grpc-bin"]
 
 [[bin]]
 name = "restful-as"
-required-features = [ "restful-bin" ]
+required-features = ["restful-bin"]
 
 [[bin]]
 name = "attestation-challenge-client"
 path = "src/bin/attestation-challenge-client/main.rs"
-required-features = [ "attestation-challenge-client" ]
+required-features = ["attestation-challenge-client"]
 
 [dependencies]
 # Pinned to 0.7.0: actix-cors 0.7.1 pulls in derive_more 2.x which requires
@@ -68,6 +102,7 @@ actix-web = { workspace = true, optional = true }
 aes-gcm = "0.10"
 aes-kw = "0.2"
 anyhow.workspace = true
+artifact-resolve-sdk = { git = "https://github.com/aliyun/artifact-server-rust-sdk.git", tag = "v0.1.0", optional = true }
 async-trait.workspace = true
 base64.workspace = true
 canon-json = { git = "https://github.com/inclavare-containers/canon-json-rs" }
@@ -113,6 +148,7 @@ uuid = { version = "1.1.2", features = ["v4", "js"] }
 getrandom = { version = "0.2", features = ["js"] }
 web-time.workspace = true
 
+
 [build-dependencies]
 shadow-rs.workspace = true
 tonic-build.workspace = true
@@ -126,4 +162,7 @@ serial_test.workspace = true
 sha2.workspace = true
 testing_logger = "0.1.1"
 tokio = { workspace = true, features = ["full"] }
-x509-cert = { version = "0.2.5", default-features = false, features = ["pem", "std"] }
+x509-cert = { version = "0.2.5", default-features = false, features = [
+    "pem",
+    "std",
+] }

--- a/attestation-service/config.json
+++ b/attestation-service/config.json
@@ -6,6 +6,7 @@
             "type": "LocalFs"
 	}
     },
+    "artifact_server_address": "https://attest-pre.aliyuncs.com",
     "attestation_token_broker": {
         "type": "Simple",
         "duration_min": 5

--- a/attestation-service/docs/config.md
+++ b/attestation-service/docs/config.md
@@ -17,6 +17,7 @@ section:
 |----------------------------|-----------------------------|-----------------------------------------------------|----------|---------|
 | `work_dir`                 | String                      | The location for Attestation Service to store data. | False      | Firstly try to read from ENV `AS_WORK_DIR`. If not any, use `/opt/confidential-containers/attestation-service`       |
 | `rvps_config`              | [RVPSConfiguration][2]      | RVPS configuration                                  | False      | -       |
+| `artifact_server_address`  | String                      | Artifact Server URL used by policy `query_artifact_server`. | False | `https://attest-pre.aliyuncs.com` |
 | `attestation_token_broker` | [AttestationTokeBroker][1]  | Attestation result token configuration.             | False      | -       |
 | `challenge_key_path`       | String                      | Path to the RSA private key (PEM) used to sign and verify attestation challenge (nonce) tokens. The key is generated on first use if the file does not exist. | False | `/etc/trustee/attestation-service/nonce_token_issuer/key.pem` |
 
@@ -117,6 +118,7 @@ Running with a built-in RVPS:
             "file_path": "/var/lib/attestation-service/reference-values"
         }
     },
+    "artifact_server_address": "https://attest-pre.aliyuncs.com",
     "attestation_token_broker": {
         "type": "Ear",
         "duration_min": 5
@@ -134,6 +136,7 @@ Running with a remote RVPS:
         "type": "GrpcRemote",
         "address": "127.0.0.1:50003"
     },
+    "artifact_server_address": "https://attest-pre.aliyuncs.com",
     "attestation_token_broker": {
 	"type": "Ear",
         "duration_min": 5
@@ -151,6 +154,7 @@ Configurations for token signer
         "type": "GrpcRemote",
         "address": "127.0.0.1:50003"
     },
+    "artifact_server_address": "https://attest-pre.aliyuncs.com",
     "attestation_token_broker": {
 	"type": "Ear",
         "duration_min": 5,

--- a/attestation-service/docs/policy.md
+++ b/attestation-service/docs/policy.md
@@ -58,6 +58,28 @@ New policies should use `query_reference_value` because it avoids loading
 unrelated records. During migration, policies may use both styles; the
 per-attestation cache keeps their view consistent.
 
+## Artifact Server queries
+
+`query_artifact_server` asks the configured Artifact Server whether a set of
+evidence measurements is a known, non-revoked release. The argument is one
+object: keys are measurement types, values are strings.
+
+```rego
+allow if {
+    query_artifact_server({
+        "tdx.td-shim": input.tdx.td_shim,
+        "container.image.cmaas-runtime": input.container.image
+    })
+}
+```
+
+The function returns `true` when resolve succeeds (`status` is `resolved`)
+and `false` when a measurement is unknown or revoked. The Artifact Server URL comes from AS
+config `artifact_server_address` (default
+`https://attest-pre.aliyuncs.com`).
+
+Transport failures, request validation errors, unexpected HTTP bodies, and other Artifact Server API errors fail policy evaluation rather than returning `false`.
+
 ## Simple
 
 The simple token broker only evaluates one claim, which is `allow`.

--- a/attestation-service/src/bin/attestation-challenge-client/config.rs
+++ b/attestation-service/src/bin/attestation-challenge-client/config.rs
@@ -40,7 +40,7 @@ pub fn build_default_config(work_dir: &Path) -> Result<Config> {
         work_dir: work_dir.to_path_buf(),
         rvps_config,
         attestation_token_broker: AttestationTokenConfig::Ear(ear_cfg),
-        challenge_key_path: None,
+        ..Default::default()
     })
 }
 

--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 /// Environment macro for Attestation Service work dir.
 const AS_WORK_DIR: &str = "AS_WORK_DIR";
 pub const DEFAULT_WORK_DIR: &str = "/opt/confidential-containers/attestation-service";
+pub const DEFAULT_ARTIFACT_SERVER_ADDRESS: &str = "https://attest-pre.aliyuncs.com";
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Config {
@@ -19,6 +20,10 @@ pub struct Config {
     /// Configurations for RVPS.
     #[serde(default)]
     pub rvps_config: RvpsConfig,
+
+    /// Artifact Server address used by policy `query_artifact_server`.
+    #[serde(default = "default_artifact_server_address")]
+    pub artifact_server_address: String,
 
     /// The Attestation Result Token Broker Config
     #[serde(default)]
@@ -34,6 +39,10 @@ pub struct Config {
 
 fn default_work_dir() -> PathBuf {
     PathBuf::from(std::env::var(AS_WORK_DIR).unwrap_or_else(|_| DEFAULT_WORK_DIR.to_string()))
+}
+
+fn default_artifact_server_address() -> String {
+    DEFAULT_ARTIFACT_SERVER_ADDRESS.to_string()
 }
 
 #[derive(Error, Debug)]
@@ -54,6 +63,7 @@ impl Default for Config {
         Config {
             work_dir: default_work_dir(),
             rvps_config: RvpsConfig::default(),
+            artifact_server_address: default_artifact_server_address(),
             attestation_token_broker: AttestationTokenConfig::default(),
             challenge_key_path: None,
         }
@@ -71,6 +81,7 @@ impl TryFrom<&Path> for Config {
     ///            }
     ///            "store_config": {},
     ///        },
+    ///        "artifact_server_address": "https://attest-pre.aliyuncs.com",
     ///        "attestation_token_broker": {
     ///            "type": "Ear",
     ///            "duration_min": 5
@@ -88,7 +99,7 @@ mod tests {
     use rstest::rstest;
     use std::path::PathBuf;
 
-    use super::Config;
+    use super::{Config, DEFAULT_ARTIFACT_SERVER_ADDRESS};
     use crate::rvps::RvpsCrateConfig;
     use crate::{
         rvps::RvpsConfig,
@@ -111,6 +122,7 @@ mod tests {
             policy_dir: "/var/lib/attestation-service/policies".into(),
         }),
         challenge_key_path: None,
+        artifact_server_address: DEFAULT_ARTIFACT_SERVER_ADDRESS.to_string(),
     })]
     #[case("./tests/configs/example2.json", Config {
         work_dir: PathBuf::from("/var/lib/attestation-service/"),
@@ -130,6 +142,7 @@ mod tests {
             }),
         }),
         challenge_key_path: None,
+        artifact_server_address: DEFAULT_ARTIFACT_SERVER_ADDRESS.to_string(),
     })]
     #[case("./tests/configs/example3.json", Config {
         work_dir: PathBuf::from("/var/lib/attestation-service/"),
@@ -148,6 +161,7 @@ mod tests {
             policy_dir: "/var/lib/attestation-service/policies".into(),
         }),
         challenge_key_path: None,
+        artifact_server_address: DEFAULT_ARTIFACT_SERVER_ADDRESS.to_string(),
     })]
     #[case("./tests/configs/example4.json", Config {
         work_dir: PathBuf::from("/var/lib/attestation-service/"),
@@ -170,6 +184,7 @@ mod tests {
             }),
         }),
         challenge_key_path: None,
+        artifact_server_address: DEFAULT_ARTIFACT_SERVER_ADDRESS.to_string(),
     })]
     #[case("./tests/configs/example5.json", Config {
         work_dir: PathBuf::from("/var/lib/attestation-service/"),
@@ -197,6 +212,7 @@ mod tests {
             policy_dir: "/var/lib/attestation-service/policies".into(),
         }),
         challenge_key_path: None,
+        artifact_server_address: DEFAULT_ARTIFACT_SERVER_ADDRESS.to_string(),
     })]
     fn read_config(#[case] config: &str, #[case] expected: Config) {
         let config = std::fs::read_to_string(config).unwrap();
@@ -225,6 +241,7 @@ mod tests {
             settings,
             signer,
             policy_dir,
+            ..
         } = match cfg {
             AttestationTokenConfig::Simple(c) => c,
             _ => unreachable!(),
@@ -249,6 +266,7 @@ mod tests {
             settings,
             signer,
             policy_dir,
+            ..
         } = match cfg {
             AttestationTokenConfig::Ear(c) => c,
             _ => unreachable!(),
@@ -275,6 +293,7 @@ mod tests {
             settings,
             signer,
             policy_dir,
+            ..
         } = match cfg {
             AttestationTokenConfig::OIDC(c) => c,
             _ => unreachable!(),

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -240,7 +240,9 @@ impl AttestationService {
             .await
             .map_err(ServiceError::Rvps)?;
 
-        let token_broker = config.attestation_token_broker.to_token_broker()?;
+        let token_broker = config
+            .attestation_token_broker
+            .to_token_broker(&config.artifact_server_address)?;
 
         Ok(Self {
             _config: config,

--- a/attestation-service/src/policy_engine/mod.rs
+++ b/attestation-service/src/policy_engine/mod.rs
@@ -50,6 +50,10 @@ pub enum PolicyError {
     InvalidClaimValue,
     #[error("Cannot delete default policy")]
     CannotDeleteDefaultPolicy,
+
+    #[cfg(feature = "policy-artifact-server")]
+    #[error("Failed to create artifact server client: {0}")]
+    ArtifactServerClientCreationFailed(#[source] artifact_resolve_sdk::Error),
 }
 
 #[derive(Debug, EnumString, Deserialize)]
@@ -66,12 +70,14 @@ impl PolicyEngineType {
         work_dir: &Path,
         default_policy: &str,
         default_policy_id: &str,
+        artifact_server_address: &str,
     ) -> Result<Arc<dyn PolicyEngine>> {
         match self {
             PolicyEngineType::OPA => Ok(Arc::new(opa::OPA::new(
                 work_dir.to_path_buf(),
                 default_policy,
                 default_policy_id,
+                artifact_server_address,
             )?) as Arc<dyn PolicyEngine>),
         }
     }
@@ -105,7 +111,7 @@ pub trait PolicyEngine: Send + Sync {
     /// - `reference_value_resolver`: the per-attestation RVPS snapshot. Policies
     /// can query it through `query_reference_value(key)`. Legacy
     /// `data.reference` policies are populated lazily by the engine.
-    ///
+    /// Artifact Server queries use the address configured on the engine.
     async fn evaluate(
         &self,
         input: &str,

--- a/attestation-service/src/policy_engine/opa/fs.rs
+++ b/attestation-service/src/policy_engine/opa/fs.rs
@@ -16,6 +16,9 @@ use crate::policy_engine::{EvaluationResult, PolicyDigest, PolicyEngine, PolicyE
 #[derive(Debug, Clone)]
 pub struct OPA {
     policy_dir_path: PathBuf,
+
+    #[cfg(feature = "policy-artifact-server")]
+    artifact_server_client: Arc<artifact_resolve_sdk::Client>,
 }
 
 impl OPA {
@@ -23,6 +26,7 @@ impl OPA {
         work_dir: PathBuf,
         default_policy: &str,
         default_policy_id: &str,
+        artifact_server_address: &str,
     ) -> Result<Self, PolicyError> {
         let mut policy_dir_path = work_dir;
 
@@ -45,7 +49,20 @@ impl OPA {
             warn!("Default policy file is already populated. Existing policy file will be used.");
         }
 
-        Ok(Self { policy_dir_path })
+        #[cfg(feature = "policy-artifact-server")]
+        {
+            let client = artifact_resolve_sdk::Client::new(artifact_server_address)
+                .map_err(PolicyError::ArtifactServerClientCreationFailed)?;
+            Ok(Self {
+                policy_dir_path,
+                artifact_server_client: Arc::new(client),
+            })
+        }
+
+        #[cfg(not(feature = "policy-artifact-server"))]
+        {
+            Ok(Self { policy_dir_path })
+        }
     }
 }
 
@@ -82,6 +99,8 @@ impl PolicyEngine for OPA {
             policy_id.to_string(),
             evaluation_rules,
             reference_value_resolver,
+            #[cfg(feature = "policy-artifact-server")]
+            self.artifact_server_client.clone(),
         )
         .await
     }
@@ -183,7 +202,10 @@ impl PolicyEngine for OPA {
 
 #[cfg(test)]
 mod tests {
-    use crate::rvps::{RvpsApi, RvpsError};
+    use crate::{
+        config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        rvps::{RvpsApi, RvpsError},
+    };
     use anyhow::anyhow;
     use ear::TrustVector;
     use rstest::rstest;
@@ -225,6 +247,10 @@ mod tests {
     ) {
         let opa = OPA {
             policy_dir_path: PathBuf::from("./src/token/"),
+            #[cfg(feature = "policy-artifact-server")]
+            artifact_server_client: Arc::new(
+                artifact_resolve_sdk::Client::new(DEFAULT_ARTIFACT_SERVER_ADDRESS).unwrap(),
+            ),
         };
         let default_policy_id = "ear_default_policy_cpu".to_string();
 
@@ -265,7 +291,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_policy_management() {
-        let opa = OPA::new(PathBuf::from("tests/tmp"), "default", "default.rego").unwrap();
+        let opa = OPA::new(
+            PathBuf::from("tests/tmp"),
+            "default",
+            "default.rego",
+            DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
         let policy = "package policy
 default allow = true"
             .to_string();
@@ -346,7 +378,13 @@ minimum = query_reference_value("minimum")
 svn_again = query_reference_value("svn")
 "#;
         let tmp = tempfile::tempdir().unwrap();
-        let opa = OPA::new(tmp.path().to_path_buf(), policy, "query.rego").unwrap();
+        let opa = OPA::new(
+            tmp.path().to_path_buf(),
+            policy,
+            "query.rego",
+            DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
         let rvps = Arc::new(CountingRvps {
             keyed_queries: AtomicUsize::new(0),
             bulk_queries: AtomicUsize::new(0),
@@ -434,7 +472,13 @@ svn_again = query_reference_value("svn")
 allow = query_reference_value("svn") == [7]
 "#;
         let tmp = tempfile::tempdir().unwrap();
-        let opa = OPA::new(tmp.path().to_path_buf(), policy, "query.rego").unwrap();
+        let opa = OPA::new(
+            tmp.path().to_path_buf(),
+            policy,
+            "query.rego",
+            DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
         let resolver = Arc::new(ReferenceValueResolver::new(Arc::new(UnavailableRvps {
             timeout,
         })));

--- a/attestation-service/src/policy_engine/opa/in_memory.rs
+++ b/attestation-service/src/policy_engine/opa/in_memory.rs
@@ -19,6 +19,8 @@ use crate::{
 /// base64url wire format `set_policy` receives, matching `opa::OPA`).
 pub struct OPAInMemory {
     policies: RwLock<HashMap<String, Vec<u8>>>,
+    #[cfg(feature = "policy-artifact-server")]
+    artifact_server_client: Arc<artifact_resolve_sdk::Client>,
 }
 
 impl OPAInMemory {
@@ -28,13 +30,22 @@ impl OPAInMemory {
     /// stripped), matching how `opa::OPA::evaluate` looks up `{policy_id}.rego`.
     /// This lets a broker's default policy flow (`evaluate(..., "default", ...)`)
     /// succeed without any filesystem access.
-    pub fn with_raw_default_policy(raw_default_policy: &str, default_policy_id: &str) -> Self {
+    pub fn with_raw_default_policy(
+        raw_default_policy: &str,
+        default_policy_id: &str,
+        artifact_server_address: &str,
+    ) -> Result<Self, PolicyError> {
         let stem = default_policy_id.trim_end_matches(".rego");
         let mut policies = HashMap::new();
         policies.insert(stem.to_string(), raw_default_policy.as_bytes().to_vec());
-        Self {
+        Ok(Self {
             policies: RwLock::new(policies),
-        }
+            #[cfg(feature = "policy-artifact-server")]
+            artifact_server_client: Arc::new(
+                artifact_resolve_sdk::Client::new(artifact_server_address)
+                    .map_err(PolicyError::ArtifactServerClientCreationFailed)?,
+            ),
+        })
     }
 
     fn is_valid_policy_id(policy_id: &str) -> bool {
@@ -80,6 +91,8 @@ impl PolicyEngine for OPAInMemory {
             policy_id.to_string(),
             evaluation_rules,
             reference_value_resolver,
+            #[cfg(feature = "policy-artifact-server")]
+            self.artifact_server_client.clone(),
         )
         .await
     }
@@ -140,6 +153,8 @@ impl PolicyEngine for OPAInMemory {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS;
+
     use super::*;
 
     const RAW_ALLOW_POLICY: &str = "package policy\ndefault allow = true";
@@ -149,7 +164,12 @@ mod tests {
 
     #[tokio::test]
     async fn set_get_list_delete_roundtrip() {
-        let eng = OPAInMemory::with_raw_default_policy(RAW_ALLOW_POLICY, "test");
+        let eng = OPAInMemory::with_raw_default_policy(
+            RAW_ALLOW_POLICY,
+            "test",
+            DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
         assert_eq!(eng.list_policies().await.unwrap().len(), 1);
         assert_eq!(eng.get_policy("test".into()).await.unwrap(), allow_policy());
         eng.delete_policy("test".into()).await.unwrap();
@@ -160,7 +180,12 @@ mod tests {
     async fn set_policy_then_get_roundtrip() {
         // Covers the set_policy -> get_policy path (the roundtrip above only
         // exercises with_default_policy). Verifies raw rego in == raw rego out.
-        let eng = OPAInMemory::with_raw_default_policy(RAW_ALLOW_POLICY, "default");
+        let eng = OPAInMemory::with_raw_default_policy(
+            RAW_ALLOW_POLICY,
+            "default",
+            DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
         eng.set_policy("test".into(), allow_policy().into())
             .await
             .unwrap();
@@ -175,7 +200,12 @@ mod tests {
 
     #[tokio::test]
     async fn evaluate_uses_in_memory_policy() {
-        let eng = OPAInMemory::with_raw_default_policy(RAW_ALLOW_POLICY, "test");
+        let eng = OPAInMemory::with_raw_default_policy(
+            RAW_ALLOW_POLICY,
+            "test",
+            DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
         eng.set_policy("p".into(), allow_policy()).await.unwrap();
         let res = eng
             .evaluate(

--- a/attestation-service/src/policy_engine/opa/mod.rs
+++ b/attestation-service/src/policy_engine/opa/mod.rs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "policy-rvps")]
-use anyhow::{anyhow, bail};
-use anyhow::{Context, Result};
+#[cfg(any(feature = "policy-rvps", feature = "policy-artifact-server"))]
+use anyhow::bail;
+use anyhow::{anyhow, Context, Result};
 use log::debug;
 #[cfg(feature = "policy-rvps")]
 use log::warn;
@@ -118,12 +118,64 @@ fn query_reference_value_extension(
     })
 }
 
+#[cfg(feature = "policy-artifact-server")]
+fn query_artifact_server_extension(
+    client: Arc<artifact_resolve_sdk::Client>,
+    runtime_handle: tokio::runtime::Handle,
+) -> Box<dyn Extension> {
+    Box::new(move |params: Vec<regorus::Value>| {
+        use artifact_resolve_sdk::{Measurement, ReleaseManifest};
+
+        if params.len() != 1 {
+            bail!("query_artifact_server requires exactly one parameter");
+        }
+        let slices = params[0]
+            .as_object()
+            .context("query_artifact_server parameter must be an object")?;
+
+        debug!("query artifact value from artifact server: {slices:?}");
+
+        let measurements = slices
+            .iter()
+            .map(|(key, value)| -> Result<Measurement> {
+                let key = key.as_string().context("key is not a string")?.to_string();
+                let value = value
+                    .as_string()
+                    .context("value is not a string")?
+                    .to_string();
+                Ok(Measurement::text(key, value))
+            })
+            .collect::<Result<Vec<Measurement>>>()?;
+        let resolve_request =
+            artifact_resolve_sdk::ResolveRequest::new(ReleaseManifest::new(measurements));
+        match runtime_handle.block_on(client.resolve(&resolve_request)) {
+            Ok(resp) => {
+                if resp.status != "resolved" {
+                    bail!(
+                        "query_artifact_server returned unexpected status {:?}",
+                        resp.status
+                    );
+                }
+                Ok(regorus::Value::Bool(true))
+            }
+            Err(err) if err.is_measurement_not_found() || err.is_measurement_revoked() => {
+                debug!("query_artifact_server denied: {err}");
+                Ok(regorus::Value::Bool(false))
+            }
+            Err(err) => Err(anyhow!("query_artifact_server failed: {err}")),
+        }
+    })
+}
+
 async fn common_evaluate(
     policy: String,
     input: String,
     policy_id: String,
     evaluation_rules: Vec<String>,
     reference_value_resolver: Arc<ReferenceValueResolver>,
+    #[cfg(feature = "policy-artifact-server")] artifact_server_client: Arc<
+        artifact_resolve_sdk::Client,
+    >,
 ) -> Result<EvaluationResult, PolicyError> {
     let data = if policy_uses_legacy_reference(&policy)? {
         let reference_values = reference_value_resolver
@@ -135,13 +187,29 @@ async fn common_evaluate(
         "{}".to_string()
     };
 
+    #[cfg(any(feature = "policy-rvps", feature = "policy-artifact-server"))]
+    let mut query_extensions = vec![];
+
     #[cfg(feature = "policy-rvps")]
     {
         let runtime_handle = tokio::runtime::Handle::current();
-        let query_extension = Some(query_reference_value_extension(
-            reference_value_resolver,
-            runtime_handle,
+        query_extensions.push((
+            "query_reference_value".to_string(),
+            query_reference_value_extension(reference_value_resolver, runtime_handle),
         ));
+    }
+
+    #[cfg(feature = "policy-artifact-server")]
+    {
+        let runtime_handle = tokio::runtime::Handle::current();
+        query_extensions.push((
+            "query_artifact_server".to_string(),
+            query_artifact_server_extension(artifact_server_client, runtime_handle),
+        ));
+    }
+
+    #[cfg(any(feature = "policy-rvps", feature = "policy-artifact-server"))]
+    {
         tokio::task::spawn_blocking(move || {
             evaluate_sync(
                 policy,
@@ -149,7 +217,7 @@ async fn common_evaluate(
                 policy_id,
                 evaluation_rules,
                 data,
-                query_extension,
+                query_extensions,
             )
         })
         .await
@@ -158,8 +226,10 @@ async fn common_evaluate(
         })?
     }
 
-    #[cfg(not(feature = "policy-rvps"))]
-    evaluate_sync(policy, input, policy_id, evaluation_rules, data, None)
+    #[cfg(not(any(feature = "policy-rvps", feature = "policy-artifact-server")))]
+    {
+        evaluate_sync(policy, input, policy_id, evaluation_rules, data, vec![])
+    }
 }
 
 fn evaluate_sync(
@@ -168,7 +238,7 @@ fn evaluate_sync(
     policy_id: String,
     evaluation_rules: Vec<String>,
     data: String,
-    query_extension: Option<Box<dyn Extension>>,
+    query_extensions: Vec<(String, Box<dyn Extension>)>,
 ) -> Result<EvaluationResult, PolicyError> {
     let mut engine = regorus::Engine::new();
 
@@ -193,9 +263,9 @@ fn evaluate_sync(
         .context("set input")
         .map_err(PolicyError::SetInputDataFailed)?;
 
-    if let Some(query_extension) = query_extension {
+    for (name, query_extension) in query_extensions {
         engine
-            .add_extension("query_reference_value".to_string(), 1, query_extension)
+            .add_extension(name, 1, query_extension)
             .map_err(PolicyError::EvalPolicyFailed)?;
     }
 

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -158,11 +158,12 @@ impl EarAttestationTokenBroker {
     /// (`key_path`, fs-gated) and builds the `PolicyEngine` from
     /// `policy_dir` (OPA fs / InMemory). Replaces the old `new(config)`.
     #[cfg(feature = "fs")]
-    pub fn from_config(config: Configuration) -> Result<Self> {
+    pub fn from_config(config: Configuration, artifact_server_address: &str) -> Result<Self> {
         let policy_engine = crate::policy_engine::PolicyEngineType::OPA.to_policy_engine(
             std::path::Path::new(&config.policy_dir),
             DEFAULT_POLICY,
             DEFAULT_POLICY_ID,
+            artifact_server_address,
         )?;
         log::info!("Loading default AS policy \"default.rego\"");
 
@@ -531,7 +532,11 @@ mod tests {
         // use default config with no signer.
         // this will sign the token with an ephemeral key.
         let config = Configuration::default();
-        let broker = EarAttestationTokenBroker::from_config(config).unwrap();
+        let broker = EarAttestationTokenBroker::from_config(
+            config,
+            crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
 
         let _token = broker
             .issue(
@@ -566,7 +571,11 @@ mod tests {
         let mut config = Configuration::default();
         config.signer = Some(signer);
 
-        let broker = EarAttestationTokenBroker::from_config(config).unwrap();
+        let broker = EarAttestationTokenBroker::from_config(
+            config,
+            crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
         let token = broker
             .issue(
                 vec![TeeClaims {
@@ -596,7 +605,11 @@ mod tests {
             policy_dir: policy_dir.path().to_string_lossy().into_owned(),
             ..Configuration::default()
         };
-        let broker = EarAttestationTokenBroker::from_config(config).unwrap();
+        let broker = EarAttestationTokenBroker::from_config(
+            config,
+            crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
         let token = broker
             .issue(
                 vec![TeeClaims {
@@ -659,10 +672,14 @@ default configuration := 36
 default file_system := 35
 "#;
         use crate::policy_engine::opa::OPAInMemory;
-        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(OPAInMemory::with_raw_default_policy(
-            TRIVIAL_EAR_POLICY,
-            DEFAULT_POLICY_ID,
-        ));
+        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(
+            OPAInMemory::with_raw_default_policy(
+                TRIVIAL_EAR_POLICY,
+                DEFAULT_POLICY_ID,
+                crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+            )
+            .unwrap(),
+        );
         let broker = EarAttestationTokenBroker::from_components(
             TokenBrokerSettings::default(),
             Arc::new(crate::token::signer::EphemeralSigner::<SecretKey>::new()),

--- a/attestation-service/src/token/mod.rs
+++ b/attestation-service/src/token/mod.rs
@@ -115,20 +115,32 @@ impl Default for AttestationTokenConfig {
 
 impl AttestationTokenConfig {
     #[cfg(feature = "fs")]
-    pub fn to_token_broker(&self) -> Result<Box<dyn AttestationTokenBroker + Send + Sync>> {
+    pub fn to_token_broker(
+        &self,
+        artifact_server_address: &str,
+    ) -> Result<Box<dyn AttestationTokenBroker + Send + Sync>> {
         match self {
-            AttestationTokenConfig::Simple(cfg) => Ok(Box::new(
-                simple::SimpleAttestationTokenBroker::from_config(cfg.clone())?,
-            )
-                as Box<dyn AttestationTokenBroker + Send + Sync>),
-            AttestationTokenConfig::Ear(cfg) => Ok(Box::new(
-                ear_broker::EarAttestationTokenBroker::from_config(cfg.clone())?,
-            )
-                as Box<dyn AttestationTokenBroker + Send + Sync>),
-            AttestationTokenConfig::OIDC(cfg) => Ok(Box::new(
-                oidc::OIDCAttestationTokenBroker::from_config(cfg.clone())?,
-            )
-                as Box<dyn AttestationTokenBroker + Send + Sync>),
+            AttestationTokenConfig::Simple(cfg) => {
+                Ok(Box::new(simple::SimpleAttestationTokenBroker::from_config(
+                    cfg.clone(),
+                    artifact_server_address,
+                )?)
+                    as Box<dyn AttestationTokenBroker + Send + Sync>)
+            }
+            AttestationTokenConfig::Ear(cfg) => {
+                Ok(Box::new(ear_broker::EarAttestationTokenBroker::from_config(
+                    cfg.clone(),
+                    artifact_server_address,
+                )?)
+                    as Box<dyn AttestationTokenBroker + Send + Sync>)
+            }
+            AttestationTokenConfig::OIDC(cfg) => {
+                Ok(Box::new(oidc::OIDCAttestationTokenBroker::from_config(
+                    cfg.clone(),
+                    artifact_server_address,
+                )?)
+                    as Box<dyn AttestationTokenBroker + Send + Sync>)
+            }
         }
     }
 }

--- a/attestation-service/src/token/oidc.rs
+++ b/attestation-service/src/token/oidc.rs
@@ -147,11 +147,12 @@ pub struct OIDCAttestationTokenBroker {
 
 impl OIDCAttestationTokenBroker {
     #[cfg(feature = "fs")]
-    pub fn from_config(config: Configuration) -> Result<Self> {
+    pub fn from_config(config: Configuration, artifact_server_address: &str) -> Result<Self> {
         let policy_engine = crate::policy_engine::PolicyEngineType::OPA.to_policy_engine(
             std::path::Path::new(&config.policy_dir),
             DEFAULT_POLICY,
             DEFAULT_POLICY_ID,
+            artifact_server_address,
         )?;
         log::info!("Loading default AS policy \"oidc_default_policy.rego\"");
 
@@ -561,7 +562,11 @@ mod tests {
         // use default config with no signer.
         // this will sign the token with an ephemeral key.
         let config = Configuration::default();
-        let broker = OIDCAttestationTokenBroker::from_config(config).unwrap();
+        let broker = OIDCAttestationTokenBroker::from_config(
+            config,
+            crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
 
         let _token = broker
             .issue(
@@ -588,7 +593,11 @@ mod tests {
             policy_dir: policy_dir.path().to_string_lossy().into_owned(),
             ..Configuration::default()
         };
-        let broker = OIDCAttestationTokenBroker::from_config(config).unwrap();
+        let broker = OIDCAttestationTokenBroker::from_config(
+            config,
+            crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
         let claims = TeeClaims {
             tee: Tee::Snp,
             tee_class: "cpu".to_string(),
@@ -638,10 +647,14 @@ mod tests {
         // registered under the `policy-rvps` feature — off under
         // `--no-default-features`.
         const TRIVIAL_ALLOW_POLICY: &str = "package policy\ndefault allow = true";
-        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(OPAInMemory::with_raw_default_policy(
-            TRIVIAL_ALLOW_POLICY,
-            super::DEFAULT_POLICY_ID,
-        ));
+        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(
+            OPAInMemory::with_raw_default_policy(
+                TRIVIAL_ALLOW_POLICY,
+                super::DEFAULT_POLICY_ID,
+                crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+            )
+            .unwrap(),
+        );
         let broker = OIDCAttestationTokenBroker::from_components(
             super::TokenBrokerSettings::default(),
             Arc::new(EphemeralSigner::<RsaPrivateKey>::new().unwrap()),
@@ -768,8 +781,11 @@ frJCGYDUg+8c
             ..Configuration::default()
         };
 
-        let broker = OIDCAttestationTokenBroker::from_config(config)
-            .expect("broker construction with signer + cert chain must succeed");
+        let broker = OIDCAttestationTokenBroker::from_config(
+            config,
+            crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .expect("broker construction with signer + cert chain must succeed");
 
         let jwks = serde_json::from_str::<serde_json::Value>(
             &broker.pubkey_jwks().expect("pubkey_jwks must succeed"),
@@ -840,8 +856,11 @@ frJCGYDUg+8c
             }),
             ..Configuration::default()
         };
-        let broker =
-            OIDCAttestationTokenBroker::from_config(cfg).expect("configured broker must construct");
+        let broker = OIDCAttestationTokenBroker::from_config(
+            cfg,
+            crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .expect("configured broker must construct");
         let jwks = broker
             .configured_signer_jwks()
             .await
@@ -853,10 +872,14 @@ frJCGYDUg+8c
 
         // Ephemeral signer → not published (None).
         const TRIVIAL_ALLOW_POLICY: &str = "package policy\ndefault allow = true";
-        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(OPAInMemory::with_raw_default_policy(
-            TRIVIAL_ALLOW_POLICY,
-            super::DEFAULT_POLICY_ID,
-        ));
+        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(
+            OPAInMemory::with_raw_default_policy(
+                TRIVIAL_ALLOW_POLICY,
+                super::DEFAULT_POLICY_ID,
+                crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+            )
+            .unwrap(),
+        );
         let ephemeral = OIDCAttestationTokenBroker::from_components(
             super::TokenBrokerSettings::default(),
             Arc::new(EphemeralSigner::<RsaPrivateKey>::new().unwrap()),

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -115,11 +115,12 @@ pub struct SimpleAttestationTokenBroker {
 
 impl SimpleAttestationTokenBroker {
     #[cfg(feature = "fs")]
-    pub fn from_config(config: Configuration) -> Result<Self> {
+    pub fn from_config(config: Configuration, artifact_server_address: &str) -> Result<Self> {
         let policy_engine = crate::policy_engine::PolicyEngineType::OPA.to_policy_engine(
             std::path::Path::new(&config.policy_dir),
             DEFAULT_POLICY,
             DEFAULT_POLICY_ID,
+            artifact_server_address,
         )?;
         log::info!("Loading default AS policy \"simple_default_policy.rego\"");
 
@@ -465,7 +466,11 @@ mod tests {
         // use default config with no signer.
         // this will sign the token with an ephemeral key.
         let config = Configuration::default();
-        let broker = SimpleAttestationTokenBroker::from_config(config).unwrap();
+        let broker = SimpleAttestationTokenBroker::from_config(
+            config,
+            crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .unwrap();
 
         let _token = broker
             .issue(
@@ -503,10 +508,14 @@ mod tests {
         // `query_reference_value` regorus extension, which is only registered
         // under the `policy-rvps` feature — off under `--no-default-features`.
         const TRIVIAL_ALLOW_POLICY: &str = "package policy\ndefault allow = true";
-        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(OPAInMemory::with_raw_default_policy(
-            TRIVIAL_ALLOW_POLICY,
-            super::DEFAULT_POLICY_ID,
-        ));
+        let policy_engine: Arc<dyn PolicyEngine> = Arc::new(
+            OPAInMemory::with_raw_default_policy(
+                TRIVIAL_ALLOW_POLICY,
+                super::DEFAULT_POLICY_ID,
+                crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+            )
+            .unwrap(),
+        );
         let broker = SimpleAttestationTokenBroker::from_components(
             super::TokenBrokerSettings::default(),
             Arc::new(EphemeralSigner::<RsaPrivateKey>::new().unwrap()),
@@ -699,8 +708,11 @@ frJCGYDUg+8c
             ..Configuration::default()
         };
 
-        let broker = SimpleAttestationTokenBroker::from_config(config)
-            .expect("broker construction with signer + cert chain must succeed");
+        let broker = SimpleAttestationTokenBroker::from_config(
+            config,
+            crate::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .expect("broker construction with signer + cert chain must succeed");
 
         let jwks = serde_json::from_str::<serde_json::Value>(
             &broker.pubkey_jwks().expect("pubkey_jwks must succeed"),

--- a/attestation-service/tests/policy_rvps.rs
+++ b/attestation-service/tests/policy_rvps.rs
@@ -78,8 +78,11 @@ fn as_config(work_dir: &Path, rvps_config: RvpsConfig) -> Config {
             },
             signer: None,
             policy_dir: work_dir.join("policies").to_string_lossy().into_owned(),
+            ..Default::default()
         }),
         challenge_key_path: None,
+        artifact_server_address: attestation_service::config::DEFAULT_ARTIFACT_SERVER_ADDRESS
+            .to_string(),
     }
 }
 

--- a/deploy/configs/as-config.json
+++ b/deploy/configs/as-config.json
@@ -5,6 +5,7 @@
         "type": "GrpcRemote",
         "address": "http://rvps:50003"
     },
+    "artifact_server_address": "https://attest-pre.aliyuncs.com",
     "attestation_token_broker": {
 	"type": "Ear",
         "duration_min": 5,

--- a/dist/configs/as-config.json
+++ b/dist/configs/as-config.json
@@ -5,6 +5,7 @@
         "type": "GrpcRemote",
         "address": "http://127.0.0.1:50003"
     },
+    "artifact_server_address": "https://attest-pre.aliyuncs.com",
     "attestation_token_broker": {
 	"type": "Ear",
         "duration_min": 5,

--- a/helm-chart/trustee/templates/as-configmap.yaml
+++ b/helm-chart/trustee/templates/as-configmap.yaml
@@ -20,6 +20,7 @@ data:
           "address":"http://rvps:{{ .Values.rvps.service.port }}"
           {{- end }}
         },
+        "artifact_server_address": "https://attest-pre.aliyuncs.com",
         "attestation_token_broker": {
             "type": "Ear",
             "duration_min": 5,

--- a/kbs/config/as-config.json
+++ b/kbs/config/as-config.json
@@ -5,6 +5,7 @@
         "type": "GrpcRemote",
         "address": "http://rvps:50003"
     },
+    "artifact_server_address": "https://attest-pre.aliyuncs.com",
     "attestation_token_broker": {
 	"type": "Ear",
         "duration_min": 5,

--- a/kbs/config/kbs-config.toml
+++ b/kbs/config/kbs-config.toml
@@ -9,6 +9,7 @@ insecure_key = true
 type = "coco_as_builtin"
 work_dir = "/opt/confidential-containers/attestation-service"
 policy_engine = "opa"
+artifact_server_address = "https://attest-pre.aliyuncs.com"
 
 [attestation_service.attestation_token_broker]
 type = "Ear"

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -81,6 +81,7 @@ When `type` is set to `coco_as_builtin`, the following properties can be set.
 | `work_dir`                 | String                      | The location for Attestation Service to store data. |  First try from env `AS_WORK_DIR`. If no this env, then use `/opt/confidential-containers/attestation-service`       |
 | `policy_engine`            | String                      | Policy engine type. Valid values: `opa`             |  `opa`       |
 | `rvps_config`              | [RVPSConfiguration][2]      | RVPS configuration                                  |  See [RVPSConfiguration][2]       |
+| `artifact_server_address`  | String                      | Artifact Server URL used by policy `query_artifact_server`. | `https://attest-pre.aliyuncs.com` |
 | `attestation_token_broker` | [AttestationTokenConfig][1] | Attestation result token configuration.             |  See [AttestationTokenConfig][1]       |
 
 [1]: #attestationtokenbroker
@@ -502,6 +503,7 @@ insecure_api = true
 type = "coco_as_builtin"
 work_dir = "/opt/confidential-containers/attestation-service"
 policy_engine = "opa"
+artifact_server_address = "https://attest-pre.aliyuncs.com"
 
 [attestation_service.attestation_token_broker]
 type = "Ear"
@@ -554,6 +556,7 @@ insecure_api = true
 type = "coco_as_builtin"
 work_dir = "/opt/confidential-containers/attestation-service"
 policy_engine = "opa"
+artifact_server_address = "https://attest-pre.aliyuncs.com"
 
 [attestation_service.attestation_token_broker]
 type = "Ear"

--- a/kbs/docs/self-signed-https.md
+++ b/kbs/docs/self-signed-https.md
@@ -81,6 +81,7 @@ policy_path = "/opa/confidential-containers/kbs/policy.rego"
 type = "coco_as_builtin"
 work_dir = "/opt/confidential-containers/attestation-service"
 policy_engine = "opa"
+artifact_server_address = "https://attest-pre.aliyuncs.com"
 
     [attestation_serivce.attestation_token_broker]
     type = "Ear"


### PR DESCRIPTION
## Summary
- Add `query_artifact_server` policy builtin (feature `policy-artifact-server`)
- Configure Artifact Server URL once on AS `Config` (`artifact_server_address`)