### PR TITLE
attestation-service: reload challenge key per request

### DIFF
--- a/attestation-service/docs/config.md
+++ b/attestation-service/docs/config.md
@@ -18,7 +18,11 @@ section:
 | `work_dir`                 | String                      | The location for Attestation Service to store data. | False      | Firstly try to read from ENV `AS_WORK_DIR`. If not any, use `/opt/confidential-containers/attestation-service`       |
 | `rvps_config`              | [RVPSConfiguration][2]      | RVPS configuration                                  | False      | -       |
 | `attestation_token_broker` | [AttestationTokeBroker][1]  | Attestation result token configuration.             | False      | -       |
-| `challenge_key_path`       | String                      | Path to the RSA private key (PEM) used to sign and verify attestation challenge (nonce) tokens. The key is generated on first use if the file does not exist. | False | `/etc/trustee/attestation-service/nonce_token_issuer/key.pem` |
+| `challenge_key_path`       | String                      | Path to the RSA private key (PEM) used to sign and verify attestation challenge (nonce) tokens. The key is generated atomically on the first challenge request if the file does not exist, and is reloaded for every signing and verification request. | False | `/etc/trustee/attestation-service/nonce_token_issuer/key.pem` |
+
+To rotate the challenge key without restarting AS, replace the key file
+atomically. Outstanding challenge tokens signed by the previous key become
+invalid immediately after replacement.
 
 [1]: #attestationtokenbroker
 [2]: #rvps-configuration

--- a/attestation-service/src/challenge.rs
+++ b/attestation-service/src/challenge.rs
@@ -1,4 +1,4 @@
-use anyhow::*;
+use anyhow::{anyhow, bail, Context, Result};
 use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
 use rand::rngs::OsRng;
@@ -15,7 +15,12 @@ use serde_json::{json, Value};
 use sha2::Sha384;
 
 #[cfg(feature = "fs")]
-use std::path::{Path, PathBuf};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+#[cfg(feature = "fs")]
+use tempfile::NamedTempFile;
 
 #[cfg(not(all(
     target_arch = "wasm32",
@@ -46,24 +51,28 @@ fn default_challenge_key_path() -> PathBuf {
     Path::new(DEFAULT_KEY_DIR).join(DEFAULT_PRIV_KEY_PEM)
 }
 
-/// [`super::JwtChallenger`] backed by an in-memory RSA private key.
-///
 /// JWT-based (RS384) challenge key — the issued JWT itself is the challenge
 /// token, so the `exp` claim gives freshness across replicas without
 /// synchronizing every signed token; see [`build_challenge_json`] for details.
