### PR TITLE
refactor(as/challenge): wrap challenge key in JwtChallenger and verify in evaluate

### DIFF
--- a/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/src/bin/grpc/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::bail;
-use attestation_service::challenge::verify_challenge_and_extract_nonce_b64url;
 use attestation_service::HashAlgorithm;
 use attestation_service::{
     config::Config, config::ConfigError, AttestationService as Service, ServiceError, Tee,
@@ -176,13 +175,6 @@ impl AttestationService for Arc<RwLock<AttestationServer>> {
                         let structured: serde_json::Value = serde_json::from_str(&structured)
                             .map_err(|e| Status::aborted(format!(
                                 "parse structured runtime data: {e}")))?;
-                        if let Some(jwt) = structured.get("challenge_token").and_then(|x| x.as_str()) {
-                            let challenge_key_path =
-                                self.read().await.attestation_service.challenge_key_path();
-                            verify_challenge_and_extract_nonce_b64url(jwt, &challenge_key_path)
-                                .map_err(|e| Status::aborted(format!(
-                                    "verify challenge_token failed: {e}")))?;
-                        }
                         Some(attestation_service::RuntimeData::Structured(structured))
                     }
                 },

--- a/attestation-service/src/bin/restful/mod.rs
+++ b/attestation-service/src/bin/restful/mod.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use actix_web::{http::StatusCode, web, HttpRequest, HttpResponse, Responder, ResponseError};
 use anyhow::{anyhow, bail, Context};
-use attestation_service::challenge::verify_challenge_and_extract_nonce_b64url;
 use attestation_service::{
     AttestationError, AttestationService, HashAlgorithm, InitDataInput as InnerInitDataInput,
     RuntimeData as InnerRuntimeData, VerificationRequest,
@@ -127,23 +126,6 @@ impl Error {
         )
     }
 
-    fn unauthorized(
-        code: &'static str,
-        title: &'static str,
-        detail: impl Into<String>,
-        source: anyhow::Error,
-    ) -> Self {
-        Self::new(
-            ErrorKind::Unauthorized,
-            code,
-            title,
-            detail,
-            false,
-            None,
-            source,
-        )
-    }
-
     fn internal(source: anyhow::Error) -> Self {
         Self::new(
             ErrorKind::InternalError,
@@ -195,6 +177,16 @@ impl Error {
                     Some(format!("verification_requests[{request_index}].tee")),
                 )),
                 AttestationError::Verification { .. } => None,
+                AttestationError::InvalidChallengeToken { request_index, .. } => Some((
+                    ErrorKind::Unauthorized,
+                    "AS.CHALLENGE.INVALID_TOKEN",
+                    "Invalid challenge token",
+                    "The challenge token is invalid or expired.".to_string(),
+                    false,
+                    Some(format!(
+                        "verification_requests[{request_index}].runtime_data.challenge_token"
+                    )),
+                )),
             }
         });
 
@@ -503,19 +495,6 @@ pub async fn attestation(
 
         let runtime_data = match attestation_request.runtime_data {
             Some(RuntimeData::Structured(v)) => {
-                if let Some(jwt) = v.get("challenge_token").and_then(|x| x.as_str()) {
-                    // 验证 token，但不修改 runtime_data 内容
-                    let challenge_key_path = cocoas.read().await.challenge_key_path();
-                    let _ = verify_challenge_and_extract_nonce_b64url(jwt, &challenge_key_path)
-                        .map_err(|source| {
-                            Error::unauthorized(
-                                "AS.CHALLENGE.INVALID_TOKEN",
-                                "Invalid challenge token",
-                                "The challenge token is invalid or expired.",
-                                source,
-                            )
-                        })?;
-                }
                 Some(parse_runtime_data(RuntimeData::Structured(v))?)
             }
             Some(RuntimeData::Raw(raw)) => Some(parse_runtime_data(RuntimeData::Raw(raw))?),

--- a/attestation-service/src/challenge.rs
+++ b/attestation-service/src/challenge.rs
@@ -3,38 +3,114 @@ use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
 use rand::rngs::OsRng;
 use rand::RngCore;
-use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::pkcs1v15::{Signature, SigningKey, VerifyingKey};
-use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding};
 use rsa::signature::{Signer, Verifier};
+#[cfg(feature = "fs")]
+use rsa::{
+    pkcs1::DecodeRsaPrivateKey as _,
+    pkcs8::{DecodePrivateKey as _, EncodePrivateKey as _, LineEnding},
+};
 use rsa::{RsaPrivateKey, RsaPublicKey};
 use serde_json::{json, Value};
 use sha2::Sha384;
-use std::fs;
+
+#[cfg(feature = "fs")]
 use std::path::{Path, PathBuf};
 
-const RSA_KEY_BITS: u32 = 2048;
+#[cfg(not(all(
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown"
+)))]
+use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(all(
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown"
+))]
+use web_time::{SystemTime, UNIX_EPOCH};
+
+pub const RSA_KEY_BITS: u32 = 2048;
 const TOKEN_ALG: &str = "RS384";
