### PR TITLE
fix(deps): bump dcap-qvl for TDX quote reserved attributes bits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "dcap-qvl"
 version = "0.4.1"
-source = "git+https://github.com/inclavare-containers/dcap-qvl?rev=d988f7de3f5e82d0d7e8f9bceeb3af9fa8d9daa1#d988f7de3f5e82d0d7e8f9bceeb3af9fa8d9daa1"
+source = "git+https://github.com/inclavare-containers/dcap-qvl?rev=d8a260d8c87619cce607f24d16d8bd474b458592#d8a260d8c87619cce607f24d16d8bd474b458592"
 dependencies = [
  "anyhow",
  "asn1_der",

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -135,11 +135,12 @@ intel-tee-quote-verification-rs = { version = "0.3.0", optional = true }
 # dcap-qvl fork adding a `QuoteVerifier::allow_expired` option, used by the
 # pure-Rust TDX verifier backend (feature `tdx-dcap-rust`) to treat expired
 # collateral as non-fatal, matching the Intel DCAP QVL (FFI) backend. The fork
-# only relaxes the freshness check; signature/chain verification is unchanged.
-# See https://github.com/jialez0/dcap-qvl/tree/v0.4.1-allow-expired
+# only relaxes the freshness check and fix perfmon bit check; signature/chain
+# verification is unchanged.
+# See https://github.com/inclavare-containers/dcap-qvl/tree/v0.4.1-allow-expired
 # (based on Phala-Network/dcap-qvl v0.4.1). This patch is inert for the default
 # build, which does not enable `tdx-dcap-rust` and never compiles dcap-qvl.
-dcap-qvl = { git = "https://github.com/inclavare-containers/dcap-qvl", rev = "d988f7de3f5e82d0d7e8f9bceeb3af9fa8d9daa1", default-features = false, features = [
+dcap-qvl = { git = "https://github.com/inclavare-containers/dcap-qvl", rev = "d8a260d8c87619cce607f24d16d8bd474b458592", default-features = false, features = [
     "std",
     "ring",
     "default-x509",


### PR DESCRIPTION
Bump the dcap-qvl fork to a rev that fixes the "Reserved bits in TD attributes are set" error raised when a TDX quote has the perfmon bit set, so verification no longer fails on such quotes.
https://github.com/inclavare-containers/dcap-qvl/commit/d8a260d8c87619cce607f24d16d8bd474b458592