-///
-/// Native / config-file compatibility path — the AS default until a caller
-/// opts into an in-memory impl.
 pub struct JwtChallenger {
-    key: RsaPrivateKey,
+    key_source: PrivateKeySource,
+}
+
+enum PrivateKeySource {
+    InMemory(Box<RsaPrivateKey>),
+    #[cfg(feature = "fs")]
+    File(PathBuf),
 }
 
 impl JwtChallenger {
-    /// Construct with an explicit on-disk key path.
+    /// Construct with an explicit on-disk key path. The key is deliberately
+    /// not read here: file-backed challengers reload it for every request so
+    /// key rotation does not require restarting the Attestation Service.
     #[cfg(feature = "fs")]
     pub async fn new_with_private_key_path(path: &Path) -> Result<Self> {
-        let key = ensure_keypair(path).await?;
-        Ok(Self::new_with_private_key(key))
+        Ok(Self {
+            key_source: PrivateKeySource::File(path.to_path_buf()),
+        })
     }
 
     /// The built-in default path (`/etc/trustee/attestation-service/nonce_token_issuer/key.pem`).
@@ -73,7 +82,9 @@ impl JwtChallenger {
     }
 
     pub fn new_with_private_key(key: RsaPrivateKey) -> Self {
-        Self { key }
+        Self {
+            key_source: PrivateKeySource::InMemory(Box::new(key)),
+        }
     }
 
     pub fn new() -> Result<Self> {
@@ -83,7 +94,14 @@ impl JwtChallenger {
     }
 
     pub async fn generate_challenge_json(&self) -> Result<String> {
-        build_challenge_json(&self.key)
+        match &self.key_source {
+            PrivateKeySource::InMemory(key) => build_challenge_json(key),
+            #[cfg(feature = "fs")]
+            PrivateKeySource::File(path) => {
+                let key = load_or_create_private_key(path).await?;
+                build_challenge_json(&key)
+            }
+        }
     }
 
     /// Verify the challenge token JWT — signature and `exp` (freshness).
@@ -93,41 +111,123 @@ impl JwtChallenger {
     /// report is handled by the TEE measuring the `runtime_data` (which
     /// carries the challenge token) into its report.
     pub async fn verify_challenge_token(&self, challenge_token: &str) -> Result<()> {
-        verify_jwt(challenge_token, &self.key)
+        match &self.key_source {
+            PrivateKeySource::InMemory(key) => verify_jwt(challenge_token, key),
+            #[cfg(feature = "fs")]
+            PrivateKeySource::File(path) => {
+                // Verification must not create a missing key. Otherwise an
+                // invalid request could unexpectedly rotate service state.
+                let key = read_private_key(path).await?;
+                verify_jwt(challenge_token, &key)
+            }
+        }
     }
 }
 
 #[cfg(feature = "fs")]
-async fn ensure_keypair(key_path: &Path) -> Result<RsaPrivateKey> {
-    if let Some(dir) = key_path.parent() {
-        if !dir.as_os_str().is_empty() && !dir.exists() {
-            tokio::fs::create_dir_all(dir)
-                .await
-                .with_context(|| format!("create dir {} failed", dir.display()))?;
+fn parse_private_key(pem: &str) -> Result<RsaPrivateKey> {
+    // Accept both PKCS#8 (what we write now) and legacy PKCS#1 (what the
+    // implementation before #221 wrote).
+    RsaPrivateKey::from_pkcs8_pem(pem)
+        .or_else(|_| RsaPrivateKey::from_pkcs1_pem(pem))
+        .context("parse private key pem failed")
+}
+
+#[cfg(feature = "fs")]
+async fn read_private_key_if_exists(key_path: &Path) -> Result<Option<RsaPrivateKey>> {
+    let pem = match tokio::fs::read_to_string(key_path).await {
+        Ok(pem) => pem,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(source)
+                .with_context(|| format!("read private key pem {} failed", key_path.display()))
         }
+    };
+
+    parse_private_key(&pem).map(Some)
+}
+
+#[cfg(feature = "fs")]
+async fn read_private_key(key_path: &Path) -> Result<RsaPrivateKey> {
+    read_private_key_if_exists(key_path)
+        .await?
+        .ok_or_else(|| anyhow!("private key pem {} does not exist", key_path.display()))
+}
+
+#[cfg(feature = "fs")]
+fn key_parent(key_path: &Path) -> &Path {
+    key_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+/// Publish a complete key without ever replacing an existing key. Creating
+/// the temporary file in the destination directory keeps the final operation
+/// on one filesystem; `persist_noclobber` makes concurrent creators race on a
+/// single atomic no-replace operation.
+#[cfg(feature = "fs")]
+fn persist_private_key_noclobber(key_path: &Path, pem: &str) -> Result<bool> {
+    let mut temporary = NamedTempFile::new_in(key_parent(key_path)).with_context(|| {
+        format!(
+            "create temporary private key beside {} failed",
+            key_path.display()
+        )
+    })?;
+    temporary
+        .write_all(pem.as_bytes())
+        .context("write temporary private key pem failed")?;
+    temporary
+        .as_file_mut()
+        .sync_all()
+        .context("sync temporary private key pem failed")?;
+
+    match temporary.persist_noclobber(key_path) {
+        Ok(_) => Ok(true),
+        Err(source) if source.error.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(source) => Err(source.error).with_context(|| {
+            format!(
+                "atomically persist private key pem {} failed",
+                key_path.display()
+            )
+        }),
+    }
+}
+
+#[cfg(feature = "fs")]
+async fn load_or_create_private_key(key_path: &Path) -> Result<RsaPrivateKey> {
+    if let Some(key) = read_private_key_if_exists(key_path).await? {
+        return Ok(key);
     }
 
-    if key_path.exists() {
-        let pem = tokio::fs::read_to_string(key_path)
-            .await
-            .context("read private key pem failed")?;
-        // Accept both PKCS#8 (what we write now) and legacy PKCS#1 (what the
-        // previous implementation's `private_key_to_pem` wrote).
-        let rsa = RsaPrivateKey::from_pkcs8_pem(&pem)
-            .or_else(|_| RsaPrivateKey::from_pkcs1_pem(&pem))
-            .context("parse private key pem failed")?;
-        return Ok(rsa);
+    tokio::fs::create_dir_all(key_parent(key_path))
+        .await
+        .with_context(|| {
+            format!(
+                "create private key dir {} failed",
+                key_parent(key_path).display()
+            )
+        })?;
+
+    // Check again after creating the directory: another request or AS replica
+    // may have installed the key while this request was waiting.
+    if let Some(key) = read_private_key_if_exists(key_path).await? {
+        return Ok(key);
     }
 
     let mut rng = OsRng;
-    let rsa = RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?;
-    let pem = rsa
+    let key = RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize)?;
+    let pem = key
         .to_pkcs8_pem(LineEnding::LF)
         .context("dump private key to pem failed")?;
-    tokio::fs::write(key_path, pem.as_bytes())
-        .await
-        .context("write private key pem failed")?;
-    Ok(rsa)
+
+    if persist_private_key_noclobber(key_path, &pem)? {
+        Ok(key)
+    } else {
+        // A concurrent creator won. Its rename/link is complete before
+        // `AlreadyExists` is observed, so readers never see a partial PEM.
+        read_private_key(key_path).await
+    }
 }
 
 /// Build the challenge JSON `{"nonce", "extra-params":{"jwt"}}` signed with
@@ -250,16 +350,20 @@ mod tests {
 
     use super::*;
 
+    fn challenge_jwt(challenge_json: &str) -> String {
+        let outer: Value = serde_json::from_str(challenge_json).expect("outer json");
+        outer["extra-params"]["jwt"]
+            .as_str()
+            .expect("jwt in extra-params")
+            .to_string()
+    }
+
     /// Helper mirroring the `lib.rs` evaluate contract: the client echoes the
     /// challenge JSON's JWT into `runtime_data` as `challenge_token`, and the
     /// challenger verifies signature + `exp` (freshness only — no nonce is
     /// sent by the client).
     async fn issue_and_verify(c: &JwtChallenger, challenge_json: &str) {
-        let outer: Value = serde_json::from_str(challenge_json).expect("outer json");
-        let jwt = outer["extra-params"]["jwt"]
-            .as_str()
-            .expect("jwt in extra-params")
-            .to_string();
+        let jwt = challenge_jwt(challenge_json);
 
         c.verify_challenge_token(&jwt)
             .await
@@ -302,15 +406,44 @@ mod tests {
     #[tokio::test]
     async fn fs_roundtrip() {
         let tmp = tempfile::tempdir().unwrap();
-        let key_file = tmp.path().join("key.pem");
+        let key_file = tmp.path().join("keys/key.pem");
         let c = JwtChallenger::new_with_private_key_path(&key_file)
             .await
             .expect("new with key file");
+
+        assert!(
+            !key_file.exists(),
+            "constructing a file-backed challenger must not create its key"
+        );
+        assert!(
+            !key_file.parent().unwrap().exists(),
+            "the key directory is also created lazily"
+        );
 
         let challenge_json = c.generate_challenge_json().await.expect("generate");
         // The key file must have been created on first use.
         assert!(key_file.exists(), "key file created on first use");
         issue_and_verify(&c, &challenge_json).await;
+    }
+
+    /// Verifying against a missing file is an error and must not create a new
+    /// key as a side effect of an untrusted request.
+    #[cfg(feature = "fs")]
+    #[tokio::test]
+    async fn fs_verify_does_not_create_missing_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let key_file = tmp.path().join("keys/key.pem");
+        let c = JwtChallenger::new_with_private_key_path(&key_file)
+            .await
+            .expect("new with key file");
+
+        let error = c
+            .verify_challenge_token("not.a.jwt")
+            .await
+            .expect_err("verification without a key must fail");
+        assert!(error.to_string().contains("does not exist"), "{error:#}");
+        assert!(!key_file.exists());
+        assert!(!key_file.parent().unwrap().exists());
     }
 
     /// A second `JwtChallenger` instance on the same path must verify a token
@@ -330,5 +463,92 @@ mod tests {
             .await
             .expect("second instance");
         issue_and_verify(&verifier, &challenge_json).await;
+    }
+
+    /// A long-running file-backed challenger must observe a key replacement
+    /// on both its signing and verification paths without being reconstructed.
+    #[cfg(feature = "fs")]
+    #[tokio::test]
+    async fn fs_reloads_rotated_key_per_request() {
+        let tmp = tempfile::tempdir().unwrap();
+        let key_file = tmp.path().join("key.pem");
+        let c = JwtChallenger::new_with_private_key_path(&key_file)
+            .await
+            .expect("new with key file");
+
+        let old_challenge = c
+            .generate_challenge_json()
+            .await
+            .expect("initial challenge");
+        let old_jwt = challenge_jwt(&old_challenge);
+
+        let mut rng = OsRng;
+        let rotated_key = RsaPrivateKey::new(&mut rng, RSA_KEY_BITS as usize).unwrap();
+        let rotated_pem = rotated_key.to_pkcs8_pem(LineEnding::LF).unwrap();
+        let replacement = tmp.path().join("replacement.pem");
+        std::fs::write(&replacement, rotated_pem.as_bytes()).unwrap();
+        std::fs::rename(&replacement, &key_file).unwrap();
+
+        let new_challenge = c
+            .generate_challenge_json()
+            .await
+            .expect("rotated challenge");
+        let new_jwt = challenge_jwt(&new_challenge);
+        verify_jwt(&new_jwt, &rotated_key).expect("new challenge uses rotated key");
+        c.verify_challenge_token(&new_jwt)
+            .await
+            .expect("same challenger verifies with rotated key");
+        c.verify_challenge_token(&old_jwt)
+            .await
+            .expect_err("rotation invalidates outstanding tokens from the old key");
+    }
+
+    /// Concurrent first writers must never overwrite each other or expose a
+    /// partially-written file. Exactly one complete candidate is published.
+    #[cfg(feature = "fs")]
+    #[test]
+    fn fs_key_creation_is_atomic_and_noclobber() {
+        use std::sync::{Arc, Barrier};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let key_file = tmp.path().join("key.pem");
+        let barrier = Arc::new(Barrier::new(3));
+        let candidates: Vec<String> = (0..2)
+            .map(|_| {
+                RsaPrivateKey::new(&mut OsRng, 1024)
+                    .unwrap()
+                    .to_pkcs8_pem(LineEnding::LF)
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+
+        let handles: Vec<_> = candidates
+            .into_iter()
+            .map(|candidate| {
+                let barrier = Arc::clone(&barrier);
+                let key_file = key_file.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    let published = persist_private_key_noclobber(&key_file, &candidate).unwrap();
+                    (published, candidate)
+                })
+            })
+            .collect();
+
+        barrier.wait();
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+        let winners: Vec<_> = results
+            .iter()
+            .filter_map(|(published, candidate)| published.then_some(candidate))
+            .collect();
+
+        assert_eq!(winners.len(), 1, "exactly one creator wins");
+        let persisted = std::fs::read_to_string(&key_file).unwrap();
+        assert_eq!(&persisted, winners[0]);
+        parse_private_key(&persisted).expect("the complete winning PEM is readable");
     }
 }

--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -27,7 +27,8 @@ pub struct Config {
     /// Optional path to the RSA private key used to sign and verify
     /// attestation challenge (nonce) tokens. When unset, a built-in default
     /// path (`/etc/trustee/attestation-service/nonce_token_issuer/key.pem`)
-    /// is used, and the key is generated on first use if it does not exist.
+    /// is used. The key is reloaded for every request and is atomically
+    /// generated on the first challenge request if it does not exist.
     #[serde(default)]
     pub challenge_key_path: Option<PathBuf>,
 }

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -239,8 +239,8 @@ impl AttestationService {
     ///
     /// Config-file / CLI entry point, kept for backward compatibility. It
     /// constructs the RVPS and token-broker *instances* from the config,
-    /// picks a [`JwtChallenger`] (loaded from the configured path, or the
-    /// built-in default path when unset), and assembles them via
+    /// picks a file-backed [`JwtChallenger`] (using the configured path, or
+    /// the built-in default path when unset), and assembles them via
     /// [`Self::from_components`]. Pure-lib / wasm consumers that do not want
     /// to depend on [`Config`] should call [`Self::from_components`] directly
     /// with their own component instances.

--- a/attestation-service/tests/challenge_key_rotation.rs
+++ b/attestation-service/tests/challenge_key_rotation.rs
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "fs")]
+
+use std::io::Write;
+use std::path::Path;
+
+use attestation_service::config::Config;
+use attestation_service::rvps::{RvpsConfig, RvpsCrateConfig};
+use attestation_service::token::{simple, AttestationTokenConfig};
+use attestation_service::{
+    AttestationService, HashAlgorithm, RuntimeData, Tee, VerificationRequest,
+};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use canon_json::CanonicalFormatter;
+use reference_value_provider_service::storage::{in_memory, ReferenceValueStorageConfig};
+use rsa::pkcs8::{EncodePrivateKey, LineEnding};
+use rsa::RsaPrivateKey;
+use serde::Serialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha384};
+
+const MEASUREMENT: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+
+fn config(work_dir: &Path, challenge_key_path: &Path) -> Config {
+    Config {
+        work_dir: work_dir.join("work"),
+        rvps_config: RvpsConfig::BuiltIn(RvpsCrateConfig {
+            storage: ReferenceValueStorageConfig::InMemory(in_memory::Config::default()),
+        }),
+        attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration {
+            settings: simple::TokenBrokerSettings {
+                duration_min: 5,
+                issuer_name: "challenge-key-rotation-e2e".to_string(),
+            },
+            signer: None,
+            policy_dir: work_dir.join("policies").to_string_lossy().into_owned(),
+        }),
+        challenge_key_path: Some(challenge_key_path.to_path_buf()),
+    }
+}
+
+fn request_for_challenge(challenge: &str) -> VerificationRequest {
+    let challenge: Value = serde_json::from_str(challenge).unwrap();
+    let runtime_data = json!({
+        "challenge_token": challenge["extra-params"]["jwt"]
+    });
+
+    let mut canonical = Vec::new();
+    let mut serializer =
+        serde_json::Serializer::with_formatter(&mut canonical, CanonicalFormatter::new());
+    runtime_data.serialize(&mut serializer).unwrap();
+    let report_data = Sha384::digest(canonical);
+
+    VerificationRequest {
+        evidence: json!({
+            "svn": "1",
+            "report_data": STANDARD.encode(report_data),
+            "measure_register": MEASUREMENT,
+            "cc_eventlog": null
+        }),
+        tee: Tee::Sample,
+        runtime_data: Some(RuntimeData::Structured(runtime_data)),
+        runtime_data_hash_algorithm: HashAlgorithm::Sha384,
+        init_data: None,
+        additional_data: None,
+    }
+}
+
+fn replace_key_atomically(key_path: &Path) {
+    let mut rng = rand::rngs::OsRng;
+    let key = RsaPrivateKey::new(&mut rng, 2048).unwrap();
+    let pem = key.to_pkcs8_pem(LineEnding::LF).unwrap();
+
+    let mut temporary = tempfile::NamedTempFile::new_in(key_path.parent().unwrap()).unwrap();
+    temporary.write_all(pem.as_bytes()).unwrap();
+    temporary.as_file_mut().sync_all().unwrap();
+    temporary.persist(key_path).unwrap();
+}
+
+#[tokio::test]
+async fn service_reloads_challenge_key_across_full_attestation_flow() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let key_path = temp_dir.path().join("challenge/key.pem");
+    let service = AttestationService::new(config(temp_dir.path(), &key_path))
+        .await
+        .unwrap();
+
+    assert!(
+        !key_path.exists(),
+        "service construction must leave challenge key creation lazy"
+    );
+
+    let first_challenge = service.generate_challenge(None, None).await.unwrap();
+    assert!(key_path.exists(), "first challenge creates the key");
+    service
+        .evaluate(vec![request_for_challenge(&first_challenge)], vec![])
+        .await
+        .expect("first challenge-to-attestation flow succeeds");
+
+    replace_key_atomically(&key_path);
+
+    let second_challenge = service.generate_challenge(None, None).await.unwrap();
+    service
+        .evaluate(vec![request_for_challenge(&second_challenge)], vec![])
+        .await
+        .expect("same service observes rotated key without restart");
+
+    service
+        .evaluate(vec![request_for_challenge(&first_challenge)], vec![])
+        .await
+        .expect_err("an outstanding JWT signed by the old key is invalid after rotation");
+}


### PR DESCRIPTION
## Summary

- keep in-memory challengers unchanged, while file-backed challengers reload the RSA key for every signing and verification request
- lazily generate a missing key on the first challenge request and publish it with an atomic no-replace operation, so concurrent AS instances cannot overwrite each other or expose a partial PEM
- keep verification side-effect free when the key is missing
- document rotation semantics and add unit plus end-to-end coverage

Replacing the key file atomically now takes effect without restarting AS. Outstanding challenge JWTs signed by the old key become invalid immediately after rotation.

## Validation

- `cargo test -p attestation-service -p verifier`
- `cargo test -p attestation-service --no-default-features`
- `cargo clippy -p attestation-service -p verifier -- -D warnings -A clippy::derive_partial_eq_without_eq`
- fs-only and no-fs Clippy checks
- CI-equivalent Wasm checks with `nightly-2025-07-07`
- pure-Rust verifier RESTful AS build
- live HTTP `POST /challenge` to `POST /attestation` sample-evidence flow