+
+#[cfg(feature = "fs")]
 const DEFAULT_KEY_DIR: &str = "/etc/trustee/attestation-service/nonce_token_issuer";
+#[cfg(feature = "fs")]
 const DEFAULT_PRIV_KEY_PEM: &str = "key.pem";
 
 /// Default filesystem path of the RSA private key used to sign/verify
 /// attestation challenge (nonce) tokens. Used when no explicit path is
 /// configured in the Attestation Service config.
-pub fn default_challenge_key_path() -> PathBuf {
+#[cfg(feature = "fs")]
+fn default_challenge_key_path() -> PathBuf {
     Path::new(DEFAULT_KEY_DIR).join(DEFAULT_PRIV_KEY_PEM)
 }
 
-fn ensure_keypair(key_path: &Path) -> Result<RsaPrivateKey> {
+/// [`super::JwtChallenger`] backed by an in-memory RSA private key.
+///
+/// JWT-based (RS384) challenge key — the issued JWT itself is the challenge
+/// token, so the `exp` claim gives freshness across replicas without
+/// synchronizing every signed token; see [`build_challenge_json`] for details.
+///
+/// Native / config-file compatibility path — the AS default until a caller
+/// opts into an in-memory impl.
+pub struct JwtChallenger {
+    key: RsaPrivateKey,
+}
+
+impl JwtChallenger {
+    /// Construct with an explicit on-disk key path.
+    #[cfg(feature = "fs")]
+    pub async fn new_with_private_key_path(path: &Path) -> Result<Self> {
+        let key = ensure_keypair(path).await?;
+        Ok(Self::new_with_private_key(key))
+    }
+
+    /// The built-in default path (`/etc/trustee/attestation-service/nonce_token_issuer/key.pem`).
+    #[cfg(feature = "fs")]
+    pub async fn new_with_private_key_default_path() -> Result<Self> {
+        Self::new_with_private_key_path(&default_challenge_key_path()).await
+    }
+
+    pub fn new_with_private_key(key: RsaPrivateKey) -> Self {
+        Self { key }
+    }
+
+    pub fn new() -> Result<Self> {
+        let mut rng = OsRng;
+        let key = RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?;
+        Ok(Self::new_with_private_key(key))
+    }
+
+    pub async fn generate_challenge_json(&self) -> Result<String> {
+        build_challenge_json(&self.key)
+    }
+
+    /// Verify the challenge token JWT — signature and `exp` (freshness).
+    /// The token is the JWT the client echoes from `extra-params.jwt` in the
+    /// challenge response; the client is not expected to send a separate
+    /// nonce, so verification is signature + expiry only. Binding to the TEE
+    /// report is handled by the TEE measuring the `runtime_data` (which
+    /// carries the challenge token) into its report.
+    pub async fn verify_challenge_token(&self, challenge_token: &str) -> Result<()> {
+        verify_jwt(challenge_token, &self.key)
+    }
+}
+
+#[cfg(feature = "fs")]
+async fn ensure_keypair(key_path: &Path) -> Result<RsaPrivateKey> {
     if let Some(dir) = key_path.parent() {
         if !dir.as_os_str().is_empty() && !dir.exists() {
-            fs::create_dir_all(dir)
+            tokio::fs::create_dir_all(dir)
+                .await
                 .with_context(|| format!("create dir {} failed", dir.display()))?;
         }
     }
 
     if key_path.exists() {
-        let pem = fs::read_to_string(key_path).context("read private key pem failed")?;
+        let pem = tokio::fs::read_to_string(key_path)
+            .await
+            .context("read private key pem failed")?;
         // Accept both PKCS#8 (what we write now) and legacy PKCS#1 (what the
         // previous implementation's `private_key_to_pem` wrote).
         let rsa = RsaPrivateKey::from_pkcs8_pem(&pem)
@@ -48,17 +124,32 @@ fn ensure_keypair(key_path: &Path) -> Result<RsaPrivateKey> {
     let pem = rsa
         .to_pkcs8_pem(LineEnding::LF)
         .context("dump private key to pem failed")?;
-    fs::write(key_path, pem.as_bytes()).context("write private key pem failed")?;
+    tokio::fs::write(key_path, pem.as_bytes())
+        .await
+        .context("write private key pem failed")?;
     Ok(rsa)
 }
 
-fn rs384_sign(rsa: &RsaPrivateKey, payload: &[u8]) -> Result<Vec<u8>> {
-    let signing_key = SigningKey::<Sha384>::new(rsa.clone());
-    let sig: Signature = signing_key.sign(payload);
-    Ok(Box::<[u8]>::from(sig).to_vec())
-}
-
-pub fn generate_common_challenge(key_path: &Path) -> Result<String> {
+/// Build the challenge JSON `{"nonce", "extra-params":{"jwt"}}` signed with
+/// `key` (RS384, 5-minute `exp`).
+///
+/// The issued JWT serves as the challenge token. The `exp` claim bounds its
+/// validity window, which gives freshness when the Attestation Service runs
+/// with multiple replicas sharing the same signing key: each replica can
+/// verify a token's signature and `exp` independently, so a JWT that has
+/// already been consumed by one replica cannot be replayed once `exp` passes.
+/// This avoids, to a degree, the need to synchronize a record of every
+/// signed JWT across replicas — the short `exp` window bounds the window in
+/// which a consumed-but-unsynced token could be replayed, without requiring
+/// shared state on the hot path.
+///
+/// The `nonce` field (STANDARD base64 of 32 random bytes) and the JWT
+/// `nonce` claim carry the same string. The client echoes only the JWT into
+/// `runtime_data` as `challenge_token`; [`JwtChallenger::verify_challenge_token`]
+/// checks signature + `exp` and does not compare the nonce — binding to the
+/// TEE report is handled by the TEE measuring the `runtime_data` (which
+/// carries the token) into its report.
+fn build_challenge_json(key: &RsaPrivateKey) -> Result<String> {
     // nonce
     let mut nonce = [0u8; 32];
     OsRng
@@ -75,8 +166,8 @@ pub fn generate_common_challenge(key_path: &Path) -> Result<String> {
     let header_b64 = URL_SAFE_NO_PAD.encode(header_string.as_bytes());
 
     // claims with 5-minute expiry
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
         .context("time error")?
         .as_secs();
     let exp = now + 5 * 60;
@@ -90,8 +181,7 @@ pub fn generate_common_challenge(key_path: &Path) -> Result<String> {
 
     // sign
     let signing_input = format!("{}.{}", header_b64, claims_b64);
-    let rsa = ensure_keypair(key_path)?;
-    let signature = rs384_sign(&rsa, signing_input.as_bytes())?;
+    let signature = rs384_sign(key, signing_input.as_bytes())?;
     let signature_b64 = URL_SAFE_NO_PAD.encode(signature);
     let jwt = format!("{}.{}", signing_input, signature_b64);
 
@@ -103,7 +193,19 @@ pub fn generate_common_challenge(key_path: &Path) -> Result<String> {
     Ok(serde_json::to_string(&output)?)
 }
 
-pub fn verify_challenge_and_extract_nonce_b64url(token: &str, key_path: &Path) -> Result<String> {
+fn rs384_sign(rsa: &RsaPrivateKey, payload: &[u8]) -> Result<Vec<u8>> {
+    let signing_key = SigningKey::<Sha384>::new(rsa.clone());
+    let sig: Signature = signing_key.sign(payload);
+    Ok(Box::<[u8]>::from(sig).to_vec())
+}
+
+/// Verify a challenge_token JWT signed by the public half of `key` and
+/// enforce its `exp` (freshness). Signature + expiry is the only check the
+/// Attestation Service performs on the challenge token — the binding to the
+/// TEE report comes from the TEE measuring the `runtime_data` (which carries
+/// the token) into its report, so there is no nonce string to compare and
+/// nothing to return.
+fn verify_jwt(token: &str, key: &RsaPrivateKey) -> Result<()> {
     let parts: Vec<&str> = token.split('.').collect();
     if parts.len() != 3 {
         bail!("invalid JWT format in challenge_token");
@@ -114,12 +216,7 @@ pub fn verify_challenge_and_extract_nonce_b64url(token: &str, key_path: &Path) -
         .decode(parts[2])
         .context("invalid JWT signature encoding")?;
 
-    let pem_str = fs::read_to_string(key_path).context("read nonce token key failed")?;
-    let rsa = RsaPrivateKey::from_pkcs8_pem(&pem_str)
-        .or_else(|_| RsaPrivateKey::from_pkcs1_pem(&pem_str))
-        .context("parse nonce token key failed")?;
-    let public_key: RsaPublicKey = rsa.to_public_key();
-
+    let public_key: RsaPublicKey = key.to_public_key();
     let verifying_key = VerifyingKey::<Sha384>::new(public_key);
     let sig_obj = Signature::try_from(sig.as_slice()).context("invalid signature bytes")?;
     verifying_key
@@ -132,8 +229,8 @@ pub fn verify_challenge_and_extract_nonce_b64url(token: &str, key_path: &Path) -
     let v: Value = serde_json::from_slice(&payload).context("invalid JWT payload json")?;
 
     // exp
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
         .context("time error")?
         .as_secs() as i64;
     let exp = v
@@ -144,52 +241,94 @@ pub fn verify_challenge_and_extract_nonce_b64url(token: &str, key_path: &Path) -
         bail!("challenge_token expired");
     }
 
-    let nonce_b64 = v
-        .get("nonce")
-        .and_then(|x| x.as_str())
-        .ok_or_else(|| anyhow!("missing nonce claim in challenge_token"))?;
-    let nonce_bytes = STANDARD
-        .decode(nonce_b64)
-        .or_else(|_| URL_SAFE_NO_PAD.decode(nonce_b64))
-        .context("invalid nonce base64")?;
-    Ok(URL_SAFE_NO_PAD.encode(nonce_bytes))
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use serde_json::Value;
+
     use super::*;
 
-    /// Sign a challenge and verify it round-trips. Pins the rustcrypto RS384
-    /// implementation against the on-disk key format this module writes.
-    #[test]
-    fn challenge_sign_verify_roundtrip() {
-        // Use a temp key dir so we don't touch /etc/trustee/...
-        let tmp = tempfile::tempdir().unwrap();
-        let key_file = tmp.path().join("key.pem");
-
-        let challenge_json = generate_common_challenge(&key_file).expect("generate");
-        let outer: serde_json::Value = serde_json::from_str(&challenge_json).expect("json");
+    /// Helper mirroring the `lib.rs` evaluate contract: the client echoes the
+    /// challenge JSON's JWT into `runtime_data` as `challenge_token`, and the
+    /// challenger verifies signature + `exp` (freshness only — no nonce is
+    /// sent by the client).
+    async fn issue_and_verify(c: &JwtChallenger, challenge_json: &str) {
+        let outer: Value = serde_json::from_str(challenge_json).expect("outer json");
         let jwt = outer["extra-params"]["jwt"]
             .as_str()
             .expect("jwt in extra-params")
             .to_string();
 
-        // verify must accept the token we just issued and return the nonce.
-        let nonce_back =
-            verify_challenge_and_extract_nonce_b64url(&jwt, &key_file).expect("verify");
-        let nonce_original = outer["nonce"].as_str().unwrap().to_string();
-        // The challenge JSON uses STANDARD base64 for the nonce, while
-        // verify_challenge_and_extract_nonce_b64url returns URL_SAFE_NO_PAD.
-        // Compare the decoded bytes, not the encoded strings.
-        let nonce_back_bytes = URL_SAFE_NO_PAD
-            .decode(&nonce_back)
-            .expect("decode nonce_back");
-        let nonce_original_bytes = STANDARD
-            .decode(&nonce_original)
-            .expect("decode nonce_original");
-        assert_eq!(
-            nonce_back_bytes, nonce_original_bytes,
-            "nonce bytes must round-trip"
-        );
+        c.verify_challenge_token(&jwt)
+            .await
+            .expect("valid token verifies");
+    }
+
+    /// In-memory challenger: issue + verify round-trip, no filesystem. JWT
+    /// freshness is the signature + `exp`, checked at `verify_challenge_token`.
+    #[tokio::test]
+    async fn ephemeral_roundtrip() {
+        let c = JwtChallenger::new().expect("new ephemeral challenger");
+        let challenge_json = c.generate_challenge_json().await.expect("generate");
+        issue_and_verify(&c, &challenge_json).await;
+    }
+
+    /// A tampered JWT (wrong signature) must be rejected.
+    #[tokio::test]
+    async fn ephemeral_tampered_token_rejected() {
+        let c = JwtChallenger::new().expect("new ephemeral challenger");
+        let challenge_json = c.generate_challenge_json().await.expect("generate");
+        let outer: Value = serde_json::from_str(&challenge_json).expect("outer json");
+        let mut jwt = outer["extra-params"]["jwt"]
+            .as_str()
+            .expect("jwt")
+            .to_string();
+        // Flip the last char of the signature segment to break the signature.
+        let last = jwt.len() - 1;
+        let b = jwt.as_bytes()[last];
+        jwt.replace_range(last.., if b == b'A' { "B" } else { "A" });
+
+        c.verify_challenge_token(&jwt)
+            .await
+            .expect_err("tampered token rejected");
+    }
+
+    /// `fs` challenger: issue + verify round-trip on a temp dir, pinning the
+    /// on-disk PKCS#8 format this module writes. JWT freshness is the
+    /// signature + `exp`, checked at `verify_challenge_token`.
+    #[cfg(feature = "fs")]
+    #[tokio::test]
+    async fn fs_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let key_file = tmp.path().join("key.pem");
+        let c = JwtChallenger::new_with_private_key_path(&key_file)
+            .await
+            .expect("new with key file");
+
+        let challenge_json = c.generate_challenge_json().await.expect("generate");
+        // The key file must have been created on first use.
+        assert!(key_file.exists(), "key file created on first use");
+        issue_and_verify(&c, &challenge_json).await;
+    }
+
+    /// A second `JwtChallenger` instance on the same path must verify a token
+    /// the first issued — the key is persisted, not regenerated per call.
+    #[cfg(feature = "fs")]
+    #[tokio::test]
+    async fn fs_persisted_across_instances() {
+        let tmp = tempfile::tempdir().unwrap();
+        let key_file = tmp.path().join("key.pem");
+
+        let issuer = JwtChallenger::new_with_private_key_path(&key_file)
+            .await
+            .expect("new with key file");
+        let challenge_json = issuer.generate_challenge_json().await.expect("generate");
+
+        let verifier = JwtChallenger::new_with_private_key_path(&key_file)
+            .await
+            .expect("second instance");
+        issue_and_verify(&verifier, &challenge_json).await;
     }
 }

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -12,9 +12,11 @@ pub mod token;
 mod composite;
 
 use crate::{rvps::ReferenceValueResolver, token::AttestationTokenBroker};
+pub use challenge::JwtChallenger;
 
 use anyhow::{anyhow, Context, Result};
 use canon_json::CanonicalFormatter;
+#[cfg(feature = "fs")]
 use config::Config;
 pub use kbs_types::{Attestation, Tee};
 use log::info;
@@ -160,6 +162,12 @@ pub enum AttestationError {
         #[source]
         source: anyhow::Error,
     },
+    #[error("verification request {request_index} uses an invalid challenge token")]
+    InvalidChallengeToken {
+        request_index: usize,
+        #[source]
+        source: anyhow::Error,
+    },
 }
 
 /// Initdata defined in
@@ -210,9 +218,9 @@ pub struct VerificationRequest {
 }
 
 pub struct AttestationService {
-    _config: Config,
     rvps: Arc<dyn RvpsApi>,
     token_broker: Box<dyn AttestationTokenBroker + Send + Sync>,
+    challenger: JwtChallenger,
 }
 
 /// Transport-neutral runtime status exposed by REST and gRPC AS binaries.
@@ -227,9 +235,19 @@ pub struct ServiceStatus {
 }
 
 impl AttestationService {
-    /// Create a new Attestation Service instance.
+    /// Create a new Attestation Service instance from a parsed [`Config`].
+    ///
+    /// Config-file / CLI entry point, kept for backward compatibility. It
+    /// constructs the RVPS and token-broker *instances* from the config,
+    /// picks a [`JwtChallenger`] (loaded from the configured path, or the
+    /// built-in default path when unset), and assembles them via
+    /// [`Self::from_components`]. Pure-lib / wasm consumers that do not want
+    /// to depend on [`Config`] should call [`Self::from_components`] directly
+    /// with their own component instances.
     #[cfg(feature = "fs")]
     pub async fn new(config: Config) -> Result<Self, ServiceError> {
+        // Historical `new()` created the work dir at construction time. Kept
+        // as a standalone mkdir purely for behavior parity.
         if !config.work_dir.as_path().exists() {
             fs::create_dir_all(&config.work_dir)
                 .await
@@ -242,11 +260,27 @@ impl AttestationService {
 
         let token_broker = config.attestation_token_broker.to_token_broker()?;
 
-        Ok(Self {
-            _config: config,
+        let challenger: JwtChallenger = match config.challenge_key_path {
+            Some(path) => JwtChallenger::new_with_private_key_path(&path).await?,
+            None => JwtChallenger::new_with_private_key_default_path().await?,
+        };
+
+        Ok(Self::from_components(rvps, token_broker, challenger))
+    }
+
+    /// Assemble an [`AttestationService`] from already-constructed component
+    /// instances — the fs-free / pure-lib / wasm entry point. No [`Config`],
+    /// no filesystem: supply your own RVPS, token broker, and challenger.
+    pub fn from_components(
+        rvps: Arc<dyn RvpsApi>,
+        token_broker: Box<dyn AttestationTokenBroker + Send + Sync>,
+        challenger: JwtChallenger,
+    ) -> Self {
+        Self {
             rvps,
             token_broker,
-        })
+            challenger,
+        }
     }
 
     /// Return AS and verifier dependency status without performing network I/O.
@@ -308,8 +342,6 @@ impl AttestationService {
         verification_requests: Vec<VerificationRequest>,
         policy_ids: Vec<String>,
     ) -> Result<String> {
-        let mut tee_claims: Vec<TeeClaims> = vec![];
-
         if verification_requests.is_empty() {
             return Err(AttestationError::InvalidRequest {
                 request_index: None,
@@ -321,7 +353,22 @@ impl AttestationService {
 
         composite::verify_composite_bindings(&verification_requests)?;
 
+        let mut tee_claims: Vec<TeeClaims> = vec![];
+
         for (request_index, verification_request) in verification_requests.into_iter().enumerate() {
+            // Verify challenge token
+            if let Some(RuntimeData::Structured(v)) = &verification_request.runtime_data {
+                if let Some(challenge_token) = v.get("challenge_token").and_then(|x| x.as_str()) {
+                    self.challenger
+                        .verify_challenge_token(challenge_token)
+                        .await
+                        .map_err(|source| AttestationError::InvalidChallengeToken {
+                            request_index,
+                            source,
+                        })?;
+                }
+            }
+
             let verifier = verifier::to_verifier(&verification_request.tee).map_err(|source| {
                 AttestationError::UnsupportedTee {
                     request_index,
@@ -450,23 +497,13 @@ impl AttestationService {
             .await
     }
 
-    /// Filesystem path of the RSA private key used to sign and verify
-    /// attestation challenge (nonce) tokens. Falls back to the built-in
-    /// default when not set in the config.
-    pub fn challenge_key_path(&self) -> std::path::PathBuf {
-        self._config
-            .challenge_key_path
-            .clone()
-            .unwrap_or_else(challenge::default_challenge_key_path)
-    }
-
     pub async fn generate_challenge(
         &self,
         tee: Option<Tee>,
         tee_parameters: Option<String>,
     ) -> Result<String> {
         match tee {
-            None => challenge::generate_common_challenge(&self.challenge_key_path()),
+            None => self.challenger.generate_challenge_json().await,
             Some(t) => {
                 self.generate_supplemental_challenge(t, tee_parameters.unwrap_or_default())
                     .await


### PR DESCRIPTION
## Summary

This commit introduce `struct JwtChallenger` and moved challenge token checking to `AttestationService::evaluate()`.

## Breaking changes

- Private key loading happens during JwtChallenger initialization. This may speed up token verification, but so we will not be able to got notify when key file changing